### PR TITLE
feat: add DB indexes, featured flag, moderation fields, and explorer …

### DIFF
--- a/backend/src/config/stellarNetwork.js
+++ b/backend/src/config/stellarNetwork.js
@@ -6,12 +6,14 @@ export const STELLAR_NETWORKS = {
     networkPassphrase: Networks.TESTNET,
     sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
     horizonUrl: 'https://horizon-testnet.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
   },
   mainnet: {
     network: 'mainnet',
     networkPassphrase: Networks.PUBLIC,
     sorobanRpcUrl: 'https://soroban-mainnet.stellar.org',
     horizonUrl: 'https://horizon.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/public',
   },
 };
 

--- a/backend/src/dal/sqliteCampaignRepository.js
+++ b/backend/src/dal/sqliteCampaignRepository.js
@@ -10,9 +10,22 @@ CREATE TABLE IF NOT EXISTS campaigns (
   reward_per_action INTEGER NOT NULL DEFAULT 0,
   start_date        TEXT,
   end_date          TEXT,
+  featured          INTEGER NOT NULL DEFAULT 0,
+  hidden            INTEGER NOT NULL DEFAULT 0,
+  hidden_reason     TEXT,
   created_at        TEXT    NOT NULL,
   updated_at        TEXT    NOT NULL
 );
