### PR TITLE
feat: replay-safe admin ops, multipliers, participant-count view/tests, CI traces

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,3 +48,13 @@ jobs:
       - name: Test frontend
         if: steps.scripts.outputs.has_test == 'true'
         run: npm run test --workspace=frontend
+
+      - name: Upload Playwright artifacts on failure
+        if: failure() && steps.scripts.outputs.has_test == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -39,6 +39,7 @@ pub enum Error {
     CapacityReached = 102,
     CampaignInactive = 103,
     NotInAllowlist = 104,
+    InvalidAdminNonce = 105,
 }
 
 contractmeta!(key = "Description", val = "Trivela campaign configuration");
@@ -51,6 +52,7 @@ const END_TIME: Symbol = symbol_short!("end");
 const MAX_CAP: Symbol = symbol_short!("maxcap");
 const PARTICIPANT_COUNT: Symbol = symbol_short!("count");
 const MERKLE_ROOT: Symbol = symbol_short!("mkroot");
+const ADMIN_NONCE: Symbol = symbol_short!("anonce");
 
 #[contract]
 pub struct CampaignContract;
@@ -81,6 +83,24 @@ fn verify_merkle_proof(
     &computed == root
 }
 
+fn require_admin_with_nonce(
+    env: &Env,
+    admin: &Address,
+    nonce: u64,
+) -> Result<(), Error> {
+    admin.require_auth();
+    let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
+    if &stored != admin {
+        return Err(Error::Unauthorized);
+    }
+    let current: u64 = env.storage().instance().get(&ADMIN_NONCE).unwrap_or(0);
+    if nonce != current {
+        return Err(Error::InvalidAdminNonce);
+    }
+    env.storage().instance().set(&ADMIN_NONCE, &(current + 1));
+    Ok(())
+}
+
 #[contractimpl]
 impl CampaignContract {
     /// Initialize campaign contract with an admin.
@@ -90,17 +110,14 @@ impl CampaignContract {
         env.storage().instance().set(&START_TIME, &0u64);
         env.storage().instance().set(&END_TIME, &u64::MAX);
         env.storage().instance().set(&PARTICIPANT_COUNT, &0u64);
+        env.storage().instance().set(&ADMIN_NONCE, &0u64);
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
     }
 
     /// Set registration time window (admin only).
-    pub fn set_window(env: Env, admin: Address, start: u64, end: u64) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
-        if stored != admin {
-            return Err(Error::Unauthorized);
-        }
+    pub fn set_window(env: Env, admin: Address, nonce: u64, start: u64, end: u64) -> Result<(), Error> {
+        require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&START_TIME, &start);
         env.storage().instance().set(&END_TIME, &end);
         env.storage().instance().extend_ttl(50, 100);
@@ -108,24 +125,16 @@ impl CampaignContract {
     }
 
     /// Set campaign active flag (admin only).
-    pub fn set_active(env: Env, admin: Address, active: bool) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
-        if stored != admin {
-            return Err(Error::Unauthorized);
-        }
+    pub fn set_active(env: Env, admin: Address, nonce: u64, active: bool) -> Result<(), Error> {
+        require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&CAMPAIGN_ACTIVE, &active);
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
     }
 
     /// Set maximum participant cap (admin only). Set to 0 for unlimited.
