### PR TITLE
feat: add backend config route, payload validation, and Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY backend/package*.json ./
+RUN npm ci --omit=dev
+
+COPY backend/src ./src
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+EXPOSE 3001
+
+CMD ["node", "src/server.js"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,9 +13,12 @@ npm run dev
 ## Environment
 
 - `PORT`: Server port (default `3001`)
-- `CORS_ORIGIN`: Allowed origin for CORS
+- `CORS_ALLOWED_ORIGINS`: Comma-separated allowed origins for CORS (example: `https://app.example.com,https://admin.example.com`)
+- `CORS_ORIGIN`: Legacy single-origin CORS setting (fallback when `CORS_ALLOWED_ORIGINS` is not set)
 - `STELLAR_NETWORK`: `testnet` or `mainnet`
 - `SOROBAN_RPC_URL`: Soroban RPC URL exposed in API metadata
+- `REWARDS_CONTRACT_ID`: Optional rewards contract ID exposed by `/api/v1/config`
+- `CAMPAIGN_CONTRACT_ID`: Optional campaign contract ID exposed by `/api/v1/config`
 - `TRIVELA_API_KEY`: Optional API key for write endpoints (see below)
 - `RATE_LIMIT_WINDOW_MS`: Rate limit window for `/api/*` and `/api/v1/*` routes (default `60000`)
 - `RATE_LIMIT_MAX_REQUESTS`: Max requests per API key or IP in each window (default `60`)
@@ -51,6 +54,7 @@ Preferred routes:
 - `GET /health`
 - `GET /health/rpc`
 - `GET /api/v1`
+- `GET /api/v1/config`
 - `GET /api/v1/campaigns`
 - `GET /api/v1/campaigns/:id`
 - `DELETE /api/v1/campaigns/:id`
@@ -100,8 +104,40 @@ Response shape:
 Backward-compatible legacy routes remain available under `/api/*` for now:
 
 - `GET /api`
+- `GET /api/config`
 - `GET /api/campaigns`
 - `GET /api/campaigns/:id`
 - `DELETE /api/campaigns/:id`
 
 Migration note: new integrations should use `/api/v1/*`. Existing clients on `/api/*` continue to work.
+
+## Campaign payload validation
+
+`POST /api/v1/campaigns` and `PUT /api/v1/campaigns/:id` validate request bodies and return `400` with a list of errors when invalid.
+
+Validation rules:
+
+- `name` must be a non-empty string (`POST` required, `PUT` optional if omitted)
+- `rewardPerAction` must be a non-negative number (`POST` required, `PUT` optional if omitted)
+- `description` must be a string when provided
+- `active` must be a boolean when provided
+
+## Docker
+
+Build image from repo root:
+
+```bash
+docker build -f backend/Dockerfile -t trivela-backend .
+```
+
+Run container (example):
+
+```bash
+docker run --rm -p 3001:3001 \
+  -e PORT=3001 \
+  -e STELLAR_NETWORK=testnet \
+  -e SOROBAN_RPC_URL=https://soroban-testnet.stellar.org \
+  -e CORS_ALLOWED_ORIGINS=http://localhost:5173 \
+  -e TRIVELA_API_KEY=dev-secret \
+  trivela-backend
+```

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -41,6 +41,78 @@ function cloneCampaigns(campaigns) {
   return campaigns.map((campaign) => ({ ...campaign }));
 }
 
+function parseAllowedOrigins(value) {
+  if (!value) {
+    return [];
+  }
+
+  return String(value)
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function createCorsOptions(allowedOrigins) {
+  if (allowedOrigins.includes('*')) {
+    return { origin: true };
+  }
+
+  return {
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Not allowed by CORS'));
+    },
+  };
+}
+
+function readOptionalConfigValue(options, envKey) {
+  const fromOptions = options[envKey];
+  if (typeof fromOptions === 'string' && fromOptions.trim().length > 0) {
+    return fromOptions;
+  }
+
+  const fromEnv = process.env[envKey];
+  return typeof fromEnv === 'string' ? fromEnv : '';
+}
+
+function validateCampaignPayload(payload, { partial = false } = {}) {
+  const errors = [];
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return ['request body must be a JSON object'];
+  }
+
+  if (!partial || Object.hasOwn(payload, 'name')) {
+    if (typeof payload.name !== 'string' || payload.name.trim().length === 0) {
+      errors.push('name is required and must be a non-empty string');
+    }
+  }
+
+  if (!partial || Object.hasOwn(payload, 'rewardPerAction')) {
+    if (
+      typeof payload.rewardPerAction !== 'number' ||
+      !Number.isFinite(payload.rewardPerAction) ||
+      payload.rewardPerAction < 0
+    ) {
+      errors.push('rewardPerAction is required and must be a non-negative number');
+    }
+  }
+
+  if (Object.hasOwn(payload, 'description') && typeof payload.description !== 'string') {
+    errors.push('description must be a string when provided');
+  }
+
+  if (Object.hasOwn(payload, 'active') && typeof payload.active !== 'boolean') {
+    errors.push('active must be a boolean when provided');
+  }
+
+  return errors;
+}
+
 function nextCampaignId(campaigns) {
   const maxId = campaigns.reduce((currentMax, campaign) => {
     const parsed = Number.parseInt(campaign.id, 10);
@@ -52,11 +124,15 @@ function nextCampaignId(campaigns) {
 
 export function createApp(options = {}) {
   const apiKey = options.apiKey ?? process.env.TRIVELA_API_KEY ?? '';
-  const corsOrigin = options.corsOrigin ?? process.env.CORS_ORIGIN ?? '*';
+  const corsAllowedOrigins =
+    options.corsAllowedOrigins ?? process.env.CORS_ALLOWED_ORIGINS ?? process.env.CORS_ORIGIN;
   const stellarNetwork = options.stellarNetwork ?? process.env.STELLAR_NETWORK ?? 'testnet';
   const sorobanRpcUrl = options.sorobanRpcUrl ?? process.env.SOROBAN_RPC_URL ?? DEFAULT_RPC_URL;
+  const rewardsContractId = readOptionalConfigValue(options, 'REWARDS_CONTRACT_ID');
+  const campaignContractId = readOptionalConfigValue(options, 'CAMPAIGN_CONTRACT_ID');
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   const campaigns = cloneCampaigns(options.campaigns ?? defaultCampaigns());
+  const allowedOrigins = parseAllowedOrigins(corsAllowedOrigins);
   const rateLimitWindowMs = normalizePositiveInteger(
     options.rateLimit?.windowMs ?? process.env.RATE_LIMIT_WINDOW_MS,
     DEFAULT_RATE_LIMIT_WINDOW_MS,
@@ -74,7 +150,7 @@ export function createApp(options = {}) {
     timeProvider: options.rateLimit?.timeProvider,
   });
 
-  app.use(cors({ origin: corsOrigin }));
+  app.use(cors(createCorsOptions(allowedOrigins)));
   app.use(logger);
   app.use(express.json());
 
@@ -122,6 +198,7 @@ export function createApp(options = {}) {
         createCampaign: `POST ${API_V1_PREFIX}/campaigns`,
         updateCampaign: `PUT ${API_V1_PREFIX}/campaigns/:id`,
         deleteCampaign: `DELETE ${API_V1_PREFIX}/campaigns/:id`,
+        config: `GET ${API_V1_PREFIX}/config`,
       },
       compatibility: {
         legacyPrefix: LEGACY_API_PREFIX,
@@ -133,10 +210,28 @@ export function createApp(options = {}) {
         network: stellarNetwork,
         rpcUrl: sorobanRpcUrl,
       },
+      config: {
+        rewardsContractId: rewardsContractId || null,
+        campaignContractId: campaignContractId || null,
+      },
+      cors: {
+        allowedOrigins,
+      },
       rateLimit: {
         keying: 'per API key when present, otherwise per IP address',
         windowMs: rateLimitWindowMs,
         maxRequests: rateLimitMaxRequests,
+      },
+    });
+  }
+
+  function getPublicConfig(_req, res) {
+    res.json({
+      sorobanRpcUrl,
+      stellarNetwork,
+      contractIds: {
+        rewards: rewardsContractId || null,
+        campaign: campaignContractId || null,
       },
     });
   }
@@ -155,10 +250,15 @@ export function createApp(options = {}) {
   }
 
   function createCampaign(req, res) {
-    const { name, description, rewardPerAction } = req.body;
-    if (!name) {
-      return res.status(400).json({ error: 'name is required' });
+    const errors = validateCampaignPayload(req.body, { partial: false });
+    if (errors.length > 0) {
+      return res.status(400).json({
+        error: 'Invalid campaign payload',
+        details: errors,
+      });
     }
+
+    const { name, description, rewardPerAction } = req.body;
 
     const campaign = {
       id: nextCampaignId(campaigns),
@@ -179,6 +279,14 @@ export function createApp(options = {}) {
       return res.status(404).json({ error: 'Campaign not found' });
     }
 
+    const errors = validateCampaignPayload(req.body, { partial: true });
+    if (errors.length > 0) {
+      return res.status(400).json({
+        error: 'Invalid campaign payload',
+        details: errors,
+      });
+    }
+
     Object.assign(campaign, req.body, { id: campaign.id });
     return res.json(campaign);
   }
@@ -195,6 +303,7 @@ export function createApp(options = {}) {
 
   function registerApiRoutes(prefix) {
     app.get(prefix, rateLimiter, apiInfo);
+    app.get(`${prefix}/config`, rateLimiter, getPublicConfig);
     app.get(`${prefix}/campaigns`, rateLimiter, listCampaigns);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
     app.post(`${prefix}/campaigns`, rateLimiter, requireApiKey, createCampaign);


### PR DESCRIPTION
## Summary
- add `GET /api/v1/config` (and legacy `/api/config`) to expose public backend configuration: Soroban RPC URL, Stellar network, and optional contract IDs
- add stricter campaign payload validation for `POST` and `PUT` endpoints with clear 400 error details
- add env-driven CORS allowlist support (`CORS_ALLOWED_ORIGINS`) and backend Dockerfile with run instructions in README

Closes #25
Closes #27
Closes #29
Closes #31