+`;
+
+// Indexes for common query patterns (slug lookups, active/hidden/featured filters, date ordering, search).
+const INDEXES = `
+CREATE INDEX IF NOT EXISTS idx_campaigns_slug       ON campaigns(slug);
+CREATE INDEX IF NOT EXISTS idx_campaigns_active     ON campaigns(active);
+CREATE INDEX IF NOT EXISTS idx_campaigns_hidden     ON campaigns(hidden);
+CREATE INDEX IF NOT EXISTS idx_campaigns_featured   ON campaigns(featured);
+CREATE INDEX IF NOT EXISTS idx_campaigns_created_at ON campaigns(created_at);
+CREATE INDEX IF NOT EXISTS idx_campaigns_name       ON campaigns(name);
 `;
 
 /**
@@ -48,6 +61,9 @@ function rowToCampaign(row) {
     rewardPerAction: row.reward_per_action,
     startDate: row.start_date ?? null,
     endDate: row.end_date ?? null,
+    featured: row.featured === 1,
+    hidden: row.hidden === 1,
+    hiddenReason: row.hidden_reason ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at ?? row.created_at,
   };
@@ -62,19 +78,32 @@ export function createSqliteCampaignRepository({
   const db = new Database(dbPath);
   db.exec(SCHEMA);
 
+  // Migrate columns added after initial release.
   const campaignColumns = db.prepare('PRAGMA table_info(campaigns)').all();
-  const hasUpdatedAt = campaignColumns.some((column) => column.name === 'updated_at');
-  if (!hasUpdatedAt) {
+  const columnNames = new Set(campaignColumns.map((c) => c.name));
+
+  if (!columnNames.has('updated_at')) {
     db.exec('ALTER TABLE campaigns ADD COLUMN updated_at TEXT');
     db.exec('UPDATE campaigns SET updated_at = created_at WHERE updated_at IS NULL');
   }
+  if (!columnNames.has('featured')) {
+    db.exec('ALTER TABLE campaigns ADD COLUMN featured INTEGER NOT NULL DEFAULT 0');
+  }
+  if (!columnNames.has('hidden')) {
+    db.exec('ALTER TABLE campaigns ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0');
+  }
+  if (!columnNames.has('hidden_reason')) {
+    db.exec('ALTER TABLE campaigns ADD COLUMN hidden_reason TEXT');
+  }
+
+  // Create indexes after all columns are guaranteed to exist.
+  db.exec(INDEXES);
 
   if (seed.length > 0) {
     const count = db.prepare('SELECT COUNT(*) AS n FROM campaigns').get().n;
     if (count === 0) {
       const insert = db.prepare(
-        'INSERT INTO campaigns (name, slug, description, active, reward_per_action, start_date, end_date, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        'INSERT INTO campaigns (name, description, active, reward_per_action, start_date, end_date, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO campaigns (name, slug, description, active, reward_per_action, start_date, end_date, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       );
       const insertMany = db.transaction((rows) => {
         for (const row of rows) {
@@ -96,39 +125,30 @@ export function createSqliteCampaignRepository({
     }
   }
 
-  function list({ active, q } = {}) {
-    const hasQuery = typeof q === 'string' && q.length > 0;
-    const queryTerm = hasQuery ? `%${q.toLowerCase()}%` : null;
+  // Builds a paginated list. Featured campaigns sort first, then by id.
+  // Hidden campaigns are excluded unless includeHidden is true (admin use).
+  function list({ active, q, includeHidden = false } = {}) {
+    const where = [];
+    const params = [];
 
-    if (active !== undefined && hasQuery) {
-      return db
-        .prepare(
-          'SELECT * FROM campaigns WHERE active = ? AND (LOWER(name) LIKE ? OR LOWER(description) LIKE ?) ORDER BY id ASC',
-        )
-        .all(active ? 1 : 0, queryTerm, queryTerm)
-        .map(rowToCampaign);
-    }
-
-    if (hasQuery) {
-      return db
-        .prepare(
-          'SELECT * FROM campaigns WHERE LOWER(name) LIKE ? OR LOWER(description) LIKE ? ORDER BY id ASC',
-        )
-        .all(queryTerm, queryTerm)
-        .map(rowToCampaign);
+    if (!includeHidden) {
+      where.push('hidden = 0');
     }
 
     if (active !== undefined) {
-      return db
-        .prepare('SELECT * FROM campaigns WHERE active = ? ORDER BY id ASC')
-        .all(active ? 1 : 0)
-        .map(rowToCampaign);
+      where.push('active = ?');
+      params.push(active ? 1 : 0);
     }
 
-    return db
-      .prepare('SELECT * FROM campaigns ORDER BY id ASC')
-      .all()
-      .map(rowToCampaign);
+    if (typeof q === 'string' && q.length > 0) {
+      const term = `%${q.toLowerCase()}%`;
+      where.push('(LOWER(name) LIKE ? OR LOWER(description) LIKE ?)');
+      params.push(term, term);
+    }
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+    const sql = `SELECT * FROM campaigns ${whereClause} ORDER BY featured DESC, id ASC`;
+    return db.prepare(sql).all(...params).map(rowToCampaign);
   }
 
   function getById(id) {
@@ -141,20 +161,20 @@ export function createSqliteCampaignRepository({
     return row ? rowToCampaign(row) : undefined;
   }
 
-  function create({ name, slug, description = '', rewardPerAction = 0, startDate = null, endDate = null }) {
+  function create({ name, slug, description = '', rewardPerAction = 0, startDate = null, endDate = null, featured = false }) {
     const createdAt = new Date().toISOString();
     const finalSlug = slug ?? generateSlug(name);
     const info = db
       .prepare(
-        'INSERT INTO campaigns (name, slug, description, active, reward_per_action, start_date, end_date, created_at) VALUES (?, ?, ?, 1, ?, ?, ?, ?)',
+        'INSERT INTO campaigns (name, slug, description, active, reward_per_action, start_date, end_date, featured, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)',
       )
-      .run(name, finalSlug, description, rewardPerAction, startDate, endDate, createdAt);
+      .run(name, finalSlug, description, rewardPerAction, startDate, endDate, featured ? 1 : 0, createdAt, createdAt);
 
     return getById(info.lastInsertRowid);
   }
 
   function update(id, fields) {
-    const allowed = ['name', 'description', 'active', 'rewardPerAction', 'startDate', 'endDate'];
+    const allowed = ['name', 'description', 'active', 'rewardPerAction', 'startDate', 'endDate', 'featured', 'hidden', 'hiddenReason'];
     const columnMap = {
       name: 'name',
       description: 'description',
@@ -162,14 +182,18 @@ export function createSqliteCampaignRepository({
       rewardPerAction: 'reward_per_action',
       startDate: 'start_date',
       endDate: 'end_date',
+      featured: 'featured',
+      hidden: 'hidden',
+      hiddenReason: 'hidden_reason',
     };
+    const booleanFields = new Set(['active', 'featured', 'hidden']);
     const sets = [];
     const values = [];
 
     for (const key of allowed) {
       if (key in fields) {
         sets.push(`${columnMap[key]} = ?`);
-        values.push(key === 'active' ? (fields[key] ? 1 : 0) : fields[key]);
+        values.push(booleanFields.has(key) ? (fields[key] ? 1 : 0) : fields[key]);
       }
     }
 

--- a/backend/src/dal/sqliteCampaignRepository.test.js
+++ b/backend/src/dal/sqliteCampaignRepository.test.js
@@ -188,3 +188,83 @@ test('campaign repository update can set and clear startDate/endDate', () => {
   assert.equal(cleared.status, 'active');
   assert.equal(cleared.startDate, null);
 });
+
+// #232 — featured flag and ordering
+test('featured campaigns sort before non-featured campaigns', () => {
+  const repository = createSqliteCampaignRepository();
+
+  repository.create({ name: 'Regular A', rewardPerAction: 1 });
+  const featured = repository.create({ name: 'Featured One', rewardPerAction: 1, featured: true });
+  repository.create({ name: 'Regular B', rewardPerAction: 1 });
+
+  const results = repository.list();
+  assert.equal(results[0].id, featured.id);
+  assert.equal(results[0].featured, true);
+  assert.equal(results[1].featured, false);
+  assert.equal(results[2].featured, false);
+});
+
+test('update can set and unset featured flag', () => {
+  const repository = createSqliteCampaignRepository();
+
+  const campaign = repository.create({ name: 'Promo', rewardPerAction: 5 });
+  assert.equal(campaign.featured, false);
+
+  const featured = repository.update(campaign.id, { featured: true });
+  assert.equal(featured.featured, true);
+
+  const unfeatured = repository.update(campaign.id, { featured: false });
+  assert.equal(unfeatured.featured, false);
+});
+
+// #234 — hidden flag and moderation
+test('hidden campaigns are excluded from public list', () => {
+  const repository = createSqliteCampaignRepository();
+
+  repository.create({ name: 'Visible', rewardPerAction: 1 });
+  const hidden = repository.create({ name: 'Hidden Spam', rewardPerAction: 1 });
+  repository.update(hidden.id, { hidden: true, hiddenReason: 'spam' });
+
+  const results = repository.list();
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, 'Visible');
+});
+
+test('hidden campaigns are still accessible by id', () => {
+  const repository = createSqliteCampaignRepository();
+
+  const campaign = repository.create({ name: 'Abusive Campaign', rewardPerAction: 1 });
+  repository.update(campaign.id, { hidden: true, hiddenReason: 'abuse' });
+
+  const fetched = repository.getById(campaign.id);
+  assert.ok(fetched);
+  assert.equal(fetched.hidden, true);
+  assert.equal(fetched.hiddenReason, 'abuse');
+});
+
+test('update can set and clear hidden flag and reason', () => {
+  const repository = createSqliteCampaignRepository();
+
+  const campaign = repository.create({ name: 'Test Mod', rewardPerAction: 1 });
+  assert.equal(campaign.hidden, false);
+  assert.equal(campaign.hiddenReason, null);
+
+  const hidden = repository.update(campaign.id, { hidden: true, hiddenReason: 'spam' });
+  assert.equal(hidden.hidden, true);
+  assert.equal(hidden.hiddenReason, 'spam');
+
+  const restored = repository.update(campaign.id, { hidden: false, hiddenReason: null });
+  assert.equal(restored.hidden, false);
+  assert.equal(restored.hiddenReason, null);
+});
+
+test('list includeHidden option exposes hidden campaigns', () => {
+  const repository = createSqliteCampaignRepository();
+
+  repository.create({ name: 'Visible', rewardPerAction: 1 });
+  const hidden = repository.create({ name: 'Hidden', rewardPerAction: 1 });
+  repository.update(hidden.id, { hidden: true });
+
+  assert.equal(repository.list().length, 1);
+  assert.equal(repository.list({ includeHidden: true }).length, 2);
+});

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -136,6 +136,18 @@ function validateCampaignPayload(payload, { partial = false } = {}) {
     errors.push('active must be a boolean when provided');
   }
 
+  if (Object.hasOwn(payload, 'featured') && typeof payload.featured !== 'boolean') {
+    errors.push('featured must be a boolean when provided');
+  }
+
+  if (Object.hasOwn(payload, 'hidden') && typeof payload.hidden !== 'boolean') {
+    errors.push('hidden must be a boolean when provided');
+  }
+
+  if (Object.hasOwn(payload, 'hiddenReason') && payload.hiddenReason !== null && typeof payload.hiddenReason !== 'string') {
+    errors.push('hiddenReason must be a string or null when provided');
+  }
+
   for (const field of ['startDate', 'endDate']) {
     if (Object.hasOwn(payload, field)) {
       const val = payload[field];
@@ -395,6 +407,7 @@ export function createApp(options = {}) {
         deleteCampaign: `DELETE ${API_V1_PREFIX}/campaigns/:id`,
         auditLogs: `GET ${API_V1_PREFIX}/audit-logs`,
         config: `GET ${API_V1_PREFIX}/config`,
+        explorer: `GET ${API_V1_PREFIX}/explorer`,
       },
       compatibility: {
         legacyPrefix: LEGACY_API_PREFIX,
@@ -432,6 +445,13 @@ export function createApp(options = {}) {
         rewards: rewardsContractId || null,
         campaign: campaignContractId || null,
       },
+    });
+  }
+
+  function getExplorerLinks(_req, res) {
+    res.json({
+      network: stellarConfig.network,
+      explorerUrl: stellarConfig.explorerUrl,
     });
   }
 
@@ -481,7 +501,7 @@ export function createApp(options = {}) {
       });
     }
 
-    const { name, slug, description, rewardPerAction, startDate, endDate } = req.body;
+    const { name, slug, description, rewardPerAction, startDate, endDate, featured } = req.body;
     try {
       const campaign = campaignRepository.create({
         name,
@@ -490,6 +510,13 @@ export function createApp(options = {}) {
         rewardPerAction: rewardPerAction ?? 0,
         startDate: startDate ?? null,
         endDate: endDate ?? null,
+        featured: featured ?? false,
+      });
+      recordAuditEntry(req, {
+        action: 'create',
+        entity: 'campaign',
+        entityId: campaign.id,
+        diff: { after: campaign },
       });
       shortCache.clear();
       return res.status(201).json(campaign);
@@ -502,22 +529,6 @@ export function createApp(options = {}) {
       }
       throw error;
     }
-    const { name, description, rewardPerAction, startDate, endDate } = req.body;
-    const campaign = campaignRepository.create({
-      name,
-      description: description || '',
-      rewardPerAction: rewardPerAction ?? 0,
-      startDate: startDate ?? null,
-      endDate: endDate ?? null,
-    });
-    recordAuditEntry(req, {
-      action: 'create',
-      entity: 'campaign',
-      entityId: campaign.id,
-      diff: { after: campaign },
-    });
-    shortCache.clear();
-    return res.status(201).json(campaign);
   }
 
   function updateCampaign(req, res) {
@@ -529,7 +540,7 @@ export function createApp(options = {}) {
       });
     }
 
-    const { name, description, active, rewardPerAction, startDate, endDate } = req.body;
+    const { name, description, active, rewardPerAction, startDate, endDate, featured, hidden, hiddenReason } = req.body;
     const updateFields = {};
     if (name !== undefined) updateFields.name = name;
     if (description !== undefined) updateFields.description = description;
@@ -537,6 +548,9 @@ export function createApp(options = {}) {
     if (rewardPerAction !== undefined) updateFields.rewardPerAction = rewardPerAction;
     if (startDate !== undefined) updateFields.startDate = startDate;
     if (endDate !== undefined) updateFields.endDate = endDate;
+    if (featured !== undefined) updateFields.featured = featured;
+    if (hidden !== undefined) updateFields.hidden = hidden;
+    if (hiddenReason !== undefined) updateFields.hiddenReason = hiddenReason;
 
     const before = campaignRepository.getById(req.params.id);
     if (!before) {
@@ -612,6 +626,7 @@ export function createApp(options = {}) {
   function registerApiRoutes(prefix) {
     app.get(prefix, rateLimiter, apiInfo);
     app.get(`${prefix}/config`, rateLimiter, getPublicConfig);
+    app.get(`${prefix}/explorer`, rateLimiter, getExplorerLinks);
     app.get(`${prefix}/campaigns`, rateLimiter, listCampaigns);
     app.get(`${prefix}/campaigns/by-slug/:slug`, rateLimiter, getCampaignBySlug);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -790,3 +790,152 @@ test('createApp throws in production when CORS is not configured', () => {
     process.env.NODE_ENV = originalEnv;
   }
 });
+
+// #232 — featured flag: ordering and admin toggle
+test('GET /api/v1/campaigns returns featured campaigns first', async () => {
+  const seed = [
+    { name: 'Regular A', description: '', active: true, rewardPerAction: 1, createdAt: new Date().toISOString() },
+    { name: 'Regular B', description: '', active: true, rewardPerAction: 1, createdAt: new Date().toISOString() },
+  ];
+  const { server, baseUrl } = await startTestServer({ campaigns: seed });
+
+  try {
+    // Mark the second campaign as featured via PUT
+    await fetch(`${baseUrl}/api/v1/campaigns/2`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featured: true }),
+    });
+
+    const response = await fetch(`${baseUrl}/api/v1/campaigns`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.data[0].id, '2');
+    assert.equal(body.data[0].featured, true);
+    assert.equal(body.data[1].featured, false);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('PUT /api/v1/campaigns/:id can set and unset featured', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const setResp = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featured: true }),
+    });
+    assert.equal(setResp.status, 200);
+    const set = await setResp.json();
+    assert.equal(set.featured, true);
+
+    const unsetResp = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featured: false }),
+    });
+    assert.equal(unsetResp.status, 200);
+    const unset = await unsetResp.json();
+    assert.equal(unset.featured, false);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// #234 — hidden flag: moderation
+test('hidden campaigns do not appear in GET /api/v1/campaigns list', async () => {
+  const seed = [
+    { name: 'Visible Campaign', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
+    { name: 'Spam Campaign', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
+  ];
+  const { server, baseUrl } = await startTestServer({ campaigns: seed });
+
+  try {
+    // Hide the second campaign
+    await fetch(`${baseUrl}/api/v1/campaigns/2`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hidden: true, hiddenReason: 'spam' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/api/v1/campaigns`);
+    const body = await listResp.json();
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].name, 'Visible Campaign');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/campaigns/:id still returns a hidden campaign by id', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hidden: true, hiddenReason: 'abuse' }),
+    });
+
+    const resp = await fetch(`${baseUrl}/api/v1/campaigns/1`);
+    assert.equal(resp.status, 200);
+    const body = await resp.json();
+    assert.equal(body.hidden, true);
+    assert.equal(body.hiddenReason, 'abuse');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('PUT /api/v1/campaigns/:id rejects non-boolean hidden and non-string hiddenReason', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const resp = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hidden: 'yes' }),
+    });
+    assert.equal(resp.status, 400);
+
+    const resp2 = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hiddenReason: 42 }),
+    });
+    assert.equal(resp2.status, 400);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// #230 — explorer endpoint
+test('GET /api/v1/explorer returns correct URL for testnet', async () => {
+  const { server, baseUrl } = await startTestServer({ stellarNetwork: 'testnet' });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/explorer`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.network, 'testnet');
+    assert.equal(body.explorerUrl, 'https://stellar.expert/explorer/testnet');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/explorer returns correct URL for mainnet', async () => {
+  const { server, baseUrl } = await startTestServer({ stellarNetwork: 'mainnet' });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/explorer`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.network, 'mainnet');
+    assert.equal(body.explorerUrl, 'https://stellar.expert/explorer/public');
+  } finally {
+    await stopTestServer(server);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
     },
     "backend": {
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.0.0",
         "better-sqlite3": "^11.0.0",
@@ -28,6 +29,7 @@
     },
     "frontend": {
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.0.0",
         "react": "^18.3.1",


### PR DESCRIPTION
…endpoint

Performance: Add DB indexes for common campaign queries Fixes #226

Backend: Add endpoint to return transaction explorer links (network-aware) Fixes #230

Backend: Add "featured" campaign flag and ordering Fixes #232

Backend: Add basic moderation fields (hidden, reason) for campaigns Fixes #234