-    pub fn set_max_cap(env: Env, admin: Address, max_cap: u64) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
-        if stored != admin {
-            return Err(Error::Unauthorized);
-        }
+    pub fn set_max_cap(env: Env, admin: Address, nonce: u64, max_cap: u64) -> Result<(), Error> {
+        require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&MAX_CAP, &max_cap);
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
@@ -136,12 +145,8 @@ impl CampaignContract {
     /// Once set, every `register` call must supply a valid `(leaf, proof)`.
     /// Remove the root by calling this again with a root of all zeros to
     /// revert to open registration.
-    pub fn set_merkle_root(env: Env, admin: Address, root: BytesN<32>) -> Result<(), Error> {
-        admin.require_auth();
-        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
-        if stored != admin {
-            return Err(Error::Unauthorized);
-        }
+    pub fn set_merkle_root(env: Env, admin: Address, nonce: u64, root: BytesN<32>) -> Result<(), Error> {
+        require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&MERKLE_ROOT, &root);
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
@@ -263,6 +268,11 @@ impl CampaignContract {
     /// Get maximum participant cap (0 means unlimited).
     pub fn get_max_cap(env: Env) -> u64 {
         env.storage().instance().get(&MAX_CAP).unwrap_or(0)
+    }
+
+    /// Get the next required admin nonce for sensitive operations.
+    pub fn admin_nonce(env: Env) -> u64 {
+        env.storage().instance().get(&ADMIN_NONCE).unwrap_or(0)
     }
 }
 

--- a/contracts/campaign/src/test.rs
+++ b/contracts/campaign/src/test.rs
@@ -80,7 +80,7 @@ fn test_time_window_validation() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    client.set_window(&admin, &100, &200);
+    client.set_window(&admin, &0, &100, &200);
 
     let (leaf, proof) = no_proof_args(&env);
 
@@ -119,7 +119,7 @@ fn test_set_active_only_by_admin() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    let result = client.try_set_active(&other, &false);
+    let result = client.try_set_active(&other, &0, &false);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
@@ -131,7 +131,7 @@ fn test_register_when_inactive() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    client.set_active(&admin, &false);
+    client.set_active(&admin, &0, &false);
 
     let (leaf, proof) = no_proof_args(&env);
     let result = client.try_register(&participant, &leaf, &proof);
@@ -154,7 +154,7 @@ fn test_capacity_reached() {
     client.initialize(&admin);
 
     env.mock_all_auths();
-    client.set_max_cap(&admin, &1);
+    client.set_max_cap(&admin, &0, &1);
 
     let p1 = Address::generate(&env);
     let p2 = Address::generate(&env);
@@ -183,7 +183,7 @@ fn test_set_merkle_root_only_by_admin() {
 
     env.mock_all_auths();
     let dummy: BytesN<32> = BytesN::from_array(&env, &[1u8; 32]);
-    let result = client.try_set_merkle_root(&other, &dummy);
+    let result = client.try_set_merkle_root(&other, &0, &dummy);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
@@ -201,7 +201,7 @@ fn test_register_with_valid_merkle_proof() {
     let (root, proof1, proof2) = build_two_leaf_tree(&env, leaf1.clone(), leaf2.clone());
 
     env.mock_all_auths();
-    client.set_merkle_root(&admin, &root);
+    client.set_merkle_root(&admin, &0, &root);
     assert_eq!(client.get_merkle_root(), Some(root));
 
     // Both allowlisted participants can register with their correct leaf + proof.
@@ -224,7 +224,7 @@ fn test_register_rejected_with_invalid_proof() {
     let (root, _proof1, _proof2) = build_two_leaf_tree(&env, leaf1.clone(), leaf2.clone());
 
     env.mock_all_auths();
-    client.set_merkle_root(&admin, &root);
+    client.set_merkle_root(&admin, &0, &root);
 
     // p2 supplies leaf2 but with a totally wrong proof sibling.
     let wrong_sibling: BytesN<32> = BytesN::from_array(&env, &[0xFFu8; 32]);
@@ -245,7 +245,7 @@ fn test_register_rejected_with_leaf_not_in_tree() {
     let (root, _proof1, proof2) = build_two_leaf_tree(&env, leaf1.clone(), leaf2.clone());
 
     env.mock_all_auths();
-    client.set_merkle_root(&admin, &root);
+    client.set_merkle_root(&admin, &0, &root);
 
     // p3 supplies a leaf that is not in the tree at all.
     let unknown_leaf: BytesN<32> = BytesN::from_array(&env, &[0xCCu8; 32]);
@@ -265,7 +265,7 @@ fn test_register_rejected_with_empty_proof_when_root_set() {
     let (root, _proof1, _proof2) = build_two_leaf_tree(&env, leaf1.clone(), leaf2.clone());
 
     env.mock_all_auths();
-    client.set_merkle_root(&admin, &root);
+    client.set_merkle_root(&admin, &0, &root);
 
     // Empty proof should fail when root is set – a leaf alone does not equal the root.
     let result = client.try_register(&p1, &leaf1, &Vec::new(&env));
@@ -283,4 +283,38 @@ fn test_open_registration_when_no_root() {
     env.mock_all_auths();
     let (leaf, proof) = no_proof_args(&env);
     assert!(client.register(&participant, &leaf, &proof));
+}
+
+#[test]
+fn test_participant_count_increments_on_new_register_only() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let p1 = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    let (leaf, proof) = no_proof_args(&env);
+    assert_eq!(client.get_participant_count(), 0);
+    assert!(client.register(&p1, &leaf, &proof));
+    assert_eq!(client.get_participant_count(), 1);
+    assert!(!client.register(&p1, &leaf, &proof));
+    assert_eq!(client.get_participant_count(), 1);
+}
+
+#[test]
+fn test_admin_nonce_replay_protection() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    env.mock_all_auths();
+
+    assert_eq!(client.admin_nonce(), 0);
+    client.set_active(&admin, &0, &false);
+    assert_eq!(client.admin_nonce(), 1);
+
+    let replay = client.try_set_active(&admin, &0, &true);
+    assert_eq!(replay, Err(Ok(Error::InvalidAdminNonce)));
+
+    client.set_active(&admin, &1, &true);
+    assert_eq!(client.admin_nonce(), 2);
 }

--- a/contracts/campaign/test_snapshots/test/test_admin_nonce_replay_protection.1.json
+++ b/contracts/campaign/test_snapshots/test/test_admin_nonce_replay_protection.1.json
@@ -1,12 +1,65 @@
 {
   "generators": {
-    "address": 3,
+    "address": 2,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
     [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_active",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "bool": false
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_active",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "1"
+                },
+                {
+                  "bool": true
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -55,7 +108,7 @@
                         "symbol": "anonce"
                       },
                       "val": {
-                        "u64": "0"
+                        "u64": "2"
                       }
                     },
                     {
@@ -90,6 +143,46 @@
           "ext": "v0"
         },
         "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
       },
       {
         "entry": {

--- a/contracts/campaign/test_snapshots/test/test_capacity_reached.1.json
+++ b/contracts/campaign/test_snapshots/test/test_capacity_reached.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "u64": "1"
                 }
               ]
@@ -95,6 +98,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/campaign/test_snapshots/test/test_initialize_and_active.1.json
+++ b/contracts/campaign/test_snapshots/test/test_initialize_and_active.1.json
@@ -52,6 +52,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_merkle_root_not_set_by_default.1.json
+++ b/contracts/campaign/test_snapshots/test/test_merkle_root_not_set_by_default.1.json
@@ -52,6 +52,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_open_registration_when_no_root.1.json
+++ b/contracts/campaign/test_snapshots/test/test_open_registration_when_no_root.1.json
@@ -76,6 +76,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_participant_count_increments_on_new_register_only.1.json
+++ b/contracts/campaign/test_snapshots/test/test_participant_count_increments_on_new_register_only.1.json
@@ -7,23 +7,50 @@
   "auth": [
     [],
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_active",
+              "function_name": "register",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "u64": "0"
+                  "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
                 },
                 {
-                  "bool": false
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                  "vec": []
                 }
               ]
             }
@@ -64,7 +91,7 @@
                         "symbol": "active"
                       },
                       "val": {
-                        "bool": false
+                        "bool": true
                       }
                     },
                     {
@@ -80,7 +107,7 @@
                         "symbol": "anonce"
                       },
                       "val": {
-                        "u64": "1"
+                        "u64": "0"
                       }
                     },
                     {
@@ -88,7 +115,7 @@
                         "symbol": "count"
                       },
                       "val": {
-                        "u64": "0"
+                        "u64": "1"
                       }
                     },
                     {
@@ -106,6 +133,21 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "partic"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "bool": true
+                      }
                     }
                   ]
                 }
