### PR TITLE
fix: improve global error recovery and mobile layout polish

### DIFF
--- a/frontend/src/AdminCampaigns.jsx
+++ b/frontend/src/AdminCampaigns.jsx
@@ -59,20 +59,29 @@ export default function AdminCampaigns({
         onDisconnectWallet={onDisconnectWallet}
       />
       <main id="main-content" className="landing-main" tabIndex="-1">
-        <section className="section">
-          <h2 className="section-title">Protected admin campaigns UI</h2>
-          <p className="section-subtitle">
-            Uses session-only API key storage and never exposes admin credentials on public pages.
-          </p>
-          {loading ? <p>Loading campaigns…</p> : null}
+        <section className="section admin-section">
+          <div className="admin-intro">
+            <h2 className="section-title">Protected admin campaigns UI</h2>
+            <p className="section-subtitle">
+              Uses session-only API key storage and never exposes admin credentials on public pages.
+            </p>
+          </div>
+
+          {loading ? (
+            <p className="campaigns-status admin-loading" role="status">
+              Loading campaigns...
+            </p>
+          ) : null}
+
           {!loading && error ? (
-            <div className="detail-error" role="alert" style={{ marginBottom: '1rem' }}>
+            <div className="detail-error admin-error" role="alert">
               <p>{error}</p>
               <button type="button" className="btn btn-primary" onClick={loadCampaigns}>
                 Retry request
               </button>
             </div>
           ) : null}
+
           <CreateCampaign campaigns={campaigns} onCampaignCreated={loadCampaigns} />
         </section>
       </main>

--- a/frontend/src/CampaignDetail.css
+++ b/frontend/src/CampaignDetail.css
@@ -173,6 +173,11 @@
 }
 
 @media (max-width: 640px) {
+  .detail-status,
+  .detail-error {
+    padding: 2rem 1.25rem;
+  }
+
   .detail-title {
     font-size: 2.2rem;
   }
@@ -217,5 +222,15 @@
     width: 100%;
     min-height: 48px;
     font-size: 1rem;
+  }
+
+  .detail-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .detail-actions .btn {
+    width: 100%;
+    min-height: 48px;
   }
 }

--- a/frontend/src/ErrorBoundary.jsx
+++ b/frontend/src/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 
 const DEFAULT_MESSAGE = 'Something went wrong while rendering this page.';
+const FRIENDLY_MESSAGE = 'We could not render this screen. Try again or return to the home page.';
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -19,16 +20,27 @@ export default class ErrorBoundary extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    const resetKeyChanged = prevProps.resetKey !== this.props.resetKey;
+    if (this.state.hasError && resetKeyChanged) {
+      this.resetBoundary();
+    }
+  }
+
   componentDidCatch(error, errorInfo) {
     console.error('Uncaught UI error:', error, errorInfo);
   }
 
-  handleRetry = () => {
+  resetBoundary = () => {
     this.setState((prevState) => ({
       hasError: false,
       errorMessage: '',
       retryKey: prevState.retryKey + 1,
     }));
+  };
+
+  handleRetry = () => {
+    this.resetBoundary();
   };
 
   handleGoHome = () => {
@@ -45,7 +57,10 @@ export default class ErrorBoundary extends Component {
           <div className="error-boundary-card">
             <p className="error-boundary-eyebrow">Oops</p>
             <h1 className="error-boundary-title">We hit an unexpected error</h1>
-            <p className="error-boundary-message">{errorMessage || DEFAULT_MESSAGE}</p>
+            <p className="error-boundary-message">{FRIENDLY_MESSAGE}</p>
+            {errorMessage && errorMessage !== DEFAULT_MESSAGE ? (
+              <p className="error-boundary-meta">Details: {errorMessage}</p>
+            ) : null}
             <div className="error-boundary-actions">
               <button
                 type="button"

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -858,6 +858,35 @@
   color: var(--success);
 }
 
+.admin-section {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.admin-intro {
+  display: grid;
+  gap: 0.55rem;
+  text-align: center;
+}
+
+.admin-intro .section-title,
+.admin-intro .section-subtitle {
+  margin: 0;
+}
+
+.admin-loading {
+  margin: 0;
+}
+
+.admin-error {
+  margin: 0;
+  padding: 1.5rem;
+}
+
+.admin-error p {
+  margin: 0 0 1rem;
+}
+
 .cta-band {
   width: min(1200px, calc(100% - 2rem));
   margin: 0 auto;
@@ -997,6 +1026,14 @@
 
   .campaign-card-header {
     flex-direction: column;
+  }
+
+  .admin-intro {
+    text-align: left;
+  }
+
+  .admin-error .btn {
+    width: 100%;
   }
 }
 
@@ -1211,6 +1248,10 @@
 
   .create-campaign-form .btn {
     width: 100%;
+  }
+
+  .admin-error {
+    padding: 1.2rem;
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -144,6 +144,13 @@ button:disabled {
   color: var(--text-muted);
 }
 
+.error-boundary-meta {
+  margin: 0.65rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  word-break: break-word;
+}
+
 .error-boundary-actions {
   display: flex;
   flex-wrap: wrap;
@@ -178,4 +185,23 @@ button:disabled {
 .error-boundary-button-secondary:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+@media (max-width: 540px) {
+  .error-boundary {
+    padding: 16px;
+  }
+
+  .error-boundary-card {
+    padding: 20px;
+  }
+
+  .error-boundary-actions {
+    flex-direction: column;
+  }
+
+  .error-boundary-button {
+    width: 100%;
+    min-height: 46px;
+  }
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,16 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, useLocation } from 'react-router-dom';
 import App from './App';
 import ErrorBoundary from './ErrorBoundary';
 import './index.css';
 
+function RoutedApp() {
+  const location = useLocation();
+
+  return (
+    <ErrorBoundary resetKey={location.pathname}>
+      <App />
+    </ErrorBoundary>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ErrorBoundary>
+    <BrowserRouter>
+      <RoutedApp />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
Closes #121
Closes #122
Closes #120
Closes #113

## Changes
- reset the global ErrorBoundary on route changes so users can recover from crashes without a hard refresh
- improved fallback error UX with clearer guidance, optional technical detail, and mobile-friendly full-width actions
- improved admin campaigns mobile layout by stacking intro/loading/error content and removing inline-only spacing styles
- improved campaign detail mobile error state spacing and touch-friendly stacked action buttons

## Testing
- unable to run frontend build in this environment because workspace dependency tooling is missing (vite binary not found in frontend/node_modules/.bin)
- manually verified code paths and responsive CSS breakpoints in changed files
