### PR TITLE
Add metrics, retry UX, architecture overview, and line-ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Trivela/
 
 ---
 
+## Architecture
+
+For a quick system map (diagram, trust boundaries, and end-to-end data flows), see [`docs/ARCHITECTURE_OVERVIEW.md`](docs/ARCHITECTURE_OVERVIEW.md).
+
+---
+
 ## Prerequisites
 
 - **Rust** (for Soroban): [rustup](https://rustup.rs/)

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -147,6 +147,11 @@ export function createApp(options = {}) {
   };
 
   const app = express();
+  const metrics = {
+    requestTotal: 0,
+    requestErrors: 0,
+    routeHits: new Map(),
+  };
   const requireApiKey = createApiKeyAuth({ apiKey });
   const rateLimiter = createRateLimiter({
     windowMs: rateLimitWindowMs,
@@ -157,6 +162,17 @@ export function createApp(options = {}) {
   app.use(cors(createCorsOptions(allowedOrigins)));
   app.use(logger);
   app.use(express.json());
+  app.use((req, res, next) => {
+    metrics.requestTotal += 1;
+    res.on('finish', () => {
+      const routeKey = `${req.method} ${req.path}`;
+      metrics.routeHits.set(routeKey, (metrics.routeHits.get(routeKey) ?? 0) + 1);
+      if (res.statusCode >= 400) {
+        metrics.requestErrors += 1;
+      }
+    });
+    next();
+  });
 
   async function buildHealthPayload() {
     const rpc = await checkSorobanRpcHealth({
@@ -185,6 +201,36 @@ export function createApp(options = {}) {
     res.status(rpc.status === 'ok' ? 200 : 503).json(rpc);
   });
 
+  app.get('/metrics', (_req, res) => {
+    const uptimeSeconds = process.uptime();
+    const routeLines = [...metrics.routeHits.entries()]
+      .map(([route, count]) => {
+        const escapedRoute = route.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return `trivela_route_hits_total{route="${escapedRoute}"} ${count}`;
+      })
+      .join('\n');
+
+    const payload = [
+      '# HELP trivela_requests_total Total HTTP requests handled.',
+      '# TYPE trivela_requests_total counter',
+      `trivela_requests_total ${metrics.requestTotal}`,
+      '# HELP trivela_request_errors_total Total HTTP requests with status >= 400.',
+      '# TYPE trivela_request_errors_total counter',
+      `trivela_request_errors_total ${metrics.requestErrors}`,
+      '# HELP trivela_process_uptime_seconds Node.js process uptime.',
+      '# TYPE trivela_process_uptime_seconds gauge',
+      `trivela_process_uptime_seconds ${uptimeSeconds.toFixed(3)}`,
+      '# HELP trivela_route_hits_total Route-level request counts.',
+      '# TYPE trivela_route_hits_total counter',
+      routeLines,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    res.send(`${payload}\n`);
+  });
+
   function apiInfo(req, res) {
     const usingLegacyPrefix =
       req.path.startsWith(LEGACY_API_PREFIX) && !req.path.startsWith(API_V1_PREFIX);
@@ -196,6 +242,7 @@ export function createApp(options = {}) {
       endpoints: {
         health: 'GET /health',
         healthRpc: 'GET /health/rpc',
+        metrics: 'GET /metrics',
         info: `GET ${API_V1_PREFIX}`,
         campaigns: `GET ${API_V1_PREFIX}/campaigns`,
         campaign: `GET ${API_V1_PREFIX}/campaigns/:id`,

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -212,6 +212,25 @@ test('/health/rpc returns 503 when the Soroban RPC health check fails', async ()
   }
 });
 
+test('GET /metrics exposes minimal Prometheus metrics', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    await fetch(`${baseUrl}/api/v1/campaigns`);
+    const response = await fetch(`${baseUrl}/metrics`);
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /text\/plain/);
+
+    const body = await response.text();
+    assert.match(body, /trivela_requests_total \d+/);
+    assert.match(body, /trivela_request_errors_total \d+/);
+    assert.match(body, /trivela_process_uptime_seconds [0-9.]+/);
+    assert.match(body, /trivela_route_hits_total\{route="GET \/api\/v1\/campaigns"\} \d+/);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
 test('POST /api/v1/campaigns creates a new campaign and returns it', async () => {
   const { server, baseUrl } = await startTestServer();
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,64 @@
+# Trivela Architecture Overview
+
+This document gives contributors a quick map of the Trivela system, the trust boundaries, and how data moves across contracts, backend, and frontend.
+
+## System Diagram
+
+```mermaid
+flowchart LR
+    U[User Wallet / Browser] --> F[Frontend React + Vite]
+    F -->|REST /api/v1| B[Backend Express API]
+    F -->|Soroban RPC calls| R[(Soroban RPC)]
+    B -->|Health + config checks| R
+    R --> C1[Rewards Contract]
+    R --> C2[Campaign Contract]
+    B --> D[(Campaign DB / in-memory store)]
+```
+
+## Component Responsibilities
+
+- `frontend/`
+  - Renders campaigns, wallet UX, and claim/register actions.
+  - Handles client-side loading/error states and route-level rendering recovery.
+  - Reads API and contract configuration from `VITE_*` env values.
+
+- `backend/`
+  - Serves campaign CRUD endpoints under `/api/v1`.
+  - Exposes health/config/metrics endpoints for operations and integrations.
+  - Applies request logging, optional API-key auth for writes, and rate limiting.
+
+- `contracts/rewards`
+  - Tracks user points, credit events, and claims.
+  - Enforces contract-level authorization and reward accounting.
+
+- `contracts/campaign`
+  - Tracks campaign lifecycle and participant registration.
+  - Stores campaign-level constraints enforced on-chain.
+
+## Trust Model
+
+- **User wallet signatures** are the source of truth for user-authorized contract actions.
+- **Smart contracts** are authoritative for on-chain balances, claims, and campaign participation.
+- **Backend API** is authoritative for off-chain campaign metadata served to the UI.
+- **Frontend** is untrusted for business logic enforcement; it should only orchestrate and display state.
+
+## Data Flows
+
+### 1) Campaign browsing
+1. Frontend calls `GET /api/v1/campaigns`.
+2. Backend reads from campaign store and returns paginated data.
+3. Frontend renders cards/details with loading and retry behavior.
+
+### 2) Register in campaign
+1. User connects wallet in frontend.
+2. Frontend constructs/registers transaction via Soroban RPC.
+3. Campaign contract validates rules and persists participant state.
+
+### 3) Claim rewards
+1. Frontend reads wallet points from rewards contract.
+2. User submits claim action.
+3. Rewards contract validates and updates on-chain balances/events.
+
+### 4) Operational observability
+1. Health checks: `/health`, `/health/rpc`.
+2. Metrics scrape: `/metrics` (request totals, errors, route hit counters, uptime gauge).

--- a/frontend/src/AdminCampaigns.jsx
+++ b/frontend/src/AdminCampaigns.jsx
@@ -17,16 +17,22 @@ export default function AdminCampaigns({
 }) {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   const loadCampaigns = async () => {
     setLoading(true);
+    setError('');
     try {
       const response = await fetch(apiUrl('/api/v1/campaigns'));
+      if (!response.ok) {
+        throw new Error(`Campaign API returned ${response.status}`);
+      }
       const payload = await response.json();
       setCampaigns(payload.data || []);
       logSafeEvent('admin_campaigns_loaded', { count: payload.data?.length ?? 0 });
-    } catch {
+    } catch (fetchError) {
       setCampaigns([]);
+      setError(fetchError?.message || 'Unable to load campaigns.');
     } finally {
       setLoading(false);
     }
@@ -55,6 +61,14 @@ export default function AdminCampaigns({
             Uses session-only API key storage and never exposes admin credentials on public pages.
           </p>
           {loading ? <p>Loading campaigns…</p> : null}
+          {!loading && error ? (
+            <div className="detail-error" role="alert" style={{ marginBottom: '1rem' }}>
+              <p>{error}</p>
+              <button type="button" className="btn btn-primary" onClick={loadCampaigns}>
+                Retry request
+              </button>
+            </div>
+          ) : null}
           <CreateCampaign campaigns={campaigns} onCampaignCreated={loadCampaigns} />
         </section>
       </main>

--- a/frontend/src/CampaignDetail.css
+++ b/frontend/src/CampaignDetail.css
@@ -43,6 +43,14 @@
   box-shadow: var(--shadow-lg);
 }
 
+.detail-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .detail-header {
   margin-bottom: 2.5rem;
 }

--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -26,6 +26,7 @@ export default function CampaignDetail({
   const [campaign, setCampaign] = useState(null);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -61,7 +62,7 @@ export default function CampaignDetail({
       });
 
     return () => controller.abort();
-  }, [id]);
+  }, [id, retryCount]);
 
   const formatDate = (value) => {
     if (!value) return '';
@@ -99,9 +100,18 @@ export default function CampaignDetail({
             <div className="detail-error" role="alert">
               <h2>Error</h2>
               <p>{error}</p>
-              <Link to="/" className="btn btn-primary">
-                Return to landing
-              </Link>
+              <div className="detail-actions">
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => setRetryCount((count) => count + 1)}
+                >
+                  Retry request
+                </button>
+                <Link to="/" className="btn btn-secondary">
+                  Return to landing
+                </Link>
+              </div>
             </div>
           ) : (
             <article className="detail-content">


### PR DESCRIPTION
## Summary
- add a minimal Prometheus-compatible `/metrics` endpoint with request/error/uptime counters
- add frontend retry actions for API failure states in campaign detail and admin campaign views
- add architecture overview documentation with a system diagram, trust model, and data flows
- add `.gitattributes` to enforce consistent LF line endings across the repository

Closes #171
Closes #181
Closes #174
Closes #178

## Test plan
- node --test backend/src/index.test.js