@@ -122,10 +164,30 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",

--- a/contracts/campaign/test_snapshots/test/test_register_participant.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_participant.1.json
@@ -77,6 +77,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_register_participant_twice_returns_false.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_participant_twice_returns_false.1.json
@@ -101,6 +101,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_register_rejected_with_empty_proof_when_root_set.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_rejected_with_empty_proof_when_root_set.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "bytes": "e2d80f78d79027556d6619a1400605abbdca6bb6eb24e0831e33ecd5466fa5f6"
                 }
               ]
@@ -70,6 +73,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/campaign/test_snapshots/test/test_register_rejected_with_invalid_proof.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_rejected_with_invalid_proof.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "bytes": "e2d80f78d79027556d6619a1400605abbdca6bb6eb24e0831e33ecd5466fa5f6"
                 }
               ]
@@ -70,6 +73,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/campaign/test_snapshots/test/test_register_rejected_with_leaf_not_in_tree.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_rejected_with_leaf_not_in_tree.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "bytes": "e2d80f78d79027556d6619a1400605abbdca6bb6eb24e0831e33ecd5466fa5f6"
                 }
               ]
@@ -70,6 +73,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/campaign/test_snapshots/test/test_register_with_valid_merkle_proof.1.json
+++ b/contracts/campaign/test_snapshots/test/test_register_with_valid_merkle_proof.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "bytes": "e2d80f78d79027556d6619a1400605abbdca6bb6eb24e0831e33ecd5466fa5f6"
                 }
               ]
