### PR TITLE
feat: add rewards events and harden backend APIs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,6 +17,8 @@ npm run dev
 - `STELLAR_NETWORK`: `testnet` or `mainnet`
 - `SOROBAN_RPC_URL`: Soroban RPC URL exposed in API metadata
 - `TRIVELA_API_KEY`: Optional API key for write endpoints (see below)
+- `RATE_LIMIT_WINDOW_MS`: Rate limit window for `/api/*` and `/api/v1/*` routes (default `60000`)
+- `RATE_LIMIT_MAX_REQUESTS`: Max requests per API key or IP in each window (default `60`)
 
 ## API Key Authentication
 
@@ -47,9 +49,22 @@ If the key is missing or wrong the API responds with `401 Unauthorized`.
 Preferred routes:
 
 - `GET /health`
+- `GET /health/rpc`
 - `GET /api/v1`
 - `GET /api/v1/campaigns`
 - `GET /api/v1/campaigns/:id`
+- `DELETE /api/v1/campaigns/:id`
+
+`GET /health` now includes the configured Soroban RPC health in the JSON
+response. `GET /health/rpc` performs the direct RPC dependency check and returns
+`503` when the configured Soroban RPC is unavailable.
+
+## Rate limiting
+
+All `/api/*` and `/api/v1/*` routes are protected by an in-memory rate limiter.
+Requests are keyed by API key when one is present, otherwise by client IP.
+When the limit is exceeded the API returns `429 Too Many Requests` with a
+`Retry-After` header.
 
 ### Campaign pagination
 
@@ -87,5 +102,6 @@ Backward-compatible legacy routes remain available under `/api/*` for now:
 - `GET /api`
 - `GET /api/campaigns`
 - `GET /api/campaigns/:id`
+- `DELETE /api/campaigns/:id`
 
 Migration note: new integrations should use `/api/v1/*`. Existing clients on `/api/*` continue to work.

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch src/index.js",
-    "start": "node src/index.js",
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js",
     "test": "node --test src/**/*.test.js"
   },
   "dependencies": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,117 +3,219 @@
  * Serves campaign data, health, and Stellar/Soroban RPC proxy for the frontend.
  */
 
-import 'dotenv/config';
-import express from 'express';
 import cors from 'cors';
-import requireApiKey from './middleware/apiKeyAuth.js';
+import express from 'express';
+import { pathToFileURL } from 'node:url';
+import createApiKeyAuth from './middleware/apiKeyAuth.js';
+import { createRateLimiter } from './middleware/rateLimit.js';
 import { paginateItems } from './pagination.js';
+import { checkSorobanRpcHealth } from './sorobanRpc.js';
 
-const app = express();
-const PORT = process.env.PORT || 3001;
+const DEFAULT_PORT = 3001;
+const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 60;
 const LEGACY_API_PREFIX = '/api';
 const API_V1_PREFIX = '/api/v1';
 
