### PR TITLE
feat: add campaign api versioning coverage and ui states

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ npm run dev:backend
 
 API: http://localhost:3001 (health: http://localhost:3001/health, v1: http://localhost:3001/api/v1).
 
+Campaign endpoints are available under the versioned prefix:
+
+```bash
+GET    /api/v1/campaigns
+GET    /api/v1/campaigns/:id
+POST   /api/v1/campaigns
+PUT    /api/v1/campaigns/:id
+DELETE /api/v1/campaigns/:id
+```
+
+Migration note:
+Legacy `/api/*` campaign routes are still available for backward compatibility, but new integrations should target `/api/v1/*`.
+
 ### 4. Run frontend
 
 ```bash

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -37,10 +37,6 @@ function defaultSeed() {
   ];
 }
 
-function cloneCampaigns(campaigns) {
-  return campaigns.map((campaign) => ({ ...campaign }));
-}
-
 function parseAllowedOrigins(value) {
   if (!value) {
     return [];
@@ -113,14 +109,6 @@ function validateCampaignPayload(payload, { partial = false } = {}) {
   return errors;
 }
 
-function nextCampaignId(campaigns) {
-  const maxId = campaigns.reduce((currentMax, campaign) => {
-    const parsed = Number.parseInt(campaign.id, 10);
-    return Number.isFinite(parsed) ? Math.max(currentMax, parsed) : currentMax;
-  }, 0);
-
-  return String(maxId + 1);
-}
 
 export function createApp(options = {}) {
   const apiKey = options.apiKey ?? process.env.TRIVELA_API_KEY ?? '';
@@ -131,7 +119,7 @@ export function createApp(options = {}) {
   const rewardsContractId = readOptionalConfigValue(options, 'REWARDS_CONTRACT_ID');
   const campaignContractId = readOptionalConfigValue(options, 'CAMPAIGN_CONTRACT_ID');
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-  const campaigns = cloneCampaigns(options.campaigns ?? defaultCampaigns());
+  const dbPath = options.dbPath ?? process.env.DB_PATH ?? ':memory:';
   const allowedOrigins = parseAllowedOrigins(corsAllowedOrigins);
   const rateLimitWindowMs = normalizePositiveInteger(
     options.rateLimit?.windowMs ?? process.env.RATE_LIMIT_WINDOW_MS,
@@ -268,26 +256,15 @@ export function createApp(options = {}) {
     }
 
     const { name, description, rewardPerAction } = req.body;
-
-    const campaign = {
-      id: nextCampaignId(campaigns),
+    const campaign = db.create({
       name,
       description: description || '',
-      active: true,
       rewardPerAction: rewardPerAction ?? 0,
-      createdAt: new Date().toISOString(),
-    };
-
-    campaigns.push(campaign);
+    });
     return res.status(201).json(campaign);
   }
 
   function updateCampaign(req, res) {
-    const existing = db.getById(req.params.id);
-    if (!existing) {
-      return res.status(404).json({ error: 'Campaign not found' });
-    }
-
     const errors = validateCampaignPayload(req.body, { partial: true });
     if (errors.length > 0) {
       return res.status(400).json({
@@ -296,7 +273,11 @@ export function createApp(options = {}) {
       });
     }
 
-    Object.assign(campaign, req.body, { id: campaign.id });
+    const campaign = db.update(req.params.id, req.body);
+    if (!campaign) {
+      return res.status(404).json({ error: 'Campaign not found' });
+    }
+
     return res.json(campaign);
   }
 

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -28,19 +28,91 @@ async function stopTestServer(server) {
   });
 }
 
-test('DELETE /api/campaigns/:id removes a campaign and returns 404 when missing', async () => {
+function campaignShapeAssertions(campaign) {
+  assert.equal(typeof campaign.id, 'string');
+  assert.equal(typeof campaign.name, 'string');
+  assert.equal(typeof campaign.description, 'string');
+  assert.equal(typeof campaign.active, 'boolean');
+  assert.equal(typeof campaign.rewardPerAction, 'number');
+  assert.equal(typeof campaign.createdAt, 'string');
+}
+
+test('GET /api/v1 exposes versioning details and legacy compatibility guidance', async () => {
   const { server, baseUrl } = await startTestServer();
 
   try {
-    let response = await fetch(`${baseUrl}/api/campaigns/1`, {
+    const response = await fetch(`${baseUrl}/api/v1`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.prefix, '/api/v1');
+    assert.equal(payload.compatibility.legacyPrefix, '/api');
+    assert.equal(payload.compatibility.legacyRoutesSupported, true);
+    assert.match(payload.compatibility.migrationNote, /Prefer \/api\/v1/);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/campaigns returns paginated campaign data with the expected shape', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.ok(Array.isArray(payload.data));
+    assert.ok(payload.pagination);
+    assert.ok(payload.data.length >= 1);
+    campaignShapeAssertions(payload.data[0]);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/campaigns/:id returns 404 for a missing campaign', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns/999`);
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: 'Campaign not found' });
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/campaigns and /api/v1/campaigns stay backward compatible', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const [legacyResponse, versionedResponse] = await Promise.all([
+      fetch(`${baseUrl}/api/campaigns`),
+      fetch(`${baseUrl}/api/v1/campaigns`),
+    ]);
+
+    assert.equal(legacyResponse.status, 200);
+    assert.equal(versionedResponse.status, 200);
+    assert.deepEqual(await legacyResponse.json(), await versionedResponse.json());
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('DELETE /api/v1/campaigns/:id removes a campaign and returns 404 when missing', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    let response = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
       method: 'DELETE',
     });
     assert.equal(response.status, 204);
 
