### PR TITLE
feat(api): introduce v1-prefixed routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cp backend/.env.example backend/.env
 npm run dev:backend
 ```
 
-API: http://localhost:3001 (health: http://localhost:3001/health).
+API: http://localhost:3001 (health: http://localhost:3001/health, v1: http://localhost:3001/api/v1).
 
 ### 4. Run frontend
 
@@ -98,7 +98,7 @@ API: http://localhost:3001 (health: http://localhost:3001/health).
 npm run dev:frontend
 ```
 
-App: http://localhost:5173 (proxies `/api` to the backend).
+App: http://localhost:5173 (proxies `/api` and `/api/v1` to the backend).
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,25 +1,35 @@
 # Trivela Backend
 
-REST API for the Trivela campaign and rewards platform. Handles campaign metadata, health checks, and (optionally) Soroban RPC configuration for the frontend.
+REST API for the Trivela campaign and rewards platform. Handles campaign metadata, health checks, and Soroban RPC configuration for the frontend.
 
 ## Setup
 
 ```bash
 npm install
-cp .env.example .env  # then edit .env
+cp .env.example .env
 npm run dev
 ```
 
 ## Environment
 
-- `PORT` – Server port (default 3001)
-- `CORS_ORIGIN` – Allowed origin for CORS
-- `STELLAR_NETWORK` – `testnet` or `mainnet`
-- `SOROBAN_RPC_URL` – Soroban RPC URL for the frontend
+- `PORT`: Server port (default `3001`)
+- `CORS_ORIGIN`: Allowed origin for CORS
+- `STELLAR_NETWORK`: `testnet` or `mainnet`
+- `SOROBAN_RPC_URL`: Soroban RPC URL exposed in API metadata
 
 ## API
 
-- `GET /health` – Health check
-- `GET /api` – API info and endpoints
-- `GET /api/campaigns` – List campaigns
-- `GET /api/campaigns/:id` – Get one campaign
+Preferred routes:
+
+- `GET /health`
+- `GET /api/v1`
+- `GET /api/v1/campaigns`
+- `GET /api/v1/campaigns/:id`
+
+Backward-compatible legacy routes remain available under `/api/*` for now:
+
+- `GET /api`
+- `GET /api/campaigns`
+- `GET /api/campaigns/:id`
+
+Migration note: new integrations should use `/api/v1/*`. Existing clients on `/api/*` continue to work.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -9,6 +9,8 @@ import cors from 'cors';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const LEGACY_API_PREFIX = '/api';
+const API_V1_PREFIX = '/api/v1';
 
 app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
 app.use(express.json());
@@ -16,23 +18,6 @@ app.use(express.json());
 // Health check for Drip and reviewers
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', service: 'trivela-api', timestamp: new Date().toISOString() });
-});
-
-// API info
-app.get('/api', (_req, res) => {
-  res.json({
-    name: 'Trivela API',
-    version: '0.1.0',
-    endpoints: {
-      health: 'GET /health',
-      campaigns: 'GET /api/campaigns',
-      campaign: 'GET /api/campaigns/:id',
-    },
-    stellar: {
-      network: process.env.STELLAR_NETWORK || 'testnet',
-      rpcUrl: process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org',
-    },
-  });
 });
 
 // Placeholder campaigns (replace with DB later)
@@ -47,15 +32,50 @@ const campaigns = [
   },
 ];
 
