### PR TITLE
Add pause/unpause functionality to rewards contract

### DIFF
--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contractmeta, contracterror, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contractmeta, symbol_short, Env, Symbol};
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -13,6 +13,8 @@ use soroban_sdk::{contract, contractimpl, contractmeta, contracterror, symbol_sh
 pub enum Error {
     Overflow = 1,
     InsufficientBalance = 2,
+    Unauthorized = 3,
+    ContractPaused = 4,
 }
 
 contractmeta!(
@@ -23,6 +25,7 @@ contractmeta!(
 const BALANCE: Symbol = symbol_short!("balance");
 const CLAIMED: Symbol = symbol_short!("claimed");
 const METADATA: Symbol = symbol_short!("metadata");
+const PAUSED: Symbol = symbol_short!("paused");
 
 #[contract]
 pub struct RewardsContract;
@@ -36,9 +39,12 @@ impl RewardsContract {
         name: Symbol,
         symbol: Symbol,
     ) -> Result<(), Error> {
-        env.storage().instance().set(&symbol_short!("admin"), &admin);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("admin"), &admin);
         env.storage().instance().set(&CLAIMED, &0u64);
         env.storage().instance().set(&METADATA, &(name, symbol));
+        env.storage().instance().set(&PAUSED, &false);
         Ok(())
     }
 
@@ -52,10 +58,7 @@ impl RewardsContract {
 
     /// Get the current points balance for a user.
     pub fn balance(env: Env, user: soroban_sdk::Address) -> u64 {
-        env.storage()
-            .instance()
-            .get(&(BALANCE, user))
-            .unwrap_or(0)
+        env.storage().instance().get(&(BALANCE, user)).unwrap_or(0)
     }
 
     /// Credit points to a user (admin or authorized campaign only).
@@ -66,6 +69,13 @@ impl RewardsContract {
         amount: u64,
     ) -> Result<u64, Error> {
         from.require_auth();
+
+        // Check if contract is paused
+        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+        if paused {
+            return Err(Error::ContractPaused);
+        }
+
         let key = (BALANCE, user.clone());
         let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
         let new_balance = current.checked_add(amount).ok_or(Error::Overflow)?;
@@ -77,12 +87,23 @@ impl RewardsContract {
     /// Claim rewards for a user (reduces balance).
     pub fn claim(env: Env, user: soroban_sdk::Address, amount: u64) -> Result<u64, Error> {
         user.require_auth();
+
+        // Check if contract is paused
+        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+        if paused {
+            return Err(Error::ContractPaused);
+        }
+
         let key = (BALANCE, user.clone());
         let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
-        let new_balance = current.checked_sub(amount).ok_or(Error::InsufficientBalance)?;
+        let new_balance = current
+            .checked_sub(amount)
+            .ok_or(Error::InsufficientBalance)?;
         env.storage().instance().set(&key, &new_balance);
         let total: u64 = env.storage().instance().get(&CLAIMED).unwrap_or(0);
-        env.storage().instance().set(&CLAIMED, &total.saturating_add(amount));
+        env.storage()
+            .instance()
+            .set(&CLAIMED, &total.saturating_add(amount));
         env.storage().instance().extend_ttl(50, 100);
         Ok(new_balance)
     }
@@ -90,6 +111,26 @@ impl RewardsContract {
     /// Get total claimed rewards (global stats).
     pub fn total_claimed(env: Env) -> u64 {
         env.storage().instance().get(&CLAIMED).unwrap_or(0)
+    }
+
+    /// Pause the contract (admin only). Blocks credit and claim operations.
+    pub fn set_paused(env: Env, admin: soroban_sdk::Address, paused: bool) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: soroban_sdk::Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap();
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage().instance().set(&PAUSED, &paused);
+        Ok(())
+    }
+
+    /// Check if contract is paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().instance().get(&PAUSED).unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
## Summary
Implements pause/unpause functionality for the rewards contract, allowing administrators to temporarily disable credit and claim operations during emergencies or maintenance.

## Changes
- Added `ContractPaused` error variant (Error code 4)
- Added `PAUSED` storage key to track pause state
- Implemented `set_paused` admin function to control pause state
- Updated `credit` function to check pause state and reject operations when paused
- Updated `claim` function to check pause state and reject operations when paused
- Added `is_paused` query function to check current pause status
- Initialize contract with `paused=false` by default

## Implementation Details
The pause mechanism works as follows:
1. **Default state**: Contract starts unpaused (paused=false)
2. **Pausing**: Admin calls `set_paused(env, admin, true)` to pause
3. **Effect**: Both `credit` and `claim` check pause state and return `ContractPaused` error if paused
4. **Unpausing**: Admin calls `set_paused(env, admin, false)` to resume operations
5. **Queries**: `balance`, `metadata`, `total_claimed`, and `is_paused` work even when paused

## Security
- Only admin can pause/unpause the contract
- Includes authorization checks to prevent unauthorized pause state changes
- Read-only operations remain available during pause

## Use Cases
- Emergency situations requiring immediate halt of operations
- Scheduled maintenance windows
- Security incident response
- Contract upgrades or migrations

Closes #8