@@ -130,6 +133,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/campaign/test_snapshots/test/test_set_active_only_by_admin.1.json
+++ b/contracts/campaign/test_snapshots/test/test_set_active_only_by_admin.1.json
@@ -52,6 +52,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_set_merkle_root_only_by_admin.1.json
+++ b/contracts/campaign/test_snapshots/test/test_set_merkle_root_only_by_admin.1.json
@@ -52,6 +52,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/contracts/campaign/test_snapshots/test/test_time_window_validation.1.json
+++ b/contracts/campaign/test_snapshots/test/test_time_window_validation.1.json
@@ -20,6 +20,9 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "u64": "0"
+                },
+                {
                   "u64": "100"
                 },
                 {
@@ -99,6 +102,14 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "1"
                       }
                     },
                     {

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -22,6 +22,7 @@ pub enum Error {
     Unauthorized = 3,
     ContractPaused = 4,
     CreditLimitExceeded = 5,
+    InvalidMultiplier = 6,
 }
 
 contractmeta!(
@@ -37,6 +38,8 @@ const PAUSED: Symbol = symbol_short!("paused");
 const CREDIT_EVENT: Symbol = symbol_short!("credit");
 const CLAIM_EVENT: Symbol = symbol_short!("claim");
 const MAX_CREDIT_PER_CALL: Symbol = symbol_short!("mxcredit");
+const CAMPAIGN_MULTIPLIER: Symbol = symbol_short!("mult");
+const BPS_DENOMINATOR: u128 = 10_000;
 
 #[contract]
 pub struct RewardsContract;
@@ -92,6 +95,33 @@ impl RewardsContract {
             .unwrap_or(0)
     }
 
+    /// Set campaign-specific reward multiplier in basis points (admin only).
+    /// Example: 10_000 = 1.0x, 12_500 = 1.25x, 5_000 = 0.5x.
+    pub fn set_campaign_multiplier(
+        env: Env,
+        admin: Address,
+        campaign_id: u64,
+        multiplier_bps: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        if multiplier_bps == 0 {
+            return Err(Error::InvalidMultiplier);
+        }
+        env.storage()
+            .instance()
+            .set(&(CAMPAIGN_MULTIPLIER, campaign_id), &multiplier_bps);
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(())
+    }
+
+    /// Returns multiplier in basis points for campaign, defaults to 10_000.
+    pub fn campaign_multiplier(env: Env, campaign_id: u64) -> u32 {
+        env.storage()
+            .instance()
+            .get(&(CAMPAIGN_MULTIPLIER, campaign_id))
+            .unwrap_or(10_000)
+    }
+
     /// Get contract metadata (name and symbol).
     pub fn metadata(env: Env) -> (Symbol, Symbol) {
         env.storage()
@@ -126,6 +156,34 @@ impl RewardsContract {
         env.events().publish((CREDIT_EVENT, user), amount);
         env.storage().instance().extend_ttl(50, 100);
         Ok(new_balance)
+    }
+
+    /// Credit points using campaign multiplier. Rounding uses floor division:
+    /// `adjusted = base_amount * multiplier_bps / 10_000`.
+    pub fn credit_for_campaign(
+        env: Env,
+        from: Address,
+        user: Address,
+        campaign_id: u64,
+        base_amount: u64,
+    ) -> Result<u64, Error> {
+        let multiplier_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&(CAMPAIGN_MULTIPLIER, campaign_id))
+            .unwrap_or(10_000);
+        if multiplier_bps == 0 {
+            return Err(Error::InvalidMultiplier);
+        }
+        let adjusted_u128 = (base_amount as u128)
+            .checked_mul(multiplier_bps as u128)
+            .ok_or(Error::Overflow)?
+            / BPS_DENOMINATOR;
+        if adjusted_u128 > u64::MAX as u128 {
+            return Err(Error::Overflow);
+        }
+        let adjusted = adjusted_u128 as u64;
+        Self::credit(env, from, user, adjusted)
     }
 
     /// Credit points to multiple users in one call.

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -237,3 +237,34 @@ fn test_campaign_rewards_integration_flow() {
     assert_eq!(rewards.balance(&user), 50);
     assert_eq!(rewards.total_claimed(), 70);
 }
+
+#[test]
+fn test_campaign_multiplier_applies_to_credit() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    client.set_campaign_multiplier(&admin, &42u64, &12_500u32); // 1.25x
+    let balance = client.credit_for_campaign(&admin, &user, &42u64, &100u64);
+    assert_eq!(balance, 125);
+    assert_eq!(client.balance(&user), 125);
+}
+
+#[test]
+fn test_campaign_multiplier_rounding_floor() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    client.set_campaign_multiplier(&admin, &7u64, &9_999u32);
+    let balance = client.credit_for_campaign(&admin, &user, &7u64, &3u64);
+    assert_eq!(balance, 2);
+}