-app.get('/api/campaigns', (_req, res) => {
-  res.json(campaigns);
-});
+function apiInfo(req, res) {
+  const usingLegacyPrefix = req.path.startsWith(LEGACY_API_PREFIX) && !req.path.startsWith(API_V1_PREFIX);
 
-app.get('/api/campaigns/:id', (req, res) => {
+  res.json({
+    name: 'Trivela API',
+    version: '0.1.0',
+    prefix: API_V1_PREFIX,
+    endpoints: {
+      health: 'GET /health',
+      info: `GET ${API_V1_PREFIX}`,
+      campaigns: `GET ${API_V1_PREFIX}/campaigns`,
+      campaign: `GET ${API_V1_PREFIX}/campaigns/:id`,
+    },
+    compatibility: {
+      legacyPrefix: LEGACY_API_PREFIX,
+      legacyRoutesSupported: true,
+      migrationNote: 'Prefer /api/v1/* routes. Legacy /api/* routes remain available for compatibility.',
+      usingLegacyPrefix,
+    },
+    stellar: {
+      network: process.env.STELLAR_NETWORK || 'testnet',
+      rpcUrl: process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org',
+    },
+  });
+}
+
+function listCampaigns(_req, res) {
+  res.json(campaigns);
+}
+
+function getCampaignById(req, res) {
   const campaign = campaigns.find((c) => c.id === req.params.id);
   if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
   res.json(campaign);
-});
+}
+
+function registerApiRoutes(prefix) {
+  app.get(prefix, apiInfo);
+  app.get(`${prefix}/campaigns`, listCampaigns);
+  app.get(`${prefix}/campaigns/:id`, getCampaignById);
+}
+
+registerApiRoutes(API_V1_PREFIX);
+registerApiRoutes(LEGACY_API_PREFIX);
 
 app.listen(PORT, () => {
   console.log(`Trivela API running at http://localhost:${PORT}`);

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Trivela Frontend
 
-React + Vite app that talks to the Trivela API and (when wired) Stellar/Soroban for wallet connect and contract calls.
+React + Vite app that talks to the Trivela API and, when wired, Stellar/Soroban for wallet and contract interactions.
 
 ## Setup
 
@@ -9,18 +9,22 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:5173. The dev server proxies `/api` and `/health` to the backend (port 3001).
+Open `http://localhost:5173`. The dev server proxies `/api`, `/api/v1`, and `/health` to the backend on port `3001`.
 
 ## Env
 
-- `VITE_API_URL` – Base URL for API (default: '' for proxy)
+- `VITE_API_URL`: Base URL for API requests. Leave empty to use the local Vite proxy.
+
+## API routing
+
+The frontend now targets `/api/v1/*` routes by default. Legacy `/api/*` routes are still supported by the backend for backward compatibility, but new integrations should use the v1 prefix.
 
 ## Stellar integration
 
 Use `@stellar/stellar-sdk` for:
 
 - Connecting to Soroban RPC
-- Building/signing transactions
+- Building and signing transactions
 - Invoking the rewards and campaign contracts
 
 See [Stellar Developers](https://developers.stellar.org/docs) and the root README for contract IDs and flows.

--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -11,7 +11,7 @@ export default function Landing() {
 
   useEffect(() => {
     const api = import.meta.env.VITE_API_URL || '';
-    fetch(`${api}/api/campaigns`)
+    fetch(`${api}/api/v1/campaigns`)
       .then((r) => r.json())
       .then(setCampaigns)
       .catch(() => setCampaigns([]));

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      '/api/v1': { target: 'http://localhost:3001', changeOrigin: true },
       '/api': { target: 'http://localhost:3001', changeOrigin: true },
       '/health': { target: 'http://localhost:3001', changeOrigin: true },
     },


### PR DESCRIPTION
## Description
Introduce `/api/v1` as the preferred prefix for backend routes, update the frontend to consume the new versioned campaign endpoint, and keep the existing `/api/*` routes working with a documented migration note.
## Changes proposed
### What were you told to do?
Prefix all API routes with `/api/v1`, document the change, and either preserve backward compatibility or provide a short migration note.

Closes #32 

### What did I do?
#### Versioned backend routes
- registered `/api/v1`, `/api/v1/campaigns`, and `/api/v1/campaigns/:id` as the canonical API endpoints
- kept `/api`, `/api/campaigns`, and `/api/campaigns/:id` available as compatibility aliases
- updated the API info response to advertise the v1 prefix and the compatibility status
#### Frontend and docs
- updated the frontend campaign fetch path to use `/api/v1/campaigns`
- added an explicit Vite proxy entry for `/api/v1`
- documented the preferred v1 routes and the legacy-route migration note in the backend, frontend, and root READMEs
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
Validated with node --check backend/src/index.js and npm run build --workspace=frontend. Backend route definitions parse correctly and the frontend builds successfully against the new `/api/v1` endpoint path.
