### PR TITLE
feat: migration strategy, campaign search, contract ID validation, and rate-limit headers

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -67,8 +67,29 @@ export function createDb(dbPath = ':memory:', seed = []) {
   }
 
   return {
-    /** Return all campaigns, optionally filtered by active status. */
-    getAll({ active } = {}) {
+    /** Return all campaigns, optionally filtered by active status and text query. */
+    getAll({ active, q } = {}) {
+      const hasQuery = typeof q === 'string' && q.length > 0;
+      const queryTerm = hasQuery ? `%${q.toLowerCase()}%` : null;
+
+      if (active !== undefined && hasQuery) {
+        const rows = db
+          .prepare(
+            'SELECT * FROM campaigns WHERE active = ? AND (LOWER(name) LIKE ? OR LOWER(description) LIKE ?) ORDER BY id ASC',
+          )
+          .all(active ? 1 : 0, queryTerm, queryTerm);
+        return rows.map(rowToCampaign);
+      }
+
+      if (hasQuery) {
+        return db
+          .prepare(
+            'SELECT * FROM campaigns WHERE LOWER(name) LIKE ? OR LOWER(description) LIKE ? ORDER BY id ASC',
+          )
+          .all(queryTerm, queryTerm)
+          .map(rowToCampaign);
+      }
+
       if (active !== undefined) {
         const rows = db
           .prepare('SELECT * FROM campaigns WHERE active = ? ORDER BY id ASC')

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -19,6 +19,7 @@ const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 60;
 const LEGACY_API_PREFIX = '/api';
 const API_V1_PREFIX = '/api/v1';
+const CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
 
 function normalizePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value, 10);
@@ -75,6 +76,17 @@ function readOptionalConfigValue(options, envKey) {
   return typeof fromEnv === 'string' ? fromEnv : '';
 }
 
+function validateContractId(value, label) {
+  if (!value) {
+    return '';
+  }
+  const normalized = value.trim();
+  if (!CONTRACT_ID_PATTERN.test(normalized)) {
+    throw new Error(`${label} must be a valid Stellar contract ID`);
+  }
+  return normalized;
+}
+
 function validateCampaignPayload(payload, { partial = false } = {}) {
   const errors = [];
 
@@ -116,13 +128,15 @@ export function createApp(options = {}) {
     options.corsAllowedOrigins ?? process.env.CORS_ALLOWED_ORIGINS ?? process.env.CORS_ORIGIN;
   const stellarNetwork = options.stellarNetwork ?? process.env.STELLAR_NETWORK ?? 'testnet';
   const sorobanRpcUrl = options.sorobanRpcUrl ?? process.env.SOROBAN_RPC_URL ?? DEFAULT_RPC_URL;
-  const rewardsContractId = readOptionalConfigValue(options, 'REWARDS_CONTRACT_ID');
-  const campaignContractId = readOptionalConfigValue(options, 'CAMPAIGN_CONTRACT_ID');
+  const rewardsContractId = validateContractId(
+    readOptionalConfigValue(options, 'REWARDS_CONTRACT_ID'),
+    'REWARDS_CONTRACT_ID',
+  );
+  const campaignContractId = validateContractId(
+    readOptionalConfigValue(options, 'CAMPAIGN_CONTRACT_ID'),
+    'CAMPAIGN_CONTRACT_ID',
+  );
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-<<<<<<< codex/issues-112-110-115-123
-  const dbPath = options.dbPath ?? process.env.DB_PATH ?? ':memory:';
-=======
->>>>>>> main
   const allowedOrigins = parseAllowedOrigins(corsAllowedOrigins);
   const rateLimitWindowMs = normalizePositiveInteger(
     options.rateLimit?.windowMs ?? process.env.RATE_LIMIT_WINDOW_MS,
@@ -136,7 +150,7 @@ export function createApp(options = {}) {
   // When an explicit campaigns seed is provided (legacy test path), use it;
   // otherwise fall back to the default "Welcome Campaign" row.
   const seed = options.campaigns ?? defaultSeed();
-  const dbPath = options.dbPath ?? process.env.DB_PATH;
+  const dbPath = options.dbPath ?? process.env.DB_PATH ?? ':memory:';
   const db = createDb(dbPath, seed);
 
   const app = express();
@@ -238,7 +252,8 @@ export function createApp(options = {}) {
       req.query.active !== undefined
         ? req.query.active === 'true'
         : undefined;
-    const items = db.getAll({ active: activeFilter });
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    const items = db.getAll({ active: activeFilter, q });
     res.json(paginateItems(items, req.query));
   }
 
@@ -260,19 +275,11 @@ export function createApp(options = {}) {
     }
 
     const { name, description, rewardPerAction } = req.body;
-<<<<<<< codex/issues-112-110-115-123
-=======
-
->>>>>>> main
     const campaign = db.create({
       name,
       description: description || '',
       rewardPerAction: rewardPerAction ?? 0,
     });
-<<<<<<< codex/issues-112-110-115-123
-=======
-
->>>>>>> main
     return res.status(201).json(campaign);
   }
 
@@ -285,17 +292,12 @@ export function createApp(options = {}) {
       });
     }
 
-<<<<<<< codex/issues-112-110-115-123
     const campaign = db.update(req.params.id, req.body);
     if (!campaign) {
       return res.status(404).json({ error: 'Campaign not found' });
     }
 
     return res.json(campaign);
-=======
-    const updated = db.update(req.params.id, req.body);
-    return res.json(updated);
->>>>>>> main
   }
 
   function deleteCampaign(req, res) {

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -133,6 +133,11 @@ test('rate limiting applies to API routes', async () => {
   try {
     const firstResponse = await fetch(`${baseUrl}/api/v1/campaigns`);
     assert.equal(firstResponse.status, 200);
+    assert.equal(firstResponse.headers.get('x-ratelimit-limit'), '1');
+    assert.equal(firstResponse.headers.get('x-ratelimit-remaining'), '0');
+    assert.ok(firstResponse.headers.get('x-ratelimit-reset'));
+    assert.ok(firstResponse.headers.get('ratelimit-policy'));
+    assert.ok(firstResponse.headers.get('ratelimit'));
 
     const secondResponse = await fetch(`${baseUrl}/api/v1/campaigns`);
     assert.equal(secondResponse.status, 429);
@@ -144,6 +149,49 @@ test('rate limiting applies to API routes', async () => {
       windowMs: 60_000,
       retryAfterSeconds: 60,
     });
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('createApp rejects invalid contract IDs in configuration', () => {
+  assert.throws(
+    () => createApp({ REWARDS_CONTRACT_ID: 'invalid-id' }),
+    /REWARDS_CONTRACT_ID must be a valid Stellar contract ID/,
+  );
+
+  assert.throws(
+    () => createApp({ CAMPAIGN_CONTRACT_ID: 'GABC' }),
+    /CAMPAIGN_CONTRACT_ID must be a valid Stellar contract ID/,
+  );
+});
+
+test('GET /api/v1/campaigns supports text search with q parameter', async () => {
+  const seed = [
+    {
+      id: '1',
+      name: 'Stellar Quest',
+      description: 'Rewards for onboarding',
+      active: true,
+      rewardPerAction: 5,
+      createdAt: new Date().toISOString(),
+    },
+    {
+      id: '2',
+      name: 'Builder Sprint',
+      description: 'Campaign for dev tooling',
+      active: true,
+      rewardPerAction: 5,
+      createdAt: new Date().toISOString(),
+    },
+  ];
+  const { server, baseUrl } = await startTestServer({ campaigns: seed });
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns?q=stellar`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].name, 'Stellar Quest');
   } finally {
     await stopTestServer(server);
   }

--- a/backend/src/middleware/rateLimit.js
+++ b/backend/src/middleware/rateLimit.js
@@ -31,11 +31,19 @@ export function createRateLimiter({
     buckets.set(key, bucket);
 
     const remaining = Math.max(maxRequests - bucket.count, 0);
+    const resetSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+    const windowSeconds = Math.max(1, Math.ceil(windowMs / 1000));
     res.setHeader('X-RateLimit-Limit', String(maxRequests));
     res.setHeader('X-RateLimit-Remaining', String(remaining));
+    res.setHeader('X-RateLimit-Reset', String(resetSeconds));
+    res.setHeader('RateLimit-Policy', `${maxRequests};w=${windowSeconds}`);
+    res.setHeader(
+      'RateLimit',
+      `limit=${maxRequests}, remaining=${remaining}, reset=${resetSeconds}`,
+    );
 
     if (bucket.count > maxRequests) {
-      const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      const retryAfterSeconds = resetSeconds;
       res.setHeader('Retry-After', String(retryAfterSeconds));
       return res.status(429).json({
         error: 'Rate limit exceeded',

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -39,6 +39,7 @@ pub enum Error {
     CapacityReached = 102,
     CampaignInactive = 103,
     NotInAllowlist = 104,
+    UnsupportedMigration = 105,
 }
 
 contractmeta!(key = "Description", val = "Trivela campaign configuration");
@@ -51,6 +52,8 @@ const END_TIME: Symbol = symbol_short!("end");
 const MAX_CAP: Symbol = symbol_short!("maxcap");
 const PARTICIPANT_COUNT: Symbol = symbol_short!("count");
 const MERKLE_ROOT: Symbol = symbol_short!("mkroot");
+const SCHEMA_VERSION: Symbol = symbol_short!("schema_v");
+const CURRENT_SCHEMA_VERSION: u32 = 1;
 
 #[contract]
 pub struct CampaignContract;
@@ -90,8 +93,39 @@ impl CampaignContract {
         env.storage().instance().set(&START_TIME, &0u64);
         env.storage().instance().set(&END_TIME, &u64::MAX);
         env.storage().instance().set(&PARTICIPANT_COUNT, &0u64);
+        env.storage()
+            .instance()
+            .set(&SCHEMA_VERSION, &CURRENT_SCHEMA_VERSION);
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
+    }
+
+    /// Returns the active storage schema version for this contract.
+    pub fn schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&SCHEMA_VERSION)
+            .unwrap_or(CURRENT_SCHEMA_VERSION)
+    }
+
+    /// Migration entrypoint for future schema transitions.
+    ///
+    /// For now, version `1` is the only supported schema and this function
+    /// serves as an idempotent migration hook for upgrade workflows.
+    pub fn migrate(env: Env, admin: Address, target_version: u32) -> Result<u32, Error> {
+        admin.require_auth();
+        let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
+        if stored != admin {
+            return Err(Error::Unauthorized);
+        }
+        if target_version != CURRENT_SCHEMA_VERSION {
+            return Err(Error::UnsupportedMigration);
+        }
+        env.storage()
+            .instance()
+            .set(&SCHEMA_VERSION, &CURRENT_SCHEMA_VERSION);
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(CURRENT_SCHEMA_VERSION)
     }
 
     /// Set registration time window (admin only).

--- a/contracts/campaign/src/test.rs
+++ b/contracts/campaign/src/test.rs
@@ -284,3 +284,23 @@ fn test_open_registration_when_no_root() {
     let (leaf, proof) = no_proof_args(&env);
     assert!(client.register(&participant, &leaf, &proof));
 }
+
+#[test]
+fn test_schema_version_and_migrate_entrypoint() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(client.schema_version(), 1);
+
+    env.mock_all_auths();
+    let migrated = client.migrate(&admin, &1);
+    assert_eq!(migrated, 1);
+    assert_eq!(client.schema_version(), 1);
+
+    let unsupported = client.try_migrate(&admin, &2);
+    assert_eq!(unsupported, Err(Ok(Error::UnsupportedMigration)));
+
+    let unauthorized = client.try_migrate(&other, &1);
+    assert_eq!(unauthorized, Err(Ok(Error::Unauthorized)));
+}

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -22,6 +22,7 @@ pub enum Error {
     Unauthorized = 3,
     ContractPaused = 4,
     CreditLimitExceeded = 5,
+    UnsupportedMigration = 6,
 }
 
 contractmeta!(
@@ -37,6 +38,8 @@ const PAUSED: Symbol = symbol_short!("paused");
 const CREDIT_EVENT: Symbol = symbol_short!("credit");
 const CLAIM_EVENT: Symbol = symbol_short!("claim");
 const MAX_CREDIT_PER_CALL: Symbol = symbol_short!("mxcredit");
+const SCHEMA_VERSION: Symbol = symbol_short!("schema_v");
+const CURRENT_SCHEMA_VERSION: u32 = 1;
 
 #[contract]
 pub struct RewardsContract;
@@ -70,7 +73,34 @@ impl RewardsContract {
         env.storage().instance().set(&METADATA, &(name, symbol));
         env.storage().instance().set(&PAUSED, &false);
         env.storage().instance().set(&MAX_CREDIT_PER_CALL, &0u64);
+        env.storage()
+            .instance()
+            .set(&SCHEMA_VERSION, &CURRENT_SCHEMA_VERSION);
         Ok(())
+    }
+
+    /// Returns the active storage schema version for this contract.
+    pub fn schema_version(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&SCHEMA_VERSION)
+            .unwrap_or(CURRENT_SCHEMA_VERSION)
+    }
+
+    /// Migration entrypoint for future schema changes.
+    ///
+    /// Current behavior is intentionally idempotent for version `1`, so operational
+    /// scripts can call this safely during deployments/upgrades.
+    pub fn migrate(env: Env, admin: Address, target_version: u32) -> Result<u32, Error> {
+        require_admin(&env, &admin)?;
+        if target_version != CURRENT_SCHEMA_VERSION {
+            return Err(Error::UnsupportedMigration);
+        }
+        env.storage()
+            .instance()
+            .set(&SCHEMA_VERSION, &CURRENT_SCHEMA_VERSION);
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(CURRENT_SCHEMA_VERSION)
     }
 
     /// Set maximum amount allowed per single credit call (admin only).

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -237,3 +237,26 @@ fn test_campaign_rewards_integration_flow() {
     assert_eq!(rewards.balance(&user), 50);
     assert_eq!(rewards.total_claimed(), 70);
 }
+
+#[test]
+fn test_schema_version_and_migrate_entrypoint() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    assert_eq!(client.schema_version(), 1);
+
+    env.mock_all_auths();
+    let migrated = client.migrate(&admin, &1);
+    assert_eq!(migrated, 1);
+    assert_eq!(client.schema_version(), 1);
+
+    let unsupported = client.try_migrate(&admin, &2);
+    assert_eq!(unsupported, Err(Ok(Error::UnsupportedMigration)));
+
+    let unauthorized = client.try_migrate(&other, &1);
+    assert_eq!(unauthorized, Err(Ok(Error::Unauthorized)));
+}

--- a/docs/upgradeability.md
+++ b/docs/upgradeability.md
@@ -1,31 +1,63 @@
-# Soroban Contract Upgradeability
+# Soroban Contract Upgradeability & Migration
 
-Trivela contracts are designed with a standard Soroban upgradeability pattern, allowing for logic updates while preserving contract address and state.
+Trivela contracts keep state at stable contract IDs and evolve logic through Soroban Wasm upgrades.  
+To make storage evolution explicit and reviewable, each contract now exposes:
 
-## Upgrade Pattern
+- `schema_version() -> u32`
+- `migrate(admin, target_version) -> Result<u32, Error>`
 
-Soroban provides a built-in mechanism for upgrading contract code. This is achieved by updating the Wasm byte-code associated with a contract ID.
+Both `campaign` and `rewards` contracts currently use **schema version `1`**.
 
-### 1. Requirements
-- The contract must implement an admin-only function that calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
-- The new WASM file must already be uploaded to the network (obtaining a `wasm_hash`).
+## Migration Entry Point Strategy
 
-### 2. Implementation Example
+1. **Schema is explicit**  
+   `initialize` persists `schema_v = 1`.
+2. **Admin-gated migration**  
+   `migrate` requires admin auth and validates supported target versions.
+3. **Idempotent current migration**  
+   Calling `migrate(..., 1)` is safe and returns `1`.
+4. **Forward-safe failure mode**  
+   Unsupported versions return `UnsupportedMigration` instead of mutating state.
 
-In a future iteration, we can add this to `RewardsContract`:
+This makes migration behavior deterministic for CI and rollout scripts.
 
-```rust
-pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
-    admin.require_auth();
-    // Verify admin matches stored admin
-    env.deployer().update_current_contract_wasm(new_wasm_hash);
-}
+## Operational Upgrade Runbook
+
+1. Build and upload new Wasm:
+
+```bash
+stellar contract build
+stellar contract install --wasm <updated_contract.wasm> --source <admin> --network testnet
 ```
 
-### 3. Migration Steps
-- **State Compatibility**: Ensure the new contract version can correctly interpret the existing instance and persistent storage.
-- **WASM Upload**: Use `stellar contract install --wasm <file>` to upload the new code and get the hash.
-- **Invoke Upgrade**: Call the `upgrade` function with the admin identity.
+2. Upgrade contract code (admin path):
 
-## Future: Managed Upgradeability
-For more complex scenarios, a **Proxy Pattern** or a **Factory pattern** can be used to manage multiple contract instances and their upgrades centrally.
+```bash
+stellar contract invoke --id <CONTRACT_ID> --source <admin> --network testnet -- \
+  upgrade --new_wasm_hash <WASM_HASH>
+```
+
+3. Run migration hook:
+
+```bash
+stellar contract invoke --id <CONTRACT_ID> --source <admin> --network testnet -- \
+  migrate --target_version <VERSION>
+```
+
+4. Verify:
+
+```bash
+stellar contract invoke --id <CONTRACT_ID> --source <admin> --network testnet -- \
+  schema_version
+```
+
+## Storage Consistency Guardrails
+
+- Never repurpose a key with incompatible value type.
+- Introduce new keys for new fields; preserve old keys until migrated.
+- Keep `migrate` pure/idempotent per target version.
+- Add test coverage for:
+  - initial schema version
+  - successful migrate at current version
+  - unsupported version rejection
+  - unauthorized caller rejection

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -600,6 +600,32 @@
   gap: 1.5rem;
 }
 
+.campaign-search {
+  width: min(720px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.campaign-search-label {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.campaign-search-input {
+  min-height: 44px;
+  padding: 0.72rem 0.95rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+  color: var(--text);
+}
+
+.campaign-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 .campaigns-panel {
   min-height: 220px;
 }

--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -59,6 +59,7 @@ export default function Landing({
   const [campaignsError, setCampaignsError] = useState('');
   const [isCampaignsLoading, setIsCampaignsLoading] = useState(true);
   const [campaignPage, setCampaignPage] = useState(1);
+  const [campaignQuery, setCampaignQuery] = useState('');
   const [campaignRefreshKey, setCampaignRefreshKey] = useState(0);
   const [pagination, setPagination] = useState(() => getFallbackPagination([], 1));
   const campaignContract = getCampaignContract();
@@ -69,7 +70,15 @@ export default function Landing({
     setIsCampaignsLoading(true);
     setCampaignsError('');
 
-    fetch(apiUrl(`/api/v1/campaigns?page=${campaignPage}&limit=${CAMPAIGNS_PER_PAGE}`), {
+    const params = new URLSearchParams({
+      page: String(campaignPage),
+      limit: String(CAMPAIGNS_PER_PAGE),
+    });
+    if (campaignQuery.trim().length > 0) {
+      params.set('q', campaignQuery.trim());
+    }
+
+    fetch(apiUrl(`/api/v1/campaigns?${params.toString()}`), {
       signal: controller.signal,
     })
       .then(async (response) => {
@@ -109,7 +118,7 @@ export default function Landing({
       });
 
     return () => controller.abort();
-  }, [campaignPage, campaignRefreshKey]);
+  }, [campaignPage, campaignRefreshKey, campaignQuery]);
 
   // Removed local loadPoints effect as it is now handled in App.jsx
 
@@ -286,6 +295,22 @@ export default function Landing({
           <p className="section-subtitle">
             Paginated from the backend API with keyboard-friendly previous and next controls.
           </p>
+          <div className="campaign-search">
+            <label htmlFor="campaign-search-input" className="campaign-search-label">
+              Search campaigns
+            </label>
+            <input
+              id="campaign-search-input"
+              type="search"
+              value={campaignQuery}
+              onChange={(event) => {
+                setCampaignPage(1);
+                setCampaignQuery(event.target.value);
+              }}
+              className="campaign-search-input"
+              placeholder="Search by campaign name or description"
+            />
+          </div>
 
           <div className="campaigns-panel" aria-busy={isCampaignsLoading}>
             {isCampaignsLoading ? (


### PR DESCRIPTION
## Summary
- Add contract migration strategy with explicit `schema_version` + `migrate` entrypoints in both Soroban contracts.
- Add backend contract-ID validation for `REWARDS_CONTRACT_ID` and `CAMPAIGN_CONTRACT_ID`.
- Standardize API rate limiting headers (`X-RateLimit-*`, `RateLimit`, `RateLimit-Policy`, and `Retry-After`).
- Add campaign search support (`q`) in backend and wire frontend search UI in `Landing`.
- Expand tests for migration behavior, search filtering, contract-ID validation, and rate-limit headers.

## Notes
- Also resolved merge-conflict markers that were present in `backend/src/index.js`.
- `docs/upgradeability.md` now documents an actionable migration runbook.

## Test plan
- Backend tests: `npm test --workspace=backend`
- Contracts: `cargo test -p trivela-rewards-contract` and `cargo test -p trivela-campaign-contract`
- Frontend: verify campaign search UI filters campaigns via `q` query

Closes #207.
Closes #213.
Closes #200.
Closes #203.

Made with [Cursor](https://cursor.com)