### PR TITLE
Add CampaignInactive error to campaign contract

### DIFF
--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contractmeta, contracterror, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contractmeta, symbol_short, Env, Symbol};
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -13,12 +13,10 @@ use soroban_sdk::{contract, contractimpl, contractmeta, contracterror, symbol_sh
 pub enum Error {
     Unauthorized = 100,
     OutsideTimeWindow = 101,
+    CampaignInactive = 102,
 }
 
-contractmeta!(
-    key = "Description",
-    val = "Trivela campaign configuration"
-);
+contractmeta!(key = "Description", val = "Trivela campaign configuration");
 
 const ADMIN: Symbol = symbol_short!("admin");
 const CAMPAIGN_ACTIVE: Symbol = symbol_short!("active");
@@ -72,6 +70,12 @@ impl CampaignContract {
     pub fn register(env: Env, participant: soroban_sdk::Address) -> Result<bool, Error> {
         participant.require_auth();
 
+        // Check if campaign is active
+        let active: bool = env.storage().instance().get(&CAMPAIGN_ACTIVE).unwrap_or(false);
+        if !active {
+            return Err(Error::CampaignInactive);
+        }
+
         let now = env.ledger().timestamp();
         let start: u64 = env.storage().instance().get(&START_TIME).unwrap_or(0);
         let end: u64 = env.storage().instance().get(&END_TIME).unwrap_or(u64::MAX);
@@ -89,6 +93,20 @@ impl CampaignContract {
         Ok(true)
     }
 
+        let key = (PARTICIPANT, participant.clone());
+        if env
+            .storage()
+            .instance()
+            .get::<_, bool>(&key)
+            .unwrap_or(false)
+        {
+            return Ok(false);
+        }
+        env.storage().instance().set(&key, &true);
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(true)
+    }
+
     /// Check if a participant is registered.
     pub fn is_participant(env: Env, participant: soroban_sdk::Address) -> bool {
         env.storage()
@@ -99,7 +117,10 @@ impl CampaignContract {
 
     /// Check if campaign is active.
     pub fn is_active(env: Env) -> bool {
-        env.storage().instance().get(&CAMPAIGN_ACTIVE).unwrap_or(false)
+        env.storage()
+            .instance()
+            .get(&CAMPAIGN_ACTIVE)
+            .unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
## Summary
Enhances the campaign contract error handling by adding a `CampaignInactive` error and validating campaign active status during registration, providing clearer error feedback to users.

## Changes
- Added `CampaignInactive` error variant (Error code 102)
- Updated `register` function to check campaign active status before processing registration
- Ensures registration is only allowed when campaign is active
- Provides clear error message when users attempt to register for inactive campaigns

## Implementation Details
The enhanced error handling works as follows:
1. **Active check**: Before processing registration, check if campaign is active
2. **Error feedback**: Return `CampaignInactive` error if campaign is not active
3. **Validation order**: 
   - First check if campaign is active
   - Then check time window constraints
   - Finally check for duplicate registration

## Benefits
- **Better UX**: Users receive clear error messages explaining why registration failed
- **Explicit validation**: Campaign active state is explicitly validated rather than implicitly assumed
- **Error specificity**: Differentiates between inactive campaigns and other registration failures
- **Admin control**: Works seamlessly with existing `set_active` admin function

## Error Hierarchy
The campaign contract now has a comprehensive error enum:
- `Unauthorized` (100): Admin authorization failed
- `OutsideTimeWindow` (101): Registration attempt outside configured time window
- `CampaignInactive` (102): Registration attempt when campaign is not active

Closes #12