### PR TITLE
Add contracts CI checks and deployment documentation.

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,0 +1,50 @@
+name: Contracts CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check contract formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint contracts
+        run: cargo clippy --workspace --all-targets -- -D warnings -A deprecated
+
+      - name: Run contract tests
+        run: cargo test --workspace
+
+      - name: Build Soroban WASM artifacts
+        run: |
+          if command -v stellar >/dev/null 2>&1; then
+            stellar contract build
+          else
+            echo "Stellar CLI is not installed in this runner; skipping Soroban WASM build."
+            echo "Install Stellar CLI to produce .wasm artifacts in CI."
+          fi

--- a/README.md
+++ b/README.md
@@ -84,6 +84,37 @@ cargo build --target wasm32-unknown-unknown --release -p trivela-rewards-contrac
 cargo build --target wasm32-unknown-unknown --release -p trivela-campaign-contract
 ```
 
+#### Building and deploying contracts
+
+Required environment for deploy commands:
+
+```bash
+export STELLAR_NETWORK=testnet
+export STELLAR_SOURCE=alice
+```
+
+`STELLAR_NETWORK` is your Stellar CLI network alias (for example `testnet` or `mainnet`), and `STELLAR_SOURCE` is the Stellar CLI identity to sign deploy transactions.
+
+Build commands:
+
+```bash
+stellar contract build
+```
+
+Deploy commands:
+
+```bash
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/trivela_rewards_contract.wasm \
+  --source "$STELLAR_SOURCE" \
+  --network "$STELLAR_NETWORK"
+
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/trivela_campaign_contract.wasm \
+  --source "$STELLAR_SOURCE" \
+  --network "$STELLAR_NETWORK"
+```
+
 #### Deploying to Testnet
 
 1. **Configure an Identity**:

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -98,11 +98,7 @@ fn verify_merkle_proof(
     &computed == root
 }
 
-fn require_admin_with_nonce(
-    env: &Env,
-    admin: &Address,
-    nonce: u64,
-) -> Result<(), Error> {
+fn require_admin_with_nonce(env: &Env, admin: &Address, nonce: u64) -> Result<(), Error> {
     admin.require_auth();
     let stored: Address = env.storage().instance().get(&ADMIN).unwrap();
     if &stored != admin {
@@ -162,7 +158,13 @@ impl CampaignContract {
     }
 
     /// Set registration time window (admin only).
-    pub fn set_window(env: Env, admin: Address, nonce: u64, start: u64, end: u64) -> Result<(), Error> {
+    pub fn set_window(
+        env: Env,
+        admin: Address,
+        nonce: u64,
+        start: u64,
+        end: u64,
+    ) -> Result<(), Error> {
         require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&START_TIME, &start);
         env.storage().instance().set(&END_TIME, &end);
@@ -194,7 +196,12 @@ impl CampaignContract {
     /// Once set, every `register` call must supply a valid `(leaf, proof)`.
     /// Remove the root by calling this again with a root of all zeros to
     /// revert to open registration.
-    pub fn set_merkle_root(env: Env, admin: Address, nonce: u64, root: BytesN<32>) -> Result<(), Error> {
+    pub fn set_merkle_root(
+        env: Env,
+        admin: Address,
+        nonce: u64,
+        root: BytesN<32>,
+    ) -> Result<(), Error> {
         require_admin_with_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&MERKLE_ROOT, &root);
         env.events().publish((SET_MERKLE_ROOT_EVENT,), root.clone());
@@ -244,11 +251,7 @@ impl CampaignContract {
         }
 
         // Merkle allowlist check – skipped when no root is stored.
-        if let Some(root) = env
-            .storage()
-            .instance()
-            .get::<_, BytesN<32>>(&MERKLE_ROOT)
-        {
+        if let Some(root) = env.storage().instance().get::<_, BytesN<32>>(&MERKLE_ROOT) {
             if !verify_merkle_proof(&env, leaf, &proof, &root) {
                 return Err(Error::NotInAllowlist);
             }

--- a/contracts/campaign/src/test.rs
+++ b/contracts/campaign/src/test.rs
@@ -215,7 +215,6 @@ fn test_register_with_valid_merkle_proof() {
 fn test_register_rejected_with_invalid_proof() {
     let (env, _contract_id, client) = setup();
     let admin = Address::generate(&env);
-    let p1 = Address::generate(&env);
     let p2 = Address::generate(&env);
     client.initialize(&admin);
 

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -245,7 +245,9 @@ impl RewardsContract {
         }
 
         for (user, new_balance) in staged.iter() {
-            env.storage().instance().set(&(BALANCE, user.clone()), &new_balance);
+            env.storage()
+                .instance()
+                .set(&(BALANCE, user.clone()), &new_balance);
         }
 
         // Emit credit event for each recipient

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -6,8 +6,8 @@ use super::*;
 use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal};
 use soroban_sdk::{BytesN, Vec as SdkVec};
-use trivela_campaign_contract::{CampaignContract, CampaignContractClient};
 use std::vec::Vec as StdVec;
+use trivela_campaign_contract::{CampaignContract, CampaignContractClient};
 
 fn seed_users(env: &Env, count: usize) -> StdVec<Address> {
     let mut users = StdVec::new();
@@ -384,6 +384,9 @@ fn test_randomized_points_accounting_invariants() {
         let expected_balance_total: u64 = expected_balances.iter().copied().sum();
 
         assert_eq!(observed_balance_total, expected_balance_total);
-        assert_eq!(observed_balance_total + client.total_claimed(), credited_total);
+        assert_eq!(
+            observed_balance_total + client.total_claimed(),
+            credited_total
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR completes all assigned open-source tasks in one branch by adding missing contract docs and CI hardening, while validating that the backend delete behavior and required Soroban contract tests are already implemented and passing.

### What was added/updated

- Added a dedicated **Contracts CI** workflow at `.github/workflows/contracts-ci.yml`:
  - Runs on `pull_request` and `push` to `main`
  - Enforces:
    - `cargo fmt --all -- --check`
    - `cargo clippy --workspace --all-targets -- -D warnings -A deprecated`
    - `cargo test --workspace`
  - Includes Soroban WASM build step:
    - Runs `stellar contract build` when Stellar CLI is available
    - Otherwise logs a clear skip reason

- Added a new **Building and deploying contracts** section in root `README.md` with:
  - Required env vars:
    - `STELLAR_NETWORK`
    - `STELLAR_SOURCE`
  - Exact build command:
    - `stellar contract build`
  - Exact deploy commands for both contracts:
    - rewards WASM deploy
    - campaign WASM deploy

- Applied Rust formatting updates from `cargo fmt` in contract files and fixed one test lint issue (unused variable).

## Assigned issue checklist

- [x] Add "Building and deploying contracts" section with exact build/deploy commands and required env
- [x] Remove campaign by id from in-memory store and return 404 if not found  
      (already present in repository; verified)
- [x] Add tests for:
  - [x] claim more than balance (expect error)
  - [x] credit overflow
  - [x] double register in campaign
  - [x] uninitialized access  
        (already present in repository; verified passing)
- [x] Add CI for contracts quality gates (format, lint, tests, WASM build behavior)

## Validation performed

- `cargo test --workspace` (contracts) passed locally
- `cargo clippy --workspace --all-targets -- -D warnings -A deprecated` passed locally
- `cargo fmt --all` applied
- Backend delete route and existing tests were reviewed for expected `404` behavior on missing campaign

## Notes

- Clippy in CI treats warnings as errors while allowing deprecation warnings (`-A deprecated`) to avoid failing on upstream Soroban SDK deprecation notices.
- WASM build step is explicit about when it is skipped (missing Stellar CLI), satisfying the requirement to either build artifacts or clearly document the skip reason.

closes #96 
closes #102 
closes #90 
closes #137 