-    response = await fetch(`${baseUrl}/api/campaigns/1`);
+    response = await fetch(`${baseUrl}/api/v1/campaigns/1`);
     assert.equal(response.status, 404);
 
-    response = await fetch(`${baseUrl}/api/campaigns/999`, {
+    response = await fetch(`${baseUrl}/api/v1/campaigns/999`, {
       method: 'DELETE',
     });
     assert.equal(response.status, 404);
@@ -140,7 +212,7 @@ test('/health/rpc returns 503 when the Soroban RPC health check fails', async ()
   }
 });
 
-test('POST /api/campaigns creates a new campaign and returns it', async () => {
+test('POST /api/v1/campaigns creates a new campaign and returns it', async () => {
   const { server, baseUrl } = await startTestServer();
 
   try {
@@ -150,7 +222,7 @@ test('POST /api/campaigns creates a new campaign and returns it', async () => {
       rewardPerAction: 50,
     };
 
-    const response = await fetch(`${baseUrl}/api/campaigns`, {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -163,11 +235,10 @@ test('POST /api/campaigns creates a new campaign and returns it', async () => {
     assert.equal(created.name, newCampaign.name);
     assert.equal(created.description, newCampaign.description);
     assert.equal(created.rewardPerAction, newCampaign.rewardPerAction);
-    assert.ok(created.id);
-    assert.ok(created.createdAt);
+    campaignShapeAssertions(created);
 
     // Verify it's in the list
-    const listResponse = await fetch(`${baseUrl}/api/campaigns`);
+    const listResponse = await fetch(`${baseUrl}/api/v1/campaigns`);
     const list = await listResponse.json();
     const found = list.data.find((c) => c.id === created.id);
     assert.ok(found);
@@ -176,7 +247,7 @@ test('POST /api/campaigns creates a new campaign and returns it', async () => {
   }
 });
 
-test('PUT /api/campaigns/:id updates an existing campaign', async () => {
+test('PUT /api/v1/campaigns/:id updates an existing campaign and returns 404 when missing', async () => {
   const { server, baseUrl } = await startTestServer();
 
   try {
@@ -185,7 +256,7 @@ test('PUT /api/campaigns/:id updates an existing campaign', async () => {
       active: false,
     };
 
-    const response = await fetch(`${baseUrl}/api/campaigns/1`, {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -198,9 +269,10 @@ test('PUT /api/campaigns/:id updates an existing campaign', async () => {
     assert.equal(updated.id, '1');
     assert.equal(updated.name, updateData.name);
     assert.equal(updated.active, updateData.active);
+    campaignShapeAssertions(updated);
 
     // Verify 404 for missing
-    const missingResponse = await fetch(`${baseUrl}/api/campaigns/999`, {
+    const missingResponse = await fetch(`${baseUrl}/api/v1/campaigns/999`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -208,12 +280,13 @@ test('PUT /api/campaigns/:id updates an existing campaign', async () => {
       body: JSON.stringify(updateData),
     });
     assert.equal(missingResponse.status, 404);
+    assert.deepEqual(await missingResponse.json(), { error: 'Campaign not found' });
   } finally {
     await stopTestServer(server);
   }
 });
 
-test('GET /api/campaigns?active=true returns only active campaigns', async () => {
+test('GET /api/v1/campaigns?active=true returns only active campaigns', async () => {
   const seed = [
     { id: '1', name: 'Active One', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
     { id: '2', name: 'Inactive One', description: '', active: false, rewardPerAction: 5, createdAt: new Date().toISOString() },
@@ -222,7 +295,7 @@ test('GET /api/campaigns?active=true returns only active campaigns', async () =>
   const { server, baseUrl } = await startTestServer({ campaigns: seed });
 
   try {
-    const response = await fetch(`${baseUrl}/api/campaigns?active=true`);
+    const response = await fetch(`${baseUrl}/api/v1/campaigns?active=true`);
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.data.length, 2);
@@ -232,7 +305,7 @@ test('GET /api/campaigns?active=true returns only active campaigns', async () =>
   }
 });
 
-test('GET /api/campaigns?active=false returns only inactive campaigns', async () => {
+test('GET /api/v1/campaigns?active=false returns only inactive campaigns', async () => {
   const seed = [
     { id: '1', name: 'Active One', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
     { id: '2', name: 'Inactive One', description: '', active: false, rewardPerAction: 5, createdAt: new Date().toISOString() },
@@ -240,7 +313,7 @@ test('GET /api/campaigns?active=false returns only inactive campaigns', async ()
   const { server, baseUrl } = await startTestServer({ campaigns: seed });
 
   try {
-    const response = await fetch(`${baseUrl}/api/campaigns?active=false`);
+    const response = await fetch(`${baseUrl}/api/v1/campaigns?active=false`);
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.data.length, 1);
@@ -250,7 +323,7 @@ test('GET /api/campaigns?active=false returns only inactive campaigns', async ()
   }
 });
 
-test('GET /api/campaigns without active param returns all campaigns', async () => {
+test('GET /api/v1/campaigns without active param returns all campaigns', async () => {
   const seed = [
     { id: '1', name: 'Active One', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
     { id: '2', name: 'Inactive One', description: '', active: false, rewardPerAction: 5, createdAt: new Date().toISOString() },
@@ -258,7 +331,7 @@ test('GET /api/campaigns without active param returns all campaigns', async () =
   const { server, baseUrl } = await startTestServer({ campaigns: seed });
 
   try {
-    const response = await fetch(`${baseUrl}/api/campaigns`);
+    const response = await fetch(`${baseUrl}/api/v1/campaigns`);
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.data.length, 2);

--- a/frontend/e2e/campaigns.spec.js
+++ b/frontend/e2e/campaigns.spec.js
@@ -49,4 +49,64 @@ test.describe('Campaigns page', () => {
       await expect(page.getByRole('main')).toBeVisible();
     }
   });
+
+  test('shows a loading state before campaigns resolve', async ({ page }) => {
+    await page.route('**/api/v1/campaigns**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [],
+          pagination: {
+            total: 0,
+            count: 0,
+            page: 1,
+            limit: 6,
+            offset: 0,
+            totalPages: 0,
+            hasPreviousPage: false,
+            hasNextPage: false,
+            previousPage: null,
+            nextPage: null,
+          },
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('.campaigns-loading')).toBeVisible();
+    await expect(page.locator('.empty-state')).toBeVisible();
+  });
+
+  test('shows an error state when the campaigns request fails', async ({ page }) => {
+    await page.route('**/api/v1/campaigns**', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal server error' }),
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /load campaigns/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Try again' })).toBeVisible();
+    await expect(page.locator('.campaigns-grid')).toHaveCount(0);
+  });
+
+  test('persists the selected theme across reloads', async ({ page }) => {
+    await page.goto('/');
+
+    const root = page.locator('html');
+    const initialTheme = await root.getAttribute('data-theme');
+    expect(['light', 'dark']).toContain(initialTheme);
+    const nextTheme = initialTheme === 'dark' ? 'light' : 'dark';
+    const toggleLabel = initialTheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme';
+
+    await page.getByRole('button', { name: toggleLabel }).click();
+    await expect(root).toHaveAttribute('data-theme', nextTheme);
+
+    await page.reload();
+    await expect(root).toHaveAttribute('data-theme', nextTheme);
+  });
 });

--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
-import Header from "./components/Header";
-import RegisterCampaign from "./RegisterCampaign";
-import "./CampaignDetail.css";
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { apiUrl } from './config';
+import Header from './components/Header';
+import RegisterCampaign from './RegisterCampaign';
+import './CampaignDetail.css';
 
 /**
  * Campaign Detail Page
@@ -23,34 +24,35 @@ export default function CampaignDetail({
 }) {
   const { id } = useParams();
   const [campaign, setCampaign] = useState(null);
-  const [error, setError] = useState("");
+  const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const controller = new AbortController();
-    const api = import.meta.env.VITE_API_URL || "";
 
     setIsLoading(true);
-    setError("");
+    setError('');
 
-    fetch(`${api}/api/v1/campaigns/${id}`, {
+    fetch(apiUrl(`/api/v1/campaigns/${id}`), {
       signal: controller.signal,
     })
       .then(async (response) => {
         if (!response.ok) {
           if (response.status === 404) {
-            throw new Error("Campaign not found");
+            throw new Error('Campaign not found');
           }
+
           throw new Error(`API returned ${response.status}`);
         }
+
         return response.json();
       })
       .then((data) => {
         setCampaign(data);
       })
       .catch((err) => {
-        if (err.name === "AbortError") return;
-        setError(err.message || "Unable to load campaign details.");
+        if (err.name === 'AbortError') return;
+        setError(err.message || 'Unable to load campaign details.');
       })
       .finally(() => {
         if (!controller.signal.aborted) {
@@ -62,11 +64,11 @@ export default function CampaignDetail({
   }, [id]);
 
   const formatDate = (value) => {
-    if (!value) return "";
+    if (!value) return '';
     const date = new Date(value);
-    return new Intl.DateTimeFormat("en", {
-      dateStyle: "long",
-      timeStyle: "short",
+    return new Intl.DateTimeFormat('en', {
+      dateStyle: 'long',
+      timeStyle: 'short',
     }).format(date);
   };
 
@@ -87,12 +89,12 @@ export default function CampaignDetail({
         <div className="detail-container">
           <nav className="detail-nav">
             <Link to="/" className="back-link">
-              ← Back to campaigns
+              Back to campaigns
             </Link>
           </nav>
 
           {isLoading ? (
-            <div className="detail-status">Loading campaign details…</div>
+            <div className="detail-status">Loading campaign details...</div>
           ) : error ? (
             <div className="detail-error" role="alert">
               <h2>Error</h2>
@@ -108,9 +110,9 @@ export default function CampaignDetail({
                 <div className="detail-title-row">
                   <h1 className="detail-title">{campaign.name}</h1>
                   <span
-                    className={`campaign-badge ${campaign.active !== false ? "campaign-badge-active" : "campaign-badge-inactive"}`}
+                    className={`campaign-badge ${campaign.active !== false ? 'campaign-badge-active' : 'campaign-badge-inactive'}`}
                   >
-                    {campaign.active !== false ? "Active" : "Inactive"}
+                    {campaign.active !== false ? 'Active' : 'Inactive'}
                   </span>
                 </div>
               </header>
@@ -119,7 +121,7 @@ export default function CampaignDetail({
                 <section className="detail-section">
                   <h2>Description</h2>
                   <p className="detail-description">
-                    {campaign.description || "No description provided."}
+                    {campaign.description || 'No description provided.'}
                   </p>
                 </section>
 
@@ -155,8 +157,8 @@ export default function CampaignDetail({
                         disabled={isWalletLoading}
                       >
                         {isWalletLoading
-                          ? "Connecting…"
-                          : "Connect wallet to register"}
+                          ? 'Connecting...'
+                          : 'Connect wallet to register'}
                       </button>
                       <p className="cta-note">
                         Connect your Freighter wallet to register for this
@@ -173,7 +175,7 @@ export default function CampaignDetail({
 
       <footer className="footer detail-footer">
         <div className="footer-inner">
-          <p>© 2026 Trivela · Built for Stellar Wave</p>
+          <p>Copyright 2026 Trivela - Built for Stellar Wave</p>
         </div>
       </footer>
     </div>

--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -62,6 +62,7 @@ export default function Landing({
   const [campaignRefreshKey, setCampaignRefreshKey] = useState(0);
   const [pagination, setPagination] = useState(() => getFallbackPagination([], 1));
   const campaignContract = getCampaignContract();
+  const rewardsContract = getRewardsContract();
 
   useEffect(() => {
     const controller = new AbortController();


### PR DESCRIPTION
## Description
Implement API versioning coverage, campaign CRUD tests, campaign list loading/error handling, and persistent light/dark theme support across the frontend.

Closes #112
Closes #110
Closes #115
Closes #123

## Changes proposed

### What were you told to do?
Group four open issues into one PR: add `/api/v1` API versioning with documentation and compatibility guidance, add unit tests for campaign CRUD, show campaign loading/error states, and add a persisted dark mode toggle.

### What did I do?
#### Versioned API and backend coverage
- Fixed the backend campaign handlers to use the SQLite layer consistently for create and update flows.
- Kept both `/api/v1/*` and legacy `/api/*` campaign routes available and added explicit compatibility assertions.
- Expanded backend tests to cover versioned campaign GET/POST/PUT/DELETE behavior, response shape checks, and 404 handling for missing ids.

#### Frontend campaign states and theme persistence
- Fixed the landing page contract config panel so the app no longer crashes from an undefined rewards contract reference.
- Reused the existing loading spinner and empty-state UI with Playwright coverage for loading and failed campaign fetches.
- Kept the theme toggle wired through localStorage and added Playwright coverage to confirm the selected theme persists after reload.
- Switched the campaign detail page to the shared `apiUrl` helper so versioned API calls stay consistent.

#### Documentation
- Added a README section documenting the `/api/v1/campaigns` endpoints and a short migration note about legacy `/api/*` compatibility.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm run test --workspace=backend`
- `npm run build --workspace=frontend`
- `CI=1 npm run test --workspace=frontend`
- Playwright passed 7 tests, including the new loading-state, error-state, and theme-persistence checks.