### PR TITLE
feat: finalize logger tests, active-filter parsing, and testnet deploy script

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -434,10 +434,10 @@ export function createApp(options = {}) {
       return res.set('x-cache', 'HIT').json(cached.payload);
     }
 
+    const activeRaw =
+      typeof req.query.active === 'string' ? req.query.active.toLowerCase() : undefined;
     const activeFilter =
-      req.query.active !== undefined
-        ? req.query.active === 'true'
-        : undefined;
+      activeRaw === 'true' ? true : activeRaw === 'false' ? false : undefined;
     const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
     const sort = typeof req.query.sort === 'string' ? req.query.sort : undefined;
     const order = req.query.order === 'asc' ? 'asc' : req.query.order === 'desc' ? 'desc' : undefined;

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -256,7 +256,10 @@ test('createApp supports injected campaign repositories', async () => {
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.data[0].id, '99');
-    assert.deepEqual(calls[0], ['list', { active: undefined, q: 'injected' }]);
+    assert.deepEqual(calls[0], [
+      'list',
+      { active: undefined, q: 'injected', sort: undefined, order: undefined },
+    ]);
   } finally {
     await stopTestServer(server);
   }
@@ -479,6 +482,37 @@ test('PUT /api/v1/campaigns/:id updates an existing campaign and returns 404 whe
   }
 });
 
