### PR TITLE
feat: harden contract errors, pause handling, fuzz invariants, and CO…

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -121,10 +121,14 @@ function validateContractId(value, label) {
 
 /** @param {Record<string, unknown>} options @returns {import('express').Application} */
 export function createApp(options = {}) {
+  const isProduction = process.env.NODE_ENV === 'production';
   const jsonBodyLimit =
     /** @type {string} */ (options.jsonBodyLimit) ?? process.env.JSON_BODY_LIMIT ?? DEFAULT_JSON_BODY_LIMIT;
-  const corsAllowedOrigins =
-    /** @type {string | undefined} */ (options.corsAllowedOrigins) ?? process.env.CORS_ALLOWED_ORIGINS ?? process.env.CORS_ORIGIN;
+  const corsAllowedOriginsRaw =
+    /** @type {string | undefined} */ (options.corsAllowedOrigins) ??
+    process.env.CORS_ALLOWED_ORIGINS ??
+    process.env.CORS_ORIGIN ??
+    (isProduction ? '' : 'http://localhost:5173');
   const stellarConfig = resolveStellarNetworkConfig({
     network: /** @type {string} */ (options.stellarNetwork) ?? process.env.STELLAR_NETWORK,
     sorobanRpcUrl: /** @type {string} */ (options.sorobanRpcUrl) ?? process.env.SOROBAN_RPC_URL,
@@ -140,12 +144,11 @@ export function createApp(options = {}) {
     'CAMPAIGN_CONTRACT_ID',
   );
   const fetchImpl = /** @type {typeof fetch} */ (options.fetchImpl) ?? globalThis.fetch;
-  const allowedOrigins = parseAllowedOrigins(corsAllowedOrigins);
+  const allowedOrigins = parseAllowedOrigins(corsAllowedOriginsRaw);
 
-  const isProduction = process.env.NODE_ENV === 'production';
-  if (isProduction && (allowedOrigins.length === 0 || allowedOrigins.includes('*'))) {
+  if (isProduction && allowedOrigins.includes('*')) {
     throw new Error(
-      'CORS_ALLOWED_ORIGINS must be explicitly configured in production. Wildcard origins are not permitted.',
+      'Wildcard origins are not permitted in production.',
     );
   }
 

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -781,14 +781,22 @@ test('CORS rejects requests from non-allowed origins', async () => {
   }
 });
 
-test('createApp throws in production when CORS is not configured', () => {
+test('createApp defaults to deny-by-default CORS in production when not configured', async () => {
   const originalEnv = process.env.NODE_ENV;
   try {
     process.env.NODE_ENV = 'production';
-    assert.throws(
-      () => createApp({ corsAllowedOrigins: '' }),
-      /CORS_ALLOWED_ORIGINS must be explicitly configured in production/,
-    );
+    const { server, baseUrl } = await startTestServer({ corsAllowedOrigins: '' });
+    try {
+      const deniedResp = await fetch(`${baseUrl}/api/v1/campaigns`, {
+        headers: {
+          Origin: 'https://unknown-origin.example',
+        },
+      });
+      assert.equal(deniedResp.status, 200);
+      assert.strictEqual(deniedResp.headers.get('access-control-allow-origin'), null);
+    } finally {
+      await stopTestServer(server);
+    }
 
     assert.throws(
       () => createApp({ corsAllowedOrigins: '*' }),

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -43,7 +43,7 @@ use soroban_sdk::{
 pub enum Error {
     Unauthorized = 100,
     OutsideTimeWindow = 101,
-    CapacityReached = 102,
+    CapReached = 102,
     CampaignInactive = 103,
     NotInAllowlist = 104,
     UnsupportedMigration = 105,
@@ -306,7 +306,7 @@ impl CampaignContract {
                 .get(&PARTICIPANT_COUNT)
                 .unwrap_or(0);
             if count >= max_cap {
-                return Err(Error::CapacityReached);
+                return Err(Error::CapReached);
             }
         }
 

--- a/contracts/campaign/src/test.rs
+++ b/contracts/campaign/src/test.rs
@@ -209,7 +209,7 @@ fn test_capacity_reached() {
     let (leaf, proof) = no_proof_args(&env);
     assert!(client.register(&p1, &leaf, &proof));
     let result = client.try_register(&p2, &leaf, &proof);
-    assert_eq!(result, Err(Ok(Error::CapacityReached)));
+    assert_eq!(result, Err(Ok(Error::CapReached)));
 }
 
 // ── Merkle tests ──────────────────────────────────────────────────────────────

--- a/contracts/rewards/fuzz/fuzz_targets/fuzz_balance.rs
+++ b/contracts/rewards/fuzz/fuzz_targets/fuzz_balance.rs
@@ -11,8 +11,9 @@
 //! 1. After every operation the in-memory balance shadow matches the contract's
 //!    reported balance for every user.
 //! 2. `total_claimed` equals the running sum of every successful claim.
-//! 3. Overflow in `credit` is handled without panicking (returns an error).
-//! 4. Under-balance in `claim` is handled without panicking (returns an error).
+//! 3. `sum(balances) + total_claimed == total_successful_credits`.
+//! 4. Overflow in `credit` is handled without panicking (returns an error).
+//! 5. Under-balance in `claim` is handled without panicking (returns an error).
 
 #![no_main]
 
@@ -50,6 +51,7 @@ fn run(data: &[u8]) {
     // Shadow state tracked by the harness.
     let mut expected_balances = [0u64; NUM_USERS];
     let mut expected_total_claimed: u64 = 0;
+    let mut expected_total_credited: u64 = 0;
 
     let mut i = 0;
     while i + 9 < data.len() {
@@ -77,6 +79,9 @@ fn run(data: &[u8]) {
                     "credit: returned balance does not match expected"
                 );
                 expected_balances[user_idx] = new_bal;
+                expected_total_credited = expected_total_credited
+                    .checked_add(amount)
+                    .expect("successful credit total overflowed harness accounting");
             }
             // On Err(_) or Ok(Err(_)): overflow / limit exceeded — balance unchanged.
         } else {
@@ -103,6 +108,12 @@ fn run(data: &[u8]) {
                 "balance invariant violated for user {idx} after op {i}"
             );
         }
+        let shadow_balance_sum: u64 = expected_balances.iter().copied().sum();
+        assert_eq!(
+            shadow_balance_sum + expected_total_claimed,
+            expected_total_credited,
+            "accounting invariant violated after op {i}"
+        );
     }
 
     // ── post-sequence invariant ────────────────────────────────────────────

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -234,6 +234,7 @@ impl RewardsContract {
         recipients: Vec<(Address, u64)>,
     ) -> Result<(), Error> {
         from.require_auth();
+        ensure_not_paused(&env)?;
 
         let mut staged = Vec::new(&env);
 

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -248,6 +248,25 @@ fn test_credit_respects_max_per_call() {
     assert_eq!(client.balance(&user), 0);
 }
 
+#[test]
+fn test_paused_blocks_credit_and_claim_with_clear_error() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    client.set_paused(&admin, &true);
+
+    assert_eq!(
+        client.try_credit(&admin, &user, &10),
+        Err(Ok(Error::ContractPaused))
+    );
+    assert_eq!(client.try_claim(&user, &1), Err(Ok(Error::ContractPaused)));
+}
+
 // Symbol mirrors `REGISTER_EVENT` in the campaign contract; redeclared here
 // because that constant is module-private.
 const CAMPAIGN_REGISTER_EVENT: soroban_sdk::Symbol = symbol_short!("register");

--- a/contracts/rewards/test_snapshots/test/test_paused_blocks_credit_and_claim_with_clear_error.1.json
+++ b/contracts/rewards/test_snapshots/test/test_paused_blocks_credit_and_claim_with_clear_error.1.json
@@ -1,0 +1,161 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_paused",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bool": true
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Summary

This PR completes four assigned contributions across Soroban contracts and backend API configuration.

### 1) Replace generic contract errors with typed `#[contracterror]` usage
- Standardized campaign contract capacity error naming to `CapReached` and updated fallible paths/tests accordingly.
- Continued using explicit contract error enums across fallible contract methods for clear, deterministic revert reasons.

### 2) Add and enforce paused behavior for rewards flows
- Ensured paused mode blocks all credit/claim paths with a clear error:
  - `credit` (already guarded)
  - `claim` (already guarded)
  - `batch_credit` (**newly guarded in this PR**)
- Added test coverage to assert paused calls return `Error::ContractPaused`.

### 3) Add/extend fuzz target for credit/claim invariant checks
- Enhanced rewards fuzz target (`fuzz_balance`) to randomize credit/claim operations and assert accounting invariants:
  - per-user on-chain balances match shadow state after every step
  - `total_claimed` matches successful claims
  - **new invariant:** `sum(balances) + total_claimed == total_successful_credits`
- Keeps overflow/underflow behavior checked as non-panicking error paths.

### 4) CORS allowed origins from env with safe production default
- Backend CORS continues reading comma-separated origins from env (`CORS_ALLOWED_ORIGINS`, fallback `CORS_ORIGIN`).
- Updated production behavior to a safer default:
  - if no origins are configured, server runs in deny-by-default mode for browser origins
  - wildcard `*` remains disallowed in production
- Updated backend tests to validate deny-by-default production CORS behavior.

## Files Changed

- `contracts/campaign/src/lib.rs`
- `contracts/campaign/src/test.rs`
- `contracts/rewards/src/lib.rs`
- `contracts/rewards/src/test.rs`
- `contracts/rewards/fuzz/fuzz_targets/fuzz_balance.rs`
- `backend/src/index.js`
- `backend/src/index.test.js`
- `contracts/rewards/test_snapshots/test/test_paused_blocks_credit_and_claim_with_clear_error.1.json`

## Test Plan

- [x] `cargo test -p trivela-campaign-contract -p trivela-rewards-contract`
- [x] `npm run test:backend`

## Notes

- Branch: `feat/contracts-errors-pause-fuzz-cors`
- Commit: `ff3c603`
- PR link: https://github.com/bandanadivya/Trivela/pull/new/feat/contracts-errors-pause-fuzz-cors

closes #92 
closes #88 
closes #97 
closes #109 