--- a/contracts/rewards/test_snapshots/test/test_campaign_multiplier_applies_to_credit.1.json
+++ b/contracts/rewards/test_snapshots/test/test_campaign_multiplier_applies_to_credit.1.json
@@ -14,16 +14,44 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_active",
+              "function_name": "set_campaign_multiplier",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "u64": "0"
+                  "u64": "42"
                 },
                 {
-                  "bool": false
+                  "u32": 12500
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit_for_campaign",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "42"
+                },
+                {
+                  "u64": "100"
                 }
               ]
             }
@@ -61,14 +89,6 @@
                   "storage": [
                     {
                       "key": {
-                        "symbol": "active"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "admin"
                       },
                       "val": {
@@ -77,15 +97,7 @@
                     },
                     {
                       "key": {
-                        "symbol": "anonce"
-                      },
-                      "val": {
-                        "u64": "1"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "count"
+                        "symbol": "claimed"
                       },
                       "val": {
                         "u64": "0"
@@ -93,18 +105,63 @@
                     },
                     {
                       "key": {
-                        "symbol": "end"
+                        "symbol": "metadata"
                       },
                       "val": {
-                        "u64": "18446744073709551615"
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
                       }
                     },
                     {
                       "key": {
-                        "symbol": "start"
+                        "symbol": "mxcredit"
                       },
                       "val": {
                         "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "125"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "mult"
+                          },
+                          {
+                            "u64": "42"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u32": 12500
                       }
                     }
                   ]
@@ -126,6 +183,26 @@
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",

--- a/contracts/rewards/test_snapshots/test/test_campaign_multiplier_rounding_floor.1.json
+++ b/contracts/rewards/test_snapshots/test/test_campaign_multiplier_rounding_floor.1.json
@@ -14,16 +14,16 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_active",
+              "function_name": "set_campaign_multiplier",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "u64": "0"
+                  "u64": "7"
                 },
                 {
-                  "bool": false
+                  "u32": 9999
                 }
               ]
             }
@@ -32,7 +32,34 @@
         }
       ]
     ],
-    []
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "credit_for_campaign",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "7"
+                },
+                {
+                  "u64": "3"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
   ],
   "ledger": {
     "protocol_version": 25,
@@ -61,14 +88,6 @@
                   "storage": [
                     {
                       "key": {
-                        "symbol": "active"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    },
-                    {
-                      "key": {
                         "symbol": "admin"
                       },
                       "val": {
@@ -77,15 +96,7 @@
                     },
                     {
                       "key": {
-                        "symbol": "anonce"
-                      },
-                      "val": {
-                        "u64": "1"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "count"
+                        "symbol": "claimed"
                       },
                       "val": {
                         "u64": "0"
@@ -93,18 +104,63 @@
                     },
                     {
                       "key": {
-                        "symbol": "end"
+                        "symbol": "metadata"
                       },
                       "val": {
-                        "u64": "18446744073709551615"
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
                       }
                     },
                     {
                       "key": {
-                        "symbol": "start"
+                        "symbol": "mxcredit"
                       },
                       "val": {
                         "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "mult"
+                          },
+                          {
+                            "u64": "7"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u32": 9999
                       }
                     }
                   ]
@@ -140,6 +196,26 @@
         "entry": {
           "last_modified_ledger_seq": 0,
           "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
             "contract_code": {
               "ext": "v0",
               "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -152,5 +228,29 @@
       }
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "credit"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u64": "2"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/contracts/rewards/test_snapshots/test/test_campaign_rewards_integration_flow.1.json
+++ b/contracts/rewards/test_snapshots/test/test_campaign_rewards_integration_flow.1.json
@@ -128,6 +128,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "anonce"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "count"
                       },
                       "val": {

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -7,7 +7,9 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: 'http://localhost:4173',
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
   projects: [
     {


### PR DESCRIPTION
## Summary
- Add replay protection for sensitive campaign admin operations using an admin nonce (`admin_nonce`) and reject stale nonces.
- Add campaign-specific reward multipliers/modifiers in rewards contract with deterministic floor rounding (`base * multiplier_bps / 10_000`).
- Strengthen participant-count support for UI pagination with explicit register increment coverage and view assertions.
- Improve Playwright CI debuggability by retaining failure traces/screenshots/videos and uploading artifacts on workflow failure.

## Validation
- `cargo test -p trivela-campaign-contract`
- `cargo test -p trivela-rewards-contract`

## Closes
- Closes #176
- Closes #206
- Closes #208
- Closes #209

Made with [Cursor](https://cursor.com)