### PR TITLE
ci(frontend): add build workflow for pull requests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,40 @@
+name: Frontend CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Detect optional frontend scripts
+        id: scripts
+        run: |
+          node --input-type=module -e "import fs from 'node:fs'; import pkg from './frontend/package.json' with { type: 'json' }; fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_lint=${pkg.scripts?.lint ? 'true' : 'false'}\nhas_test=${pkg.scripts?.test ? 'true' : 'false'}\n`);"
+
+      - name: Build frontend
+        run: npm run build --workspace=frontend
+
+      - name: Lint frontend
+        if: steps.scripts.outputs.has_lint == 'true'
+        run: npm run lint --workspace=frontend
+
+      - name: Test frontend
+        if: steps.scripts.outputs.has_test == 'true'
+        run: npm run test --workspace=frontend


### PR DESCRIPTION
## Description
Add a GitHub Actions workflow that installs dependencies and validates the frontend build on pull requests and pushes to main, with optional lint and test steps when those scripts exist.
Closes #49
## Changes proposed
### What were you told to do?
Add CI for the frontend that runs npm install, npm run build, and lint/test when available on PRs and pushes to main.
### What did I do?
#### GitHub Actions workflow
- added a new frontend CI workflow under .github/workflows
- configured it to run on pull requests and pushes to main
- set up Node.js 20 with npm caching and a repository-wide npm install step
#### Frontend validation steps
- added a frontend build step using the existing workspace build command
- added script detection so lint and test run automatically only when those frontend scripts exist
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated the workflow targets the existing frontend workspace command path, and the same npm run build --workspace=frontend command succeeds locally in this repo.