+test('PUT /api/v1/campaigns/:id with partial fields preserves untouched fields', async () => {
+  const seed = [
+    {
+      id: '1',
+      name: 'Original Name',
+      description: 'Original description',
+      active: true,
+      rewardPerAction: 25,
+      createdAt: new Date().toISOString(),
+    },
+  ];
+  const { server, baseUrl } = await startTestServer({ campaigns: seed });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns/1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ active: false }),
+    });
+
+    assert.equal(response.status, 200);
+    const updated = await response.json();
+    assert.equal(updated.active, false);
+    assert.equal(updated.name, 'Original Name', 'name should be preserved');
+    assert.equal(updated.description, 'Original description', 'description should be preserved');
+    assert.equal(updated.rewardPerAction, 25, 'rewardPerAction should be preserved');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
 test('GET /api/v1/campaigns?active=true returns only active campaigns', async () => {
   const seed = [
     { id: '1', name: 'Active One', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
@@ -511,6 +545,23 @@ test('GET /api/v1/campaigns?active=false returns only inactive campaigns', async
     const body = await response.json();
     assert.equal(body.data.length, 1);
     assert.equal(body.data[0].active, false);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/campaigns?active=invalid ignores the filter and returns all campaigns', async () => {
+  const seed = [
+    { id: '1', name: 'Active One', description: '', active: true, rewardPerAction: 5, createdAt: new Date().toISOString() },
+    { id: '2', name: 'Inactive One', description: '', active: false, rewardPerAction: 5, createdAt: new Date().toISOString() },
+  ];
+  const { server, baseUrl } = await startTestServer({ campaigns: seed });
+
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/campaigns?active=garbage`);
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.data.length, 2);
   } finally {
     await stopTestServer(server);
   }

--- a/backend/src/middleware/logger.test.js
+++ b/backend/src/middleware/logger.test.js
@@ -1,0 +1,60 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import requestLogger, { log } from './logger.js';
+
+function makeReqRes({ method = 'GET', path = '/health' } = {}) {
+  const req = { method, path };
+  const res = new EventEmitter();
+  Object.assign(res, { statusCode: 200, locals: { requestId: 'req_abc' } });
+  return { req, res };
+}
+
+test('requestLogger emits a structured log on response finish with method, path, status, and duration_ms', () => {
+  const captured = [];
+  const originalInfo = log.info.bind(log);
+  log.info = (payload) => {
+    captured.push(payload);
+  };
+
+  try {
+    const { req, res } = makeReqRes({ method: 'POST', path: '/api/v1/campaigns' });
+    res.statusCode = 201;
+    let nextCalled = false;
+
+    requestLogger(/** @type {any} */ (req), /** @type {any} */ (res), () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true, 'next() must be invoked synchronously');
+    res.emit('finish');
+
+    assert.equal(captured.length, 1, 'expected exactly one log entry per request');
+    const entry = captured[0];
+    assert.equal(entry.method, 'POST');
+    assert.equal(entry.path, '/api/v1/campaigns');
+    assert.equal(entry.status, 201);
+    assert.equal(typeof entry.duration_ms, 'number');
+    assert.ok(entry.duration_ms >= 0, 'duration_ms must be non-negative');
+    assert.equal(entry.requestId, 'req_abc');
+  } finally {
+    log.info = originalInfo;
+  }
+});
+
+test('requestLogger does not log before response finishes', () => {
+  const captured = [];
+  const originalInfo = log.info.bind(log);
+  log.info = (payload) => {
+    captured.push(payload);
+  };
+
+  try {
+    const { req, res } = makeReqRes();
+    requestLogger(/** @type {any} */ (req), /** @type {any} */ (res), () => {});
+    assert.equal(captured.length, 0, 'no log should be emitted until finish event fires');
+  } finally {
+    log.info = originalInfo;
+  }
+});

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Build and deploy the Trivela rewards and campaign contracts to a Stellar
+# network (testnet by default), printing the resulting contract IDs and
+# writing them to a frontend env file (and optionally a backend env file).
+#
+# Required env:
+#   STELLAR_SOURCE      Stellar account/identity to fund and sign the deploy.
+#
+# Optional env:
+#   STELLAR_NETWORK     Defaults to "testnet". Pass "mainnet" or a configured
+#                       stellar CLI network alias to deploy elsewhere.
+#   TRIVELA_ENV_OUT     Frontend env file path. Defaults to ".env.testnet".
+#   TRIVELA_BACKEND_ENV Optional backend env file. When set, the script also
+#                       writes REWARDS_CONTRACT_ID/CAMPAIGN_CONTRACT_ID there.
 
 set -euo pipefail
 
@@ -7,21 +21,38 @@ cd "$(dirname "$0")/.."
 NETWORK="${STELLAR_NETWORK:-testnet}"
 SOURCE="${STELLAR_SOURCE:-}"
 ENV_OUT="${TRIVELA_ENV_OUT:-.env.testnet}"
+BACKEND_ENV_OUT="${TRIVELA_BACKEND_ENV:-}"
 REWARDS_WASM="target/wasm32-unknown-unknown/release/trivela_rewards_contract.wasm"
 CAMPAIGN_WASM="target/wasm32-unknown-unknown/release/trivela_campaign_contract.wasm"
 
-if [ -z "$SOURCE" ]; then
-  echo "STELLAR_SOURCE is required"
+err() {
+  echo "error: $*" >&2
   exit 1
+}
+
+if [ -z "$SOURCE" ]; then
+  err "STELLAR_SOURCE is required (set it to a funded Stellar identity or secret key)"
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  err "cargo is required but not found in PATH"
 fi
 
 if ! command -v stellar >/dev/null 2>&1; then
-  echo "stellar CLI is required"
-  exit 1
+  err "stellar CLI is required but not found in PATH (https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup)"
 fi
 
 echo "Building rewards and campaign contracts..."
-cargo build --target wasm32-unknown-unknown --release -p trivela-rewards-contract -p trivela-campaign-contract
+cargo build --target wasm32-unknown-unknown --release \
+  -p trivela-rewards-contract \
+  -p trivela-campaign-contract
+
+if [ ! -f "$REWARDS_WASM" ]; then
+  err "expected rewards WASM at $REWARDS_WASM after build (build did not produce artifact)"
+fi
+if [ ! -f "$CAMPAIGN_WASM" ]; then
+  err "expected campaign WASM at $CAMPAIGN_WASM after build (build did not produce artifact)"
+fi
 
 echo "Deploying rewards contract to ${NETWORK}..."
 REWARDS_CONTRACT_ID="$(stellar contract deploy --wasm "$REWARDS_WASM" --source "$SOURCE" --network "$NETWORK")"
@@ -30,10 +61,24 @@ echo "Deploying campaign contract to ${NETWORK}..."
 CAMPAIGN_CONTRACT_ID="$(stellar contract deploy --wasm "$CAMPAIGN_WASM" --source "$SOURCE" --network "$NETWORK")"
 
 cat > "$ENV_OUT" <<EOF
+VITE_STELLAR_NETWORK=$NETWORK
 VITE_REWARDS_CONTRACT_ID=$REWARDS_CONTRACT_ID
 VITE_CAMPAIGN_CONTRACT_ID=$CAMPAIGN_CONTRACT_ID
 EOF
 
-echo "Rewards contract: $REWARDS_CONTRACT_ID"
-echo "Campaign contract: $CAMPAIGN_CONTRACT_ID"
-echo "Saved contract IDs to $ENV_OUT"
+if [ -n "$BACKEND_ENV_OUT" ]; then
+  cat > "$BACKEND_ENV_OUT" <<EOF
+STELLAR_NETWORK=$NETWORK
+REWARDS_CONTRACT_ID=$REWARDS_CONTRACT_ID
+CAMPAIGN_CONTRACT_ID=$CAMPAIGN_CONTRACT_ID
+EOF
+fi
+
+echo
+echo "Deployment complete on ${NETWORK}:"
+echo "  rewards  contract: $REWARDS_CONTRACT_ID"
+echo "  campaign contract: $CAMPAIGN_CONTRACT_ID"
+echo "  frontend env  -> $ENV_OUT"
+if [ -n "$BACKEND_ENV_OUT" ]; then
+  echo "  backend env   -> $BACKEND_ENV_OUT"
+fi


### PR DESCRIPTION
## Summary
Closes a batch of assigned backend/contract-script issues with focused tests and a hardened deploy script. No behavior changes to public response shapes; query-string parsing is tightened and the deploy script gains pre-flight checks.

closes #103
closes #101
closes #99
closes #93

## Changes
- **#103 — request logging middleware tests** (`backend/src/middleware/logger.test.js`): adds direct unit coverage for the existing `requestLogger`, asserting it emits a single structured entry on `finish` containing `method`, `path`, `status`, `duration_ms`, and `requestId`, and that nothing is logged before the response finishes.
- **#101 — PUT /api/campaigns/:id partial updates** (`backend/src/index.test.js`): adds an explicit test that a partial PUT (e.g. only `active: false`) preserves the campaign's `name`, `description`, and `rewardPerAction`. The existing 404 path was already covered.
- **#99 — GET /api/campaigns?active filter hardening** (`backend/src/index.js`, `backend/src/index.test.js`): only `'true'` and `'false'` (case-insensitive) are recognized. Anything else (e.g. `?active=garbage`) is now ignored and returns the unfiltered list, instead of being silently coerced to "inactive only". New test covers the invalid-value path; existing true/false/no-param tests still pass.
- **#93 — testnet deploy script hardening** (`scripts/deploy-testnet.sh`): pre-flight checks for `cargo` and `stellar` CLIs, asserts the WASM artifacts exist after `cargo build`, writes `VITE_STELLAR_NETWORK` to the frontend env, supports an optional backend env file via `TRIVELA_BACKEND_ENV` (writing `STELLAR_NETWORK`/`REWARDS_CONTRACT_ID`/`CAMPAIGN_CONTRACT_ID`), prints a clearer deployment summary, and inlines header docs describing required and optional env vars.

Also fixes a pre-existing failing test (`createApp supports injected campaign repositories`) whose assertion no longer matched the `list({ active, q, sort, order })` signature in use.

## Test plan
- [x] `node --test backend/src/index.test.js backend/src/pagination.test.js backend/src/middleware/logger.test.js backend/src/dal/sqliteCampaignRepository.test.js` — 47/47 pass locally
- [x] `bash -n scripts/deploy-testnet.sh` — script syntax valid
- [ ] Reviewer: confirm `?active=invalid` ignoring (vs returning 400) is the desired behavior
- [ ] Reviewer: confirm the optional `TRIVELA_BACKEND_ENV` output path is acceptable