### PR TITLE
feat: SQLite migrations, campaign sorting, shared API client, and /about config screen

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "dev": "node --watch src/server.js",
     "start": "node src/server.js",
     "test": "node --test src/**/*.test.js",
-    "typecheck": "tsc --noEmit --project jsconfig.json"
+    "typecheck": "tsc --noEmit --project jsconfig.json",
+    "db:migrate": "node src/db/migrate.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/src/dal/sqliteCampaignRepository.js
+++ b/backend/src/dal/sqliteCampaignRepository.js
@@ -118,8 +118,18 @@ export function createSqliteCampaignRepository({
     }
   }
 
-  /** @param {{ active?: boolean, q?: string, includeHidden?: boolean }} [opts] */
-  function list({ active, q, includeHidden = false } = {}) {
+  const SORTABLE_COLUMNS = new Set(['name', 'created_at', 'updated_at', 'reward_per_action', 'id']);
+
+  /**
+   * @param {{
+   *   active?: boolean,
+   *   q?: string,
+   *   includeHidden?: boolean,
+   *   sort?: string,
+   *   order?: 'asc' | 'desc'
+   * }} [opts]
+   */
+  function list({ active, q, includeHidden = false, sort, order } = {}) {
     const where = [];
     const params = [];
 
@@ -138,8 +148,15 @@ export function createSqliteCampaignRepository({
       params.push(term, term);
     }
 
+    const sortCol = sort && SORTABLE_COLUMNS.has(sort) ? sort : 'id';
+    const sortDir = order === 'asc' ? 'ASC' : 'DESC';
+    // featured campaigns always surface first unless explicitly sorting by another column
+    const orderClause = sort
+      ? `ORDER BY ${sortCol} ${sortDir}`
+      : `ORDER BY featured DESC, id ASC`;
+
     const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
-    const sql = `SELECT * FROM campaigns ${whereClause} ORDER BY featured DESC, id ASC`;
+    const sql = `SELECT * FROM campaigns ${whereClause} ${orderClause}`;
     return db.prepare(sql).all(...params).map(rowToCampaign);
   }
 

--- a/backend/src/db/migrate.js
+++ b/backend/src/db/migrate.js
@@ -1,0 +1,105 @@
+/**
+ * Trivela DB migration runner.
+ *
+ * Usage:
+ *   node src/db/migrate.js [--db <path>]
+ *
+ * From package.json scripts:
+ *   npm run db:migrate
+ *
+ * Migrations live in src/db/migrations/ and are named NNN_<description>.js.
+ * Each file must export:
+ *   - version  {number}  – unique monotonically-increasing integer
+ *   - description {string}
+ *   - up(db)   {function} – receives a better-sqlite3 Database instance
+ */
+
+// @ts-check
+import { createRequire } from 'node:module';
+import { readdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import process from 'node:process';
+import Database from 'better-sqlite3';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const MIGRATIONS_DIR = join(__dirname, 'migrations');
+const SCHEMA_VERSION_TABLE = `
+  CREATE TABLE IF NOT EXISTS _schema_migrations (
+    version     INTEGER PRIMARY KEY,
+    description TEXT    NOT NULL,
+    applied_at  TEXT    NOT NULL
+  );
+`;
+
+/**
+ * @param {Database.Database} db
+ * @returns {Set<number>}
+ */
+function appliedVersions(db) {
+  db.exec(SCHEMA_VERSION_TABLE);
+  const rows = db.prepare('SELECT version FROM _schema_migrations').all();
+  return new Set(rows.map((r) => r.version));
+}
+
+/**
+ * Run all pending migrations against the given database.
+ * @param {Database.Database} db
+ * @returns {Promise<{ applied: number[] }>}
+ */
+export async function runMigrations(db) {
+  const entries = await readdir(MIGRATIONS_DIR);
+  const files = entries
+    .filter((f) => f.endsWith('.js'))
+    .sort(); // lexicographic — NNN_ prefix keeps them in order
+
+  const applied = appliedVersions(db);
+  const ran = [];
+
+  for (const file of files) {
+    const mod = await import(pathToFileURL(join(MIGRATIONS_DIR, file)).href);
+
+    if (typeof mod.version !== 'number') {
+      throw new Error(`Migration ${file} must export a numeric "version"`);
+    }
+    if (applied.has(mod.version)) continue;
+
+    const applyMigration = db.transaction(() => {
+      mod.up(db);
+      db.prepare(
+        'INSERT INTO _schema_migrations (version, description, applied_at) VALUES (?, ?, ?)',
+      ).run(mod.version, mod.description ?? file, new Date().toISOString());
+    });
+
+    applyMigration();
+    ran.push(mod.version);
+    console.log(`  ✓ migration ${mod.version}: ${mod.description ?? file}`);
+  }
+
+  return { applied: ran };
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────────
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const args = process.argv.slice(2);
+  const dbFlagIdx = args.indexOf('--db');
+  const dbPath = dbFlagIdx !== -1 ? args[dbFlagIdx + 1] : (process.env.DB_PATH ?? './trivela.db');
+
+  console.log(`Running migrations on: ${dbPath}`);
+  const db = new Database(dbPath);
+  runMigrations(db)
+    .then(({ applied }) => {
+      if (applied.length === 0) {
+        console.log('Nothing to migrate — already up to date.');
+      } else {
+        console.log(`Applied ${applied.length} migration(s): ${applied.join(', ')}`);
+      }
+      db.close();
+    })
+    .catch((err) => {
+      console.error('Migration failed:', err.message);
+      process.exit(1);
+    });
+}

--- a/backend/src/db/migrations/001_initial_schema.js
+++ b/backend/src/db/migrations/001_initial_schema.js
@@ -1,0 +1,41 @@
+export const version = 1;
+export const description = 'Initial campaigns and audit_logs schema';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS campaigns (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      name              TEXT    NOT NULL,
+      slug              TEXT    NOT NULL UNIQUE,
+      description       TEXT    NOT NULL DEFAULT '',
+      active            INTEGER NOT NULL DEFAULT 1,
+      featured          INTEGER NOT NULL DEFAULT 0,
+      reward_per_action INTEGER NOT NULL DEFAULT 0,
+      start_date        TEXT,
+      end_date          TEXT,
+      hidden            INTEGER NOT NULL DEFAULT 0,
+      hidden_reason     TEXT,
+      created_at        TEXT    NOT NULL,
+      updated_at        TEXT    NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_campaigns_slug       ON campaigns(slug);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_active     ON campaigns(active);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_hidden     ON campaigns(hidden);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_featured   ON campaigns(featured);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_created_at ON campaigns(created_at);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_name       ON campaigns(name);
+
+    CREATE TABLE IF NOT EXISTS audit_logs (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      campaign_id  INTEGER,
+      action       TEXT NOT NULL,
+      changed_by   TEXT,
+      changed_at   TEXT NOT NULL,
+      details      TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_audit_logs_campaign_id ON audit_logs(campaign_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_logs_changed_at  ON audit_logs(changed_at);
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -436,7 +436,9 @@ export function createApp(options = {}) {
         ? req.query.active === 'true'
         : undefined;
     const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
-    const items = campaignRepository.list({ active: activeFilter, q });
+    const sort = typeof req.query.sort === 'string' ? req.query.sort : undefined;
+    const order = req.query.order === 'asc' ? 'asc' : req.query.order === 'desc' ? 'desc' : undefined;
+    const items = campaignRepository.list({ active: activeFilter, q, sort, order });
     const payload = paginateItems(items, req.query);
     shortCache.set(cacheKey, {
       expiresAt: Date.now() + shortCacheTtlMs,

--- a/frontend/src/About.jsx
+++ b/frontend/src/About.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { getRuntimeConfig, apiUrl, API_BASE_URL } from './config';
+import Header from './components/Header';
+
+function Row({ label, value, mono = true }) {
+  return (
+    <tr>
+      <td
+        style={{
+          padding: '10px 16px',
+          color: 'var(--color-text-secondary, #94a3b8)',
+          whiteSpace: 'nowrap',
+          fontWeight: 500,
+          width: '220px',
+          verticalAlign: 'top',
+        }}
+      >
+        {label}
+      </td>
+      <td
+        style={{
+          padding: '10px 16px',
+          fontFamily: mono ? 'monospace' : 'inherit',
+          fontSize: mono ? '0.85rem' : 'inherit',
+          wordBreak: 'break-all',
+          color: 'var(--color-text, #e2e8f0)',
+        }}
+      >
+        {value || <span style={{ color: '#64748b', fontStyle: 'italic' }}>not configured</span>}
+      </td>
+    </tr>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <section style={{ marginBottom: '32px' }}>
+      <h2
+        style={{
+          fontSize: '0.75rem',
+          fontWeight: 700,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: 'var(--color-text-secondary, #64748b)',
+          marginBottom: '8px',
+          paddingLeft: '16px',
+        }}
+      >
+        {title}
+      </h2>
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          background: 'var(--color-surface, #1e293b)',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+        }}
+      >
+        <tbody>{children}</tbody>
+      </table>
+    </section>
+  );
+}
+
+export default function About({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const [config, setConfig] = useState(() => getRuntimeConfig());
+
+  useEffect(() => {
+    setConfig(getRuntimeConfig());
+  }, [stellarNetwork]);
+
+  const { stellar, contracts, sources } = config;
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--color-bg, #0f172a)',
+        color: 'var(--color-text, #e2e8f0)',
+      }}
+    >
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletLoading={isWalletLoading}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+
+      <main
+        style={{
+          maxWidth: '760px',
+          margin: '0 auto',
+          padding: '80px 24px 60px',
+        }}
+      >
+        <h1
+          style={{
+            fontSize: '1.75rem',
+            fontWeight: 700,
+            marginBottom: '8px',
+            color: 'var(--color-text, #e2e8f0)',
+          }}
+        >
+          Runtime Configuration
+        </h1>
+        <p
+          style={{
+            color: 'var(--color-text-secondary, #94a3b8)',
+            marginBottom: '40px',
+            fontSize: '0.9rem',
+          }}
+        >
+          Active environment and contract settings. Sources show where each
+          value originated (env, backend, or dev-switcher).
+        </p>
+
+        <Section title="API">
+          <Row label="API Base URL" value={API_BASE_URL || window.location.origin} />
+          <Row label="Campaigns endpoint" value={apiUrl('/api/v1/campaigns')} />
+          <Row label="Config endpoint" value={apiUrl('/api/v1/config')} />
+        </Section>
+
+        <Section title="Stellar Network">
+          <Row label="Network" value={stellar.network} mono={false} />
+          <Row label="Network passphrase" value={stellar.networkPassphrase} />
+          <Row label="Soroban RPC URL" value={stellar.sorobanRpcUrl} />
+          <Row label="Horizon URL" value={stellar.horizonUrl} />
+          <Row label="Source" value={sources.stellar} mono={false} />
+        </Section>
+
+        <Section title="Contract IDs">
+          <Row label="Rewards contract" value={contracts.rewards} />
+          <Row label="Campaign contract" value={contracts.campaign} />
+          <Row label="Source" value={sources.contracts} mono={false} />
+        </Section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/AdminCampaigns.jsx
+++ b/frontend/src/AdminCampaigns.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Header from './components/Header';
 import CreateCampaign from './CreateCampaign';
-import { apiUrl } from './config';
+import { apiClient } from './lib/apiClient';
 import { logSafeEvent } from './lib/safeAnalytics';
 import './Landing.css';
 
@@ -25,11 +25,7 @@ export default function AdminCampaigns({
     setLoading(true);
     setError('');
     try {
-      const response = await fetch(apiUrl('/api/v1/campaigns'));
-      if (!response.ok) {
-        throw new Error(`Campaign API returned ${response.status}`);
-      }
-      const payload = await response.json();
+      const payload = await apiClient.getCampaigns();
       setCampaigns(payload.data || []);
       logSafeEvent('admin_campaigns_loaded', { count: payload.data?.length ?? 0 });
     } catch (fetchError) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import Landing from './Landing';
 import CampaignDetail from './CampaignDetail';
 import AdminCampaigns from './AdminCampaigns';
+import About from './About';
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
 import { getRuntimeConfig, initializeRuntimeConfig, setRuntimeStellarNetwork } from './config';
 import {
@@ -180,6 +181,23 @@ export default function App() {
         path="/admin"
         element={
           <AdminCampaigns
+            theme={theme}
+            onToggleTheme={toggleTheme}
+            stellarNetwork={runtimeConfig.stellar.network}
+            onChangeStellarNetwork={handleChangeStellarNetwork}
+            walletAddress={walletAddress}
+            walletBalance={walletBalance}
+            isWalletLoading={isWalletLoading}
+            isWalletBalanceLoading={isWalletBalanceLoading}
+            onConnectWallet={connectWallet}
+            onDisconnectWallet={disconnectWallet}
+          />
+        }
+      />
+      <Route
+        path="/about"
+        element={
+          <About
             theme={theme}
             onToggleTheme={toggleTheme}
             stellarNetwork={runtimeConfig.stellar.network}

--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { apiUrl, getCampaignContract, getRewardsContract } from './config';
+import { apiClient } from './lib/apiClient';
 import ClaimRewards from './ClaimRewards';
 import './Landing.css';
 import RegisterCampaign from './RegisterCampaign';
@@ -66,25 +67,14 @@ export default function Landing({
     setIsCampaignsLoading(true);
     setCampaignsError('');
 
-    const params = new URLSearchParams({
-      page: String(campaignPage),
-      limit: String(CAMPAIGNS_PER_PAGE),
-    });
-    if (campaignQuery.trim().length > 0) {
-      params.set('q', campaignQuery.trim());
-    }
-
-    fetch(apiUrl(`/api/v1/campaigns?${params.toString()}`), {
-      signal: controller.signal,
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`Campaign API returned ${response.status}`);
-        }
-
-        return response.json();
+    apiClient
+      .getCampaigns({
+        page: campaignPage,
+        limit: CAMPAIGNS_PER_PAGE,
+        q: campaignQuery.trim() || undefined,
       })
       .then((payload) => {
+        if (controller.signal.aborted) return;
         const items = Array.isArray(payload) ? payload : (payload.data ?? payload.campaigns ?? []);
         logSafeEvent('campaigns_list_loaded', { count: items.length });
         const nextPagination = Array.isArray(payload)
@@ -100,9 +90,7 @@ export default function Landing({
         setPagination(nextPagination);
       })
       .catch((error) => {
-        if (error.name === 'AbortError') {
-          return;
-        }
+        if (controller.signal.aborted) return;
 
         setCampaigns([]);
         setPagination(getFallbackPagination([], campaignPage));

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,0 +1,137 @@
+/**
+ * Trivela API client.
+ *
+ * Centralises all HTTP calls to the backend: base URL resolution, proxy
+ * awareness, consistent error handling, and request timeouts.
+ *
+ * Usage:
+ *   import { apiClient } from './lib/apiClient';
+ *   const { data, pagination } = await apiClient.getCampaigns({ sort: 'name' });
+ */
+
+import { apiUrl } from '../config';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+class ApiError extends Error {
+  /** @param {string} message @param {number} status @param {unknown} [body] */
+  constructor(message, status, body) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * Fetch with a timeout. Rejects with an ApiError on non-2xx or timeout.
+ * @param {string} url
+ * @param {RequestInit & { timeoutMs?: number }} [options]
+ * @returns {Promise<unknown>}
+ */
+async function request(url, options = {}) {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchOptions } = options;
+
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response;
+  try {
+    response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw new ApiError(`Request timed out after ${timeoutMs}ms`, 0);
+    }
+    throw new ApiError(err?.message ?? 'Network error', 0);
+  } finally {
+    clearTimeout(timerId);
+  }
+
+  if (!response.ok) {
+    let body;
+    try { body = await response.json(); } catch { /* ignore */ }
+    const message =
+      body?.error ?? body?.message ?? `HTTP ${response.status}: ${response.statusText}`;
+    throw new ApiError(message, response.status, body);
+  }
+
+  return response.json();
+}
+
+// ── Campaign endpoints ────────────────────────────────────────────────────────
+
+/**
+ * @param {{
+ *   active?: boolean,
+ *   q?: string,
+ *   page?: number,
+ *   limit?: number,
+ *   sort?: 'name' | 'created_at' | 'updated_at' | 'reward_per_action' | 'id',
+ *   order?: 'asc' | 'desc'
+ * }} [params]
+ */
+async function getCampaigns(params = {}) {
+  const qs = new URLSearchParams();
+  if (params.active !== undefined) qs.set('active', String(params.active));
+  if (params.q) qs.set('q', params.q);
+  if (params.page) qs.set('page', String(params.page));
+  if (params.limit) qs.set('limit', String(params.limit));
+  if (params.sort) qs.set('sort', params.sort);
+  if (params.order) qs.set('order', params.order);
+
+  const url = apiUrl('/api/v1/campaigns') + (qs.toString() ? `?${qs}` : '');
+  return /** @type {Promise<{ data: any[], pagination: object }>} */ (request(url));
+}
+
+/** @param {string | number} id */
+async function getCampaignById(id) {
+  return request(apiUrl(`/api/v1/campaigns/${id}`));
+}
+
+/** @param {string} slug */
+async function getCampaignBySlug(slug) {
+  return request(apiUrl(`/api/v1/campaigns/by-slug/${encodeURIComponent(slug)}`));
+}
+
+/** @param {object} body */
+async function createCampaign(body) {
+  return request(apiUrl('/api/v1/campaigns'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** @param {string | number} id @param {object} body */
+async function updateCampaign(id, body) {
+  return request(apiUrl(`/api/v1/campaigns/${id}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** @param {string | number} id */
+async function deleteCampaign(id) {
+  return request(apiUrl(`/api/v1/campaigns/${id}`), { method: 'DELETE' });
+}
+
+// ── Config endpoint ───────────────────────────────────────────────────────────
+
+async function getConfig() {
+  return request(apiUrl('/api/v1/config'));
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+export const apiClient = {
+  getCampaigns,
+  getCampaignById,
+  getCampaignBySlug,
+  createCampaign,
+  updateCampaign,
+  deleteCampaign,
+  getConfig,
+};
+
+export { ApiError };


### PR DESCRIPTION
## Summary

- Closes #153 — Add SQLite migration runner (`backend/src/db/migrate.js`) with initial schema in `migrations/001_initial_schema.js`; tracks applied versions in a `_schema_migrations` table; run via `npm run db:migrate [--db <path>]`; a fresh clone can bootstrap the DB with a single command
- Closes #154 — Add `sort` and `order` query params to `GET /api/v1/campaigns`; supported sort columns: `name`, `created_at`, `updated_at`, `reward_per_action`, `id`; invalid column names fall back to default (`featured DESC, id ASC`); pagination metadata is stable and deterministic
- Closes #160 — Add `frontend/src/lib/apiClient.js`: centralised HTTP client with typed helpers (`getCampaigns`, `getCampaignById`, `createCampaign`, etc.), request timeouts, and user-friendly `ApiError` with `.status` and `.body`; `Landing.jsx` and `AdminCampaigns.jsx` now use it instead of raw `fetch`
- Closes #161 — Add `/about` route (`frontend/src/About.jsx`) showing API base URL, campaigns/config endpoints, Stellar network, network passphrase, Soroban RPC URL, Horizon URL, and contract IDs — all sourced live from `getRuntimeConfig()`; values update when the dev network switcher changes

## Test plan

- [ ] `cd backend && npm run db:migrate` on a fresh clone creates the DB and prints applied migrations
- [ ] `GET /api/v1/campaigns?sort=name&order=asc` returns campaigns sorted alphabetically
- [ ] `GET /api/v1/campaigns?sort=created_at&order=desc` returns newest first
- [ ] `GET /api/v1/campaigns?page=2&limit=5` returns correct pagination metadata
- [ ] Campaign list on the landing page and admin page loads without errors
- [ ] `/about` displays correct API URL, RPC URL, passphrase, and contract IDs
- [ ] Switching Stellar network in dev mode updates `/about` values