-app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
-app.use(express.json());
+function normalizePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
-// Health check for Drip and reviewers
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'trivela-api', timestamp: new Date().toISOString() });
-});
-
-// Placeholder campaigns (replace with DB later)
-const campaigns = [
-  {
-    id: '1',
-    name: 'Welcome Campaign',
-    description: 'Earn points for completing onboarding',
-    active: true,
-    rewardPerAction: 10,
-    createdAt: new Date().toISOString(),
-  },
-];
-
-function apiInfo(req, res) {
-  const usingLegacyPrefix = req.path.startsWith(LEGACY_API_PREFIX) && !req.path.startsWith(API_V1_PREFIX);
-
-  res.json({
-    name: 'Trivela API',
-    version: '0.1.0',
-    prefix: API_V1_PREFIX,
-    endpoints: {
-      health: 'GET /health',
-      info: `GET ${API_V1_PREFIX}`,
-      campaigns: `GET ${API_V1_PREFIX}/campaigns`,
-      campaign: `GET ${API_V1_PREFIX}/campaigns/:id`,
+function defaultCampaigns() {
+  return [
+    {
+      id: '1',
+      name: 'Welcome Campaign',
+      description: 'Earn points for completing onboarding',
+      active: true,
+      rewardPerAction: 10,
+      createdAt: new Date().toISOString(),
     },
-    compatibility: {
-      legacyPrefix: LEGACY_API_PREFIX,
-      legacyRoutesSupported: true,
-      migrationNote: 'Prefer /api/v1/* routes. Legacy /api/* routes remain available for compatibility.',
-      usingLegacyPrefix,
-    },
-    stellar: {
-      network: process.env.STELLAR_NETWORK || 'testnet',
-      rpcUrl: process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org',
-    },
+  ];
+}
+
+function cloneCampaigns(campaigns) {
+  return campaigns.map((campaign) => ({ ...campaign }));
+}
+
+function nextCampaignId(campaigns) {
+  const maxId = campaigns.reduce((currentMax, campaign) => {
+    const parsed = Number.parseInt(campaign.id, 10);
+    return Number.isFinite(parsed) ? Math.max(currentMax, parsed) : currentMax;
+  }, 0);
+
+  return String(maxId + 1);
+}
+
+export function createApp(options = {}) {
+  const apiKey = options.apiKey ?? process.env.TRIVELA_API_KEY ?? '';
+  const corsOrigin = options.corsOrigin ?? process.env.CORS_ORIGIN ?? '*';
+  const stellarNetwork = options.stellarNetwork ?? process.env.STELLAR_NETWORK ?? 'testnet';
+  const sorobanRpcUrl = options.sorobanRpcUrl ?? process.env.SOROBAN_RPC_URL ?? DEFAULT_RPC_URL;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const campaigns = cloneCampaigns(options.campaigns ?? defaultCampaigns());
+  const rateLimitWindowMs = normalizePositiveInteger(
+    options.rateLimit?.windowMs ?? process.env.RATE_LIMIT_WINDOW_MS,
+    DEFAULT_RATE_LIMIT_WINDOW_MS,
+  );
+  const rateLimitMaxRequests = normalizePositiveInteger(
+    options.rateLimit?.maxRequests ?? process.env.RATE_LIMIT_MAX_REQUESTS,
+    DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+  );
+
+  const app = express();
+  const requireApiKey = createApiKeyAuth({ apiKey });
+  const rateLimiter = createRateLimiter({
+    windowMs: rateLimitWindowMs,
+    maxRequests: rateLimitMaxRequests,
+    timeProvider: options.rateLimit?.timeProvider,
+  });
+
+  app.use(cors({ origin: corsOrigin }));
+  app.use(express.json());
+
+  async function buildHealthPayload() {
+    const rpc = await checkSorobanRpcHealth({
+      rpcUrl: sorobanRpcUrl,
+      fetchImpl,
+    });
+
+    return {
+      status: rpc.status === 'ok' ? 'ok' : 'degraded',
+      service: 'trivela-api',
+      timestamp: new Date().toISOString(),
+      rpc,
+    };
+  }
+
+  app.get('/health', async (_req, res) => {
+    const payload = await buildHealthPayload();
+    res.json(payload);
+  });
+
+  app.get('/health/rpc', async (_req, res) => {
+    const rpc = await checkSorobanRpcHealth({
+      rpcUrl: sorobanRpcUrl,
+      fetchImpl,
+    });
+    res.status(rpc.status === 'ok' ? 200 : 503).json(rpc);
+  });
+
+  function apiInfo(req, res) {
+    const usingLegacyPrefix =
+      req.path.startsWith(LEGACY_API_PREFIX) && !req.path.startsWith(API_V1_PREFIX);
+
+    res.json({
+      name: 'Trivela API',
+      version: '0.1.0',
+      prefix: API_V1_PREFIX,
+      endpoints: {
+        health: 'GET /health',
+        healthRpc: 'GET /health/rpc',
+        info: `GET ${API_V1_PREFIX}`,
+        campaigns: `GET ${API_V1_PREFIX}/campaigns`,
+        campaign: `GET ${API_V1_PREFIX}/campaigns/:id`,
+        deleteCampaign: `DELETE ${API_V1_PREFIX}/campaigns/:id`,
+      },
+      compatibility: {
+        legacyPrefix: LEGACY_API_PREFIX,
+        legacyRoutesSupported: true,
+        migrationNote: 'Prefer /api/v1/* routes. Legacy /api/* routes remain available for compatibility.',
+        usingLegacyPrefix,
+      },
+      stellar: {
+        network: stellarNetwork,
+        rpcUrl: sorobanRpcUrl,
+      },
+      rateLimit: {
+        keying: 'per API key when present, otherwise per IP address',
+        windowMs: rateLimitWindowMs,
+        maxRequests: rateLimitMaxRequests,
+      },
+    });
+  }
+
+  function listCampaigns(req, res) {
+    res.json(paginateItems(campaigns, req.query));
+  }
+
+  function getCampaignById(req, res) {
+    const campaign = campaigns.find((entry) => entry.id === req.params.id);
+    if (!campaign) {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+
+    return res.json(campaign);
+  }
+
+  function createCampaign(req, res) {
+    const { name, description, rewardPerAction } = req.body;
+    if (!name) {
+      return res.status(400).json({ error: 'name is required' });
+    }
+
+    const campaign = {
+      id: nextCampaignId(campaigns),
+      name,
+      description: description || '',
+      active: true,
+      rewardPerAction: rewardPerAction ?? 0,
+      createdAt: new Date().toISOString(),
+    };
+
+    campaigns.push(campaign);
+    return res.status(201).json(campaign);
+  }
+
+  function updateCampaign(req, res) {
+    const campaign = campaigns.find((entry) => entry.id === req.params.id);
+    if (!campaign) {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+
+    Object.assign(campaign, req.body, { id: campaign.id });
+    return res.json(campaign);
+  }
+
+  function deleteCampaign(req, res) {
+    const index = campaigns.findIndex((entry) => entry.id === req.params.id);
+    if (index === -1) {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+
+    campaigns.splice(index, 1);
+    return res.status(204).end();
+  }
+
+  function registerApiRoutes(prefix) {
+    app.get(prefix, rateLimiter, apiInfo);
+    app.get(`${prefix}/campaigns`, rateLimiter, listCampaigns);
+    app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
+    app.post(`${prefix}/campaigns`, rateLimiter, requireApiKey, createCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, updateCampaign);
+    app.delete(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, deleteCampaign);
+  }
+
+  registerApiRoutes(API_V1_PREFIX);
+  registerApiRoutes(LEGACY_API_PREFIX);
+
+  return app;
+}
+
+export function startServer(options = {}) {
+  const app = createApp(options);
+  const port = options.port ?? process.env.PORT ?? DEFAULT_PORT;
+
+  return app.listen(port, () => {
+    console.log(`Trivela API running at http://localhost:${port}`);
   });
 }
 
-function listCampaigns(req, res) {
-  res.json(paginateItems(campaigns, req.query));
+const isExecutedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isExecutedDirectly) {
+  startServer();
 }
-
-function getCampaignById(req, res) {
-  const campaign = campaigns.find((c) => c.id === req.params.id);
-  if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
-  res.json(campaign);
-}
-
-function createCampaign(req, res) {
-  const { name, description, rewardPerAction } = req.body;
-  if (!name) return res.status(400).json({ error: 'name is required' });
-  const campaign = {
-    id: String(campaigns.length + 1),
-    name,
-    description: description || '',
-    active: true,
-    rewardPerAction: rewardPerAction ?? 0,
-    createdAt: new Date().toISOString(),
-  };
-  campaigns.push(campaign);
-  res.status(201).json(campaign);
-}
-
-function updateCampaign(req, res) {
-  const campaign = campaigns.find((c) => c.id === req.params.id);
-  if (!campaign) return res.status(404).json({ error: 'Campaign not found' });
-  Object.assign(campaign, req.body, { id: campaign.id });
-  res.json(campaign);
-}
-
-function deleteCampaign(req, res) {
-  const idx = campaigns.findIndex((c) => c.id === req.params.id);
-  if (idx === -1) return res.status(404).json({ error: 'Campaign not found' });
-  campaigns.splice(idx, 1);
-  res.status(204).end();
-}
-
-function registerApiRoutes(prefix) {
-  // Read endpoints — open
-  app.get(prefix, apiInfo);
-  app.get(`${prefix}/campaigns`, listCampaigns);
-  app.get(`${prefix}/campaigns/:id`, getCampaignById);
-
-  // Write endpoints — protected by optional API key
-  app.post(`${prefix}/campaigns`, requireApiKey, createCampaign);
-  app.put(`${prefix}/campaigns/:id`, requireApiKey, updateCampaign);
-  app.delete(`${prefix}/campaigns/:id`, requireApiKey, deleteCampaign);
-}
-
-registerApiRoutes(API_V1_PREFIX);
-registerApiRoutes(LEGACY_API_PREFIX);
-
-app.listen(PORT, () => {
-  console.log(`Trivela API running at http://localhost:${PORT}`);
-});

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import test from 'node:test';
+import { createApp } from './index.js';
+
+async function startTestServer(options = {}) {
+  const app = createApp(options);
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const address = server.address();
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function stopTestServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+test('DELETE /api/campaigns/:id removes a campaign and returns 404 when missing', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    let response = await fetch(`${baseUrl}/api/campaigns/1`, {
+      method: 'DELETE',
+    });
+    assert.equal(response.status, 204);
+
+    response = await fetch(`${baseUrl}/api/campaigns/1`);
+    assert.equal(response.status, 404);
+
+    response = await fetch(`${baseUrl}/api/campaigns/999`, {
+      method: 'DELETE',
+    });
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: 'Campaign not found' });
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('rate limiting applies to API routes', async () => {
+  const { server, baseUrl } = await startTestServer({
+    rateLimit: {
+      windowMs: 60_000,
+      maxRequests: 1,
+    },
+  });
+
+  try {
+    const firstResponse = await fetch(`${baseUrl}/api/v1/campaigns`);
+    assert.equal(firstResponse.status, 200);
+
+    const secondResponse = await fetch(`${baseUrl}/api/v1/campaigns`);
+    assert.equal(secondResponse.status, 429);
+    assert.equal(secondResponse.headers.get('retry-after'), '60');
+    assert.deepEqual(await secondResponse.json(), {
+      error: 'Rate limit exceeded',
+      keying: 'per API key when present, otherwise per IP address',
+      limit: 1,
+      windowMs: 60_000,
+      retryAfterSeconds: 60,
+    });
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('/health includes Soroban RPC health when the RPC is reachable', async () => {
+  const fetchImpl = async (url, init) => {
+    assert.equal(url, 'https://rpc.example');
+    assert.equal(init.method, 'POST');
+    assert.equal(JSON.parse(init.body).method, 'getNetwork');
+
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'health-check',
+        result: {
+          friendbotUrl: 'https://friendbot.example',
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  };
+
+  const { server, baseUrl } = await startTestServer({
+    sorobanRpcUrl: 'https://rpc.example',
+    fetchImpl,
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/health`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.status, 'ok');
+    assert.equal(payload.rpc.status, 'ok');
+    assert.equal(payload.rpc.url, 'https://rpc.example');
+    assert.equal(payload.rpc.method, 'getNetwork');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('/health/rpc returns 503 when the Soroban RPC health check fails', async () => {
+  const fetchImpl = async () => {
+    throw new Error('connection refused');
+  };
+
+  const { server, baseUrl } = await startTestServer({
+    sorobanRpcUrl: 'https://rpc.example',
+    fetchImpl,
+  });
+
+  try {
+    const response = await fetch(`${baseUrl}/health/rpc`);
+    assert.equal(response.status, 503);
+
+    const payload = await response.json();
+    assert.equal(payload.status, 'error');
+    assert.equal(payload.url, 'https://rpc.example');
+    assert.match(payload.error, /connection refused/);
+  } finally {
+    await stopTestServer(server);
+  }
+});

--- a/backend/src/middleware/apiKeyAuth.js
+++ b/backend/src/middleware/apiKeyAuth.js
@@ -1,28 +1,24 @@
 /**
  * Optional API key authentication middleware.
  *
- * If the environment variable TRIVELA_API_KEY is set, all requests that pass
- * through this middleware must include a matching key via one of:
- *   - Header:  X-API-Key: <key>
- *   - Query:   ?api_key=<key>
- *
- * If TRIVELA_API_KEY is **not** set the middleware is a no-op, keeping the API
- * open for local development.
+ * If the provided API key is empty, the middleware is a no-op to keep local
+ * development convenient.
  */
 
-const API_KEY = process.env.TRIVELA_API_KEY || '';
+export default function createApiKeyAuth({
+  apiKey = process.env.TRIVELA_API_KEY || '',
+} = {}) {
+  return function requireApiKey(req, res, next) {
+    if (!apiKey) {
+      return next();
+    }
 
-export default function requireApiKey(req, res, next) {
-  if (!API_KEY) {
-    return next();
-  }
+    const provided = req.headers['x-api-key'] || req.query.api_key;
 
-  const provided =
-    req.headers['x-api-key'] || req.query.api_key;
+    if (provided === apiKey) {
+      return next();
+    }
 
-  if (provided === API_KEY) {
-    return next();
-  }
-
-  return res.status(401).json({ error: 'Unauthorized – valid API key required.' });
+    return res.status(401).json({ error: 'Unauthorized – valid API key required.' });
+  };
 }

--- a/backend/src/middleware/rateLimit.js
+++ b/backend/src/middleware/rateLimit.js
@@ -1,0 +1,51 @@
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX_REQUESTS = 60;
+
+function defaultKeyGenerator(req) {
+  const apiKey = req.headers['x-api-key'] || req.query.api_key;
+  if (apiKey) {
+    return `api-key:${apiKey}`;
+  }
+
+  return `ip:${req.ip || req.socket?.remoteAddress || 'unknown'}`;
+}
+
+export function createRateLimiter({
+  windowMs = DEFAULT_WINDOW_MS,
+  maxRequests = DEFAULT_MAX_REQUESTS,
+  timeProvider = () => Date.now(),
+  keyGenerator = defaultKeyGenerator,
+} = {}) {
+  const buckets = new Map();
+
+  return function rateLimit(req, res, next) {
+    const now = timeProvider();
+    const key = keyGenerator(req);
+    const existing = buckets.get(key);
+    const bucket =
+      existing && existing.resetAt > now
+        ? existing
+        : { count: 0, resetAt: now + windowMs };
+
+    bucket.count += 1;
+    buckets.set(key, bucket);
+
+    const remaining = Math.max(maxRequests - bucket.count, 0);
+    res.setHeader('X-RateLimit-Limit', String(maxRequests));
+    res.setHeader('X-RateLimit-Remaining', String(remaining));
+
+    if (bucket.count > maxRequests) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      return res.status(429).json({
+        error: 'Rate limit exceeded',
+        keying: 'per API key when present, otherwise per IP address',
+        limit: maxRequests,
+        windowMs,
+        retryAfterSeconds,
+      });
+    }
+
+    return next();
+  };
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,4 @@
+import 'dotenv/config';
+import { startServer } from './index.js';
+
+startServer();

--- a/backend/src/sorobanRpc.js
+++ b/backend/src/sorobanRpc.js
@@ -1,0 +1,60 @@
+const HEALTHCHECK_REQUEST = {
+  jsonrpc: '2.0',
+  id: 'health-check',
+  method: 'getNetwork',
+};
+
+export async function checkSorobanRpcHealth({
+  rpcUrl,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    return {
+      status: 'error',
+      url: rpcUrl,
+      error: 'Fetch is not available in this runtime.',
+    };
+  }
+
+  try {
+    const response = await fetchImpl(rpcUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(HEALTHCHECK_REQUEST),
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      return {
+        status: 'error',
+        url: rpcUrl,
+        httpStatus: response.status,
+        error: payload?.error?.message || `HTTP ${response.status}`,
+      };
+    }
+
+    if (payload?.error) {
+      return {
+        status: 'error',
+        url: rpcUrl,
+        error: payload.error.message || 'Soroban RPC returned an error.',
+      };
+    }
+
+    return {
+      status: 'ok',
+      url: rpcUrl,
+      method: HEALTHCHECK_REQUEST.method,
+      result: payload?.result ?? null,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      url: rpcUrl,
+      error: error instanceof Error ? error.message : 'Unknown Soroban RPC error',
+    };
+  }
+}

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contractmeta, symbol_short, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contractmeta, symbol_short, Address, Env, Symbol};
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -14,7 +14,7 @@ pub enum Error {
     Unauthorized = 100,
     OutsideTimeWindow = 101,
     CapacityReached = 102,
-    CampaignInactive = 102,
+    CampaignInactive = 103,
 }
 
 contractmeta!(key = "Description", val = "Trivela campaign configuration");
@@ -33,7 +33,7 @@ pub struct CampaignContract;
 #[contractimpl]
 impl CampaignContract {
     /// Initialize campaign contract with an admin.
-    pub fn initialize(env: Env, admin: soroban_sdk::Address) -> Result<(), Error> {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&CAMPAIGN_ACTIVE, &true);
         env.storage().instance().set(&START_TIME, &0u64);
@@ -43,49 +43,46 @@ impl CampaignContract {
     }
 
     /// Set registration time window (admin only).
-    pub fn set_window(
-        env: Env,
-        admin: soroban_sdk::Address,
-        start: u64,
-        end: u64,
-    ) -> Result<(), Error> {
+    pub fn set_window(env: Env, admin: Address, start: u64, end: u64) -> Result<(), Error> {
         admin.require_auth();
-        let stored: soroban_sdk::Address = env.storage().instance().get(&ADMIN).unwrap();
+        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
         if stored != admin {
             return Err(Error::Unauthorized);
         }
+
         env.storage().instance().set(&START_TIME, &start);
         env.storage().instance().set(&END_TIME, &end);
         Ok(())
     }
 
     /// Set campaign active flag (admin only).
-    pub fn set_active(env: Env, admin: soroban_sdk::Address, active: bool) -> Result<(), Error> {
+    pub fn set_active(env: Env, admin: Address, active: bool) -> Result<(), Error> {
         admin.require_auth();
-        let stored: soroban_sdk::Address = env.storage().instance().get(&ADMIN).unwrap();
+        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
         if stored != admin {
             return Err(Error::Unauthorized);
         }
+
         env.storage().instance().set(&CAMPAIGN_ACTIVE, &active);
         Ok(())
     }
 
     /// Set maximum participant cap (admin only). Set to 0 for unlimited.
-    pub fn set_max_cap(env: Env, admin: soroban_sdk::Address, max_cap: u64) -> Result<(), Error> {
+    pub fn set_max_cap(env: Env, admin: Address, max_cap: u64) -> Result<(), Error> {
         admin.require_auth();
-        let stored: soroban_sdk::Address = env.storage().instance().get(&ADMIN).unwrap();
+        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
         if stored != admin {
             return Err(Error::Unauthorized);
         }
+
         env.storage().instance().set(&MAX_CAP, &max_cap);
         Ok(())
     }
 
     /// Register a participant (authorized caller).
-    pub fn register(env: Env, participant: soroban_sdk::Address) -> Result<bool, Error> {
+    pub fn register(env: Env, participant: Address) -> Result<bool, Error> {
         participant.require_auth();
 
-        // Check if campaign is active
         let active: bool = env.storage().instance().get(&CAMPAIGN_ACTIVE).unwrap_or(false);
         if !active {
             return Err(Error::CampaignInactive);
@@ -109,14 +106,9 @@ impl CampaignContract {
             return Ok(false);
         }
 
-        // Check capacity if max_cap is set
         let max_cap: u64 = env.storage().instance().get(&MAX_CAP).unwrap_or(0);
         if max_cap > 0 {
-            let count: u64 = env
-                .storage()
-                .instance()
-                .get(&PARTICIPANT_COUNT)
-                .unwrap_or(0);
+            let count: u64 = env.storage().instance().get(&PARTICIPANT_COUNT).unwrap_or(0);
             if count >= max_cap {
                 return Err(Error::CapacityReached);
             }
@@ -124,36 +116,15 @@ impl CampaignContract {
 
         env.storage().instance().set(&key, &true);
 
-        // Increment participant count
-        let count: u64 = env
-            .storage()
-            .instance()
-            .get(&PARTICIPANT_COUNT)
-            .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&PARTICIPANT_COUNT, &(count + 1));
+        let count: u64 = env.storage().instance().get(&PARTICIPANT_COUNT).unwrap_or(0);
+        env.storage().instance().set(&PARTICIPANT_COUNT, &(count + 1));
 
-        env.storage().instance().extend_ttl(50, 100);
-        Ok(true)
-    }
-
-        let key = (PARTICIPANT, participant.clone());
-        if env
-            .storage()
-            .instance()
-            .get::<_, bool>(&key)
-            .unwrap_or(false)
-        {
-            return Ok(false);
-        }
-        env.storage().instance().set(&key, &true);
         env.storage().instance().extend_ttl(50, 100);
         Ok(true)
     }
 
     /// Check if a participant is registered.
-    pub fn is_participant(env: Env, participant: soroban_sdk::Address) -> bool {
+    pub fn is_participant(env: Env, participant: Address) -> bool {
         env.storage()
             .instance()
             .get(&(PARTICIPANT, participant))
@@ -162,18 +133,12 @@ impl CampaignContract {
 
     /// Check if campaign is active.
     pub fn is_active(env: Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&CAMPAIGN_ACTIVE)
-            .unwrap_or(false)
+        env.storage().instance().get(&CAMPAIGN_ACTIVE).unwrap_or(false)
     }
 
     /// Get current participant count.
     pub fn get_participant_count(env: Env) -> u64 {
-        env.storage()
-            .instance()
-            .get(&PARTICIPANT_COUNT)
-            .unwrap_or(0)
+        env.storage().instance().get(&PARTICIPANT_COUNT).unwrap_or(0)
     }
 
     /// Get maximum participant cap (0 means unlimited).

--- a/contracts/campaign/test_snapshots/test/test_register_participant_twice_returns_false.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_participant_twice_returns_false.1.json
@@ -1,0 +1,195 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "active"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "count"
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "end"
+                      },
+                      "val": {
+                        "u64": "18446744073709551615"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "start"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "partic"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/README.md
+++ b/contracts/rewards/README.md
@@ -1,0 +1,15 @@
+# Rewards Contract
+
+The Trivela rewards contract tracks user balances and claimed totals on Soroban.
+
+## Events
+
+- `credit`
+  Topics: `(credit, user)`
+  Data: credited `amount` as `u64`
+- `claim`
+  Topics: `(claim, user)`
+  Data: claimed `amount` as `u64`
+
+These events are emitted by the `credit` and `claim` contract functions so
+indexers and off-chain services can track reward balance changes.

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -2,10 +2,16 @@
 //!
 //! On-chain points and rewards for the Trivela campaign platform.
 //! Tracks user balances and allows claiming rewards.
+//!
+//! Events:
+//! - `credit`: topics `(credit, user)`, data `amount: u64`
+//! - `claim`: topics `(claim, user)`, data `amount: u64`
 
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contractmeta, symbol_short, Env, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contractmeta, symbol_short, Address, Env, Symbol, Vec,
+};
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -22,26 +28,42 @@ contractmeta!(
     val = "Trivela campaign rewards and points"
 );
 
+const ADMIN: Symbol = symbol_short!("admin");
 const BALANCE: Symbol = symbol_short!("balance");
 const CLAIMED: Symbol = symbol_short!("claimed");
 const METADATA: Symbol = symbol_short!("metadata");
 const PAUSED: Symbol = symbol_short!("paused");
+const CREDIT_EVENT: Symbol = symbol_short!("credit");
+const CLAIM_EVENT: Symbol = symbol_short!("claim");
 
 #[contract]
 pub struct RewardsContract;
 
+fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+    admin.require_auth();
+
+    let stored_admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+    if &stored_admin != admin {
+        return Err(Error::Unauthorized);
+    }
+
+    Ok(())
+}
+
+fn ensure_not_paused(env: &Env) -> Result<(), Error> {
+    let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+    if paused {
+        return Err(Error::ContractPaused);
+    }
+
+    Ok(())
+}
+
 #[contractimpl]
 impl RewardsContract {
     /// Initialize the rewards contract (admin).
-    pub fn initialize(
-        env: Env,
-        admin: soroban_sdk::Address,
-        name: Symbol,
-        symbol: Symbol,
-    ) -> Result<(), Error> {
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+    pub fn initialize(env: Env, admin: Address, name: Symbol, symbol: Symbol) -> Result<(), Error> {
+        env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&CLAIMED, &0u64);
         env.storage().instance().set(&METADATA, &(name, symbol));
         env.storage().instance().set(&PAUSED, &false);
@@ -57,29 +79,20 @@ impl RewardsContract {
     }
 
     /// Get the current points balance for a user.
-    pub fn balance(env: Env, user: soroban_sdk::Address) -> u64 {
+    pub fn balance(env: Env, user: Address) -> u64 {
         env.storage().instance().get(&(BALANCE, user)).unwrap_or(0)
     }
 
-    /// Credit points to a user (admin or authorized campaign only).
-    pub fn credit(
-        env: Env,
-        from: soroban_sdk::Address,
-        user: soroban_sdk::Address,
-        amount: u64,
-    ) -> Result<u64, Error> {
+    /// Credit points to a user.
+    pub fn credit(env: Env, from: Address, user: Address, amount: u64) -> Result<u64, Error> {
         from.require_auth();
-
-        // Check if contract is paused
-        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
-        if paused {
-            return Err(Error::ContractPaused);
-        }
+        ensure_not_paused(&env)?;
 
         let key = (BALANCE, user.clone());
         let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
         let new_balance = current.checked_add(amount).ok_or(Error::Overflow)?;
         env.storage().instance().set(&key, &new_balance);
+        env.events().publish((CREDIT_EVENT, user), amount);
         env.storage().instance().extend_ttl(50, 100);
         Ok(new_balance)
     }
@@ -87,8 +100,8 @@ impl RewardsContract {
     /// Credit points to multiple users in one call.
     pub fn batch_credit(
         env: Env,
-        from: soroban_sdk::Address,
-        recipients: Vec<(soroban_sdk::Address, u64)>,
+        from: Address,
+        recipients: Vec<(Address, u64)>,
     ) -> Result<(), Error> {
         from.require_auth();
 
@@ -110,14 +123,9 @@ impl RewardsContract {
     }
 
     /// Claim rewards for a user (reduces balance).
-    pub fn claim(env: Env, user: soroban_sdk::Address, amount: u64) -> Result<u64, Error> {
+    pub fn claim(env: Env, user: Address, amount: u64) -> Result<u64, Error> {
         user.require_auth();
-
-        // Check if contract is paused
-        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
-        if paused {
-            return Err(Error::ContractPaused);
-        }
+        ensure_not_paused(&env)?;
 
         let key = (BALANCE, user.clone());
         let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
@@ -125,10 +133,13 @@ impl RewardsContract {
             .checked_sub(amount)
             .ok_or(Error::InsufficientBalance)?;
         env.storage().instance().set(&key, &new_balance);
+
         let total: u64 = env.storage().instance().get(&CLAIMED).unwrap_or(0);
         env.storage()
             .instance()
             .set(&CLAIMED, &total.saturating_add(amount));
+
+        env.events().publish((CLAIM_EVENT, user), amount);
         env.storage().instance().extend_ttl(50, 100);
         Ok(new_balance)
     }
@@ -141,33 +152,21 @@ impl RewardsContract {
     /// Transfer points from one user to another (admin only).
     pub fn admin_transfer(
         env: Env,
-        admin: soroban_sdk::Address,
-        from: soroban_sdk::Address,
-        to: soroban_sdk::Address,
+        admin: Address,
+        from: Address,
+        to: Address,
         amount: u64,
     ) -> Result<(), Error> {
-    /// Pause the contract (admin only). Blocks credit and claim operations.
-    pub fn set_paused(env: Env, admin: soroban_sdk::Address, paused: bool) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: soroban_sdk::Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap();
-        if stored_admin != admin {
-            return Err(Error::Unauthorized);
-        }
+        require_admin(&env, &admin)?;
 
-        // Debit source
-        let from_key = (BALANCE, from.clone());
+        let from_key = (BALANCE, from);
         let from_balance: u64 = env.storage().instance().get(&from_key).unwrap_or(0);
         let new_from_balance = from_balance
             .checked_sub(amount)
             .ok_or(Error::InsufficientBalance)?;
         env.storage().instance().set(&from_key, &new_from_balance);
 
-        // Credit destination
-        let to_key = (BALANCE, to.clone());
+        let to_key = (BALANCE, to);
         let to_balance: u64 = env.storage().instance().get(&to_key).unwrap_or(0);
         let new_to_balance = to_balance.checked_add(amount).ok_or(Error::Overflow)?;
         env.storage().instance().set(&to_key, &new_to_balance);
@@ -175,6 +174,10 @@ impl RewardsContract {
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
     }
+
+    /// Pause the contract (admin only). Blocks credit and claim operations.
+    pub fn set_paused(env: Env, admin: Address, paused: bool) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&PAUSED, &paused);
         Ok(())
     }

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -1,8 +1,10 @@
 //! Tests for the Trivela rewards contract.
 
+extern crate std;
+
 use super::*;
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::Address;
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal};
 
 #[test]
 fn test_balance_empty() {
@@ -11,31 +13,66 @@ fn test_balance_empty() {
     let client = RewardsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
-    client.initialize(
-        &admin,
-        &symbol_short!("Trivela"),
-        &symbol_short!("TVL"),
-    );
-    let balance = client.balance(&user);
-    assert_eq!(balance, 0);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    assert_eq!(client.balance(&user), 0);
 }
 
 #[test]
-fn test_credit_and_balance() {
+fn test_credit_and_balance_emits_event() {
     let env = Env::default();
     let contract_id = env.register_contract(None, RewardsContract);
     let client = RewardsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
-    client.initialize(
-        &admin,
-        &symbol_short!("Trivela"),
-        &symbol_short!("TVL"),
-    );
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
     env.mock_all_auths();
     let new_balance = client.credit(&admin, &user, &100);
+
     assert_eq!(new_balance, 100);
+    assert_eq!(
+        env.events().all(),
+        vec![&env, (
+            contract_id.clone(),
+            vec![
+                &env,
+                CREDIT_EVENT.into_val(&env),
+                user.clone().into_val(&env)
+            ],
+            100u64.into_val(&env)
+        )]
+    );
     assert_eq!(client.balance(&user), 100);
+}
+
+#[test]
+fn test_claim_emits_event_and_updates_total_claimed() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    client.credit(&admin, &user, &100);
+    let new_balance = client.claim(&user, &40);
+
+    assert_eq!(new_balance, 60);
+    assert_eq!(
+        env.events().all(),
+        vec![&env, (
+            contract_id.clone(),
+            vec![&env, CLAIM_EVENT.into_val(&env), user.into_val(&env)],
+            40u64.into_val(&env)
+        )]
+    );
+    assert_eq!(client.balance(&user), 60);
+    assert_eq!(client.total_claimed(), 40);
 }
 
 #[test]
@@ -46,6 +83,7 @@ fn test_metadata() {
     let admin = Address::generate(&env);
     let name = symbol_short!("MyReward");
     let symbol = symbol_short!("REW");
+
     client.initialize(&admin, &name, &symbol);
 
     let metadata = client.metadata();
@@ -55,19 +93,13 @@ fn test_metadata() {
 
 #[test]
 fn test_claim_more_than_balance_errors() {
-fn test_batch_credit() {
     let env = Env::default();
     let contract_id = env.register_contract(None, RewardsContract);
     let client = RewardsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
-    let user_a = Address::generate(&env);
-    let user_b = Address::generate(&env);
-    client.initialize(
-        &admin,
-        &symbol_short!("Trivela"),
-        &symbol_short!("TVL"),
-    );
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
 
     env.mock_all_auths();
     let result = client.try_claim(&user, &1);
@@ -76,17 +108,40 @@ fn test_batch_credit() {
 }
 
 #[test]
-fn test_credit_overflow_errors() {
-    let recipients = soroban_sdk::vec![
-        &env,
-        (user_a.clone(), 50u64),
-        (user_b.clone(), 75u64),
-    ];
+fn test_batch_credit() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
 
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    let recipients = vec![&env, (user_a.clone(), 50u64), (user_b.clone(), 75u64)];
     client.batch_credit(&admin, &recipients);
 
     assert_eq!(client.balance(&user_a), 50);
     assert_eq!(client.balance(&user_b), 75);
+}
+
+#[test]
+fn test_credit_overflow_errors() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    client.credit(&admin, &user, &u64::MAX);
+
+    let result = client.try_credit(&admin, &user, &1);
+    assert!(result.is_err());
+    assert_eq!(client.balance(&user), u64::MAX);
 }
 
 #[test]
@@ -95,21 +150,21 @@ fn test_batch_credit_is_atomic_on_overflow() {
     let contract_id = env.register_contract(None, RewardsContract);
     let client = RewardsContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
-    let user = Address::generate(&env);
     let user_a = Address::generate(&env);
     let user_b = Address::generate(&env);
-    client.initialize(
-        &admin,
-        &symbol_short!("Trivela"),
-        &symbol_short!("TVL"),
-    );
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
 
     env.mock_all_auths();
-    client.credit(&admin, &user, &u64::MAX);
+    client.credit(&admin, &user_a, &10);
+    client.credit(&admin, &user_b, &u64::MAX);
 
-    let result = client.try_credit(&admin, &user, &1);
+    let recipients = vec![&env, (user_a.clone(), 15u64), (user_b.clone(), 1u64)];
+    let result = client.try_batch_credit(&admin, &recipients);
+
     assert!(result.is_err());
-    assert_eq!(client.balance(&user), u64::MAX);
+    assert_eq!(client.balance(&user_a), 10);
+    assert_eq!(client.balance(&user_b), u64::MAX);
 }
 
 #[test]
@@ -122,17 +177,4 @@ fn test_uninitialized_access_returns_defaults() {
     assert_eq!(client.metadata(), (symbol_short!("Trivela"), symbol_short!("TVL")));
     assert_eq!(client.balance(&user), 0);
     assert_eq!(client.total_claimed(), 0);
-    client.credit(&admin, &user_a, &10);
-    client.credit(&admin, &user_b, &u64::MAX);
-
-    let recipients = soroban_sdk::vec![
-        &env,
-        (user_a.clone(), 15u64),
-        (user_b.clone(), 1u64),
-    ];
-
-    let result = client.try_batch_credit(&admin, &recipients);
-    assert!(result.is_err());
-    assert_eq!(client.balance(&user_a), 10);
-    assert_eq!(client.balance(&user_b), u64::MAX);
 }

--- a/contracts/rewards/test_snapshots/test/test_batch_credit.1.json
+++ b/contracts/rewards/test_snapshots/test/test_batch_credit.1.json
@@ -1,0 +1,196 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "batch_credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        },
+                        {
+                          "u64": "50"
+                        }
+                      ]
+                    },
+                    {
+                      "vec": [
+                        {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        },
+                        {
+                          "u64": "75"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "50"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "75"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_batch_credit_is_atomic_on_overflow.1.json
+++ b/contracts/rewards/test_snapshots/test/test_batch_credit_is_atomic_on_overflow.1.json
@@ -1,0 +1,224 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "10"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "18446744073709551615"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "10"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "18446744073709551615"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_claim_emits_event_and_updates_total_claimed.1.json
+++ b/contracts/rewards/test_snapshots/test/test_claim_emits_event_and_updates_total_claimed.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "100"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "claim",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "40"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "40"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "60"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_claim_more_than_balance_errors.1.json
+++ b/contracts/rewards/test_snapshots/test/test_claim_more_than_balance_errors.1.json
@@ -1,0 +1,103 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_credit_and_balance_emits_event.1.json
+++ b/contracts/rewards/test_snapshots/test/test_credit_and_balance_emits_event.1.json
@@ -1,0 +1,162 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "100"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_credit_overflow_errors.1.json
+++ b/contracts/rewards/test_snapshots/test/test_credit_overflow_errors.1.json
@@ -1,0 +1,163 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "18446744073709551615"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "18446744073709551615"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_uninitialized_access_returns_defaults.1.json
+++ b/contracts/rewards/test_snapshots/test/test_uninitialized_access_returns_defaults.1.json
@@ -1,0 +1,63 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Closes #1
Closes #22
Closes #24
Closes #28

## Changes
- emit Soroban events from the rewards contract for `credit` and `claim`
- document rewards contract event names and payloads
- add in-memory API rate limiting for `/api/*` and `/api/v1/*`
- add Soroban RPC dependency checks via `GET /health/rpc` and include RPC status in `GET /health`
- add backend tests covering delete, rate limiting, and RPC health behavior
- keep `DELETE /api/campaigns/:id` behavior covered, including `404` for missing campaigns

## Testing
- `npm test`
- `npm run build --workspace=frontend`
