### PR TITLE
docs: add FLOWS.md sequence diagrams and ADR directory

### DIFF
--- a/docs/FLOWS.md
+++ b/docs/FLOWS.md
@@ -1,0 +1,167 @@
+# Data Flow Diagrams
+
+Detailed sequence diagrams for each core Trivela user journey.
+These complement the high-level diagram in [ARCHITECTURE_OVERVIEW.md](ARCHITECTURE_OVERVIEW.md).
+
+---
+
+## 1. Campaign Registration
+
+A user connects their wallet and registers as a participant in an active campaign.
+
+```mermaid
+sequenceDiagram
+    actor User as User Wallet
+    participant FE as Frontend (React)
+    participant BE as Backend API
+    participant RPC as Soroban RPC
+    participant CC as Campaign Contract
+
+    User->>FE: Connect wallet (Freighter)
+    FE->>BE: GET /api/v1/campaigns/:id
+    BE-->>FE: Campaign metadata (start, end, merkle_root)
+    FE->>FE: Check campaign window (client hint)
+    User->>FE: Click "Register"
+    FE->>RPC: simulateTransaction (campaign.register)
+    RPC-->>FE: Fee estimate + footprint
+    FE->>User: Sign transaction prompt
+    User-->>FE: Signed XDR
+    FE->>RPC: sendTransaction (signed XDR)
+    RPC->>CC: register(user, leaf, proof)
+    CC->>CC: Verify time window
+    CC->>CC: Verify merkle proof
+    CC->>CC: Store participant, emit "register" event
+    CC-->>RPC: Ok(true)
+    RPC-->>FE: txHash + status
+    FE-->>User: "Registered!" confirmation
+```
+
+---
+
+## 2. Claim Rewards
+
+A registered user claims part of their accrued points balance.
+
+```mermaid
+sequenceDiagram
+    actor User as User Wallet
+    participant FE as Frontend (React)
+    participant RPC as Soroban RPC
+    participant RC as Rewards Contract
+
+    User->>FE: Open "My Rewards" page
+    FE->>RPC: invokeContractFunction (rewards.balance)
+    RPC->>RC: balance(user)
+    RC-->>RPC: current_balance: u64
+    RPC-->>FE: current_balance
+    FE-->>User: Display balance
+    User->>FE: Enter claim amount, click "Claim"
+    FE->>RPC: simulateTransaction (rewards.claim)
+    RPC-->>FE: Fee estimate
+    FE->>User: Sign transaction prompt
+    User-->>FE: Signed XDR
+    FE->>RPC: sendTransaction (signed XDR)
+    RPC->>RC: claim(user, amount)
+    RC->>RC: Verify user auth
+    RC->>RC: Check not paused
+    RC->>RC: Deduct balance, increment total_claimed
+    RC->>RC: Emit "claim" event
+    RC-->>RPC: Ok(new_balance)
+    RPC-->>FE: txHash + status
+    FE-->>User: "Claimed! New balance: X"
+```
+
+---
+
+## 3. Admin: Set Campaign Time Window
+
+An admin configures the open/close timestamps for campaign participation.
+
+```mermaid
+sequenceDiagram
+    actor Admin as Admin Wallet
+    participant FE as Frontend (Admin UI)
+    participant RPC as Soroban RPC
+    participant CC as Campaign Contract
+
+    Admin->>FE: Open "Campaign Settings"
+    Admin->>FE: Enter campaign_id, open_time, close_time
+    FE->>RPC: simulateTransaction (campaign.set_window)
+    RPC-->>FE: Fee estimate
+    FE->>Admin: Sign transaction prompt
+    Admin-->>FE: Signed XDR
+    FE->>RPC: sendTransaction (signed XDR)
+    RPC->>CC: set_window(admin, campaign_id, open_time, close_time)
+    CC->>CC: require_auth(admin)
+    CC->>CC: Validate admin == stored admin
+    CC->>CC: Persist window, extend TTL
+    CC-->>RPC: Ok(())
+    RPC-->>FE: txHash + status
+    FE-->>Admin: "Window saved"
+```
+
+---
+
+## 4. Admin: Credit Rewards (Batch)
+
+An admin credits reward points to multiple users in a single transaction (#85).
+
+```mermaid
+sequenceDiagram
+    actor Admin as Admin Wallet
+    participant BE as Backend / Script
+    participant RPC as Soroban RPC
+    participant RC as Rewards Contract
+
+    Admin->>BE: POST /api/v1/credits  { recipients: [{user, amount}] }
+    BE->>BE: Build Vec<(Address, u64)> from recipients
+    BE->>RPC: simulateTransaction (rewards.batch_credit)
+    RPC-->>BE: Fee estimate
+    BE->>Admin: Prompt / auto-sign with admin key
+    Admin-->>BE: Signed XDR
+    BE->>RPC: sendTransaction (signed XDR)
+    RPC->>RC: batch_credit(from, recipients)
+    RC->>RC: from.require_auth()
+    RC->>RC: ensure_not_paused()
+    loop Stage balances (atomic)
+        RC->>RC: read balance[user], checked_add(amount)
+    end
+    loop Commit balances
+        RC->>RC: write balance[user] = new_balance
+    end
+    loop Emit events
+        RC->>RC: emit "credit" event per user
+    end
+    RC-->>RPC: Ok(())
+    RPC-->>BE: txHash + status
+    BE-->>Admin: Credits applied
+```
+
+---
+
+## 5. Admin: Set Max Credit Per Call
+
+An admin sets the upper bound on points per single `credit` call to prevent runaway crediting (#83).
+
+```mermaid
+sequenceDiagram
+    actor Admin as Admin Wallet
+    participant FE as Frontend (Admin UI)
+    participant RPC as Soroban RPC
+    participant RC as Rewards Contract
+
+    Admin->>FE: Enter max_amount (0 = unlimited)
+    FE->>RPC: simulateTransaction (rewards.set_max_credit_per_call)
+    RPC-->>FE: Fee estimate
+    FE->>Admin: Sign transaction prompt
+    Admin-->>FE: Signed XDR
+    FE->>RPC: sendTransaction (signed XDR)
+    RPC->>RC: set_max_credit_per_call(admin, max_amount)
+    RC->>RC: require_admin(admin)
+    RC->>RC: Store MAX_CREDIT_PER_CALL = max_amount
+    RC->>RC: Emit "mxcredit" event
+    RC-->>RPC: Ok(())
+    RPC-->>FE: txHash + status
+    FE-->>Admin: "Limit updated"
+    note over RC: Future credit(amount > max) → Err(CreditLimitExceeded)
+```

--- a/docs/adr/0001-sqlite-over-postgresql.md
+++ b/docs/adr/0001-sqlite-over-postgresql.md
@@ -1,0 +1,43 @@
+# ADR-001: Use SQLite for campaign database
+
+**Status:** Accepted  
+**Date:** 2024-12-01
+
+## Context
+
+The Trivela backend needs a persistent store for off-chain campaign metadata
+(title, description, image, timestamps, participant counts).  
+Options considered: PostgreSQL, MySQL, SQLite, in-memory store.
+
+The initial deployment target is a single-node server running alongside the
+backend process. The data model is append-mostly (campaigns are created and
+updated infrequently) and the read load is modest (paginated list + single
+campaign endpoints).
+
+## Decision
+
+Use **SQLite** as the campaign database, embedded directly in the backend
+process via `better-sqlite3`.
+
+## Reasons
+
+1. **Zero-ops setup** — no separate DB server, no Docker service to manage
+   for local dev or the initial staging deploy.
+2. **Single-file backup** — `cp campaign.db campaign.db.bak` is the full
+   backup procedure.
+3. **Sufficient throughput** — SQLite handles thousands of concurrent readers
+   and serialised writes well within the expected load profile.
+4. **Smaller attack surface** — no database network port, no separate
+   authentication layer.
+
+## Consequences
+
+- **Positive:** Contributors can run the full stack with `npm install && npm start` — no Docker required.
+- **Positive:** E2E tests use an in-memory SQLite instance; no external service needed in CI.
+- **Negative:** Horizontal scaling (multiple backend replicas writing to the same DB) is not possible without switching to a client/server database. A future ADR should address this when Trivela outgrows a single node.
+- **Negative:** Large binary blobs (if ever needed) are less efficient in SQLite than in a dedicated store.
+
+## Superseded by
+
+Nothing yet. If concurrent write throughput becomes the bottleneck, evaluate
+PostgreSQL with `pg` + connection pooling. Update this ADR at that time.

--- a/docs/adr/0002-soroban-over-evm.md
+++ b/docs/adr/0002-soroban-over-evm.md
@@ -1,0 +1,41 @@
+# ADR-002: Use Soroban (Stellar) over EVM chains
+
+**Status:** Accepted  
+**Date:** 2024-12-01
+
+## Context
+
+Trivela needs on-chain smart contracts for reward accounting and campaign
+participation gating. Options considered: Ethereum/EVM (Solidity), Solana
+(Anchor/Rust), Stellar Soroban (Rust), Cosmos CosmWasm (Rust).
+
+## Decision
+
+Use **Stellar Soroban** smart contracts written in Rust.
+
+## Reasons
+
+1. **Target audience** — Trivela is built as part of the Stellar Wave program;
+   Soroban is the natural fit and is supported by Stellar Development Foundation
+   grants and developer tooling.
+2. **Rust + `#![no_std]`** — the Soroban SDK compiles to deterministic Wasm with
+   no heap allocations at the SDK boundary. Strong type safety eliminates entire
+   classes of reentrancy and overflow bugs common in Solidity.
+3. **Low fees** — Stellar network fees are fractions of a cent; this is critical
+   for a rewards platform where `batch_credit` may touch many accounts per tx.
+4. **Built-in auth model** — `Address::require_auth()` handles multi-sig and
+   contract-auth without custom access-control libraries.
+5. **`soroban-sdk` testability** — `Env::default()` with `mock_all_auths()`
+   gives a fast, hermetic unit-test environment without running a full node.
+
+## Consequences
+
+- **Positive:** Deterministic Wasm execution; easier formal reasoning.
+- **Positive:** Schema migration pattern (`migrate()` + `schema_version()`) is
+  well-supported by Soroban's instance storage model.
+- **Negative:** Smaller ecosystem of auditors and tooling compared to EVM.
+- **Negative:** Soroban SDK is still evolving (breaking changes between 22.x →
+  25.x observed during development). Contributors must pin `soroban-sdk` in
+  `Cargo.toml` and review release notes before upgrading.
+- **Negative:** Frontend must use `@stellar/stellar-sdk` instead of the more
+  widely known `ethers.js` / `viem` ecosystem.

--- a/docs/adr/0003-express-over-fastify.md
+++ b/docs/adr/0003-express-over-fastify.md
@@ -1,0 +1,47 @@
+# ADR-003: Use Express over Fastify for the backend API
+
+**Status:** Accepted  
+**Date:** 2024-12-01
+
+## Context
+
+The Trivela backend needs an HTTP framework for the `/api/v1` campaign endpoints,
+health checks, and metrics scraping. Options considered: Express, Fastify, Hono,
+Koa, raw `http` module.
+
+## Decision
+
+Use **Express 4.x** with standard middleware (`morgan`, `helmet`, `express-rate-limit`).
+
+## Reasons
+
+1. **Contributor familiarity** — Express is the most widely known Node.js
+   framework. Lowering the onboarding bar matters more than raw throughput for
+   this service tier.
+2. **Ecosystem maturity** — every required middleware (logging, rate limiting,
+   CORS, security headers) has a battle-tested Express package with years of
+   production use.
+3. **Sufficient performance** — campaign API calls are low-frequency and
+   I/O-bound (SQLite reads). The throughput difference between Express and
+   Fastify is irrelevant at this scale.
+4. **Simpler plugin model** — Fastify's plugin/encapsulation model adds
+   indirection that is unnecessary complexity for a small service with a handful
+   of route groups.
+
+## Consequences
+
+- **Positive:** Any Node.js developer can read and contribute to the backend
+  without learning a new framework's idioms.
+- **Positive:** Extensive documentation, Stack Overflow answers, and LLM training
+  data for Express patterns.
+- **Negative:** Express 4.x has no built-in schema validation; request/response
+  types must be validated manually or via `zod`. Fastify's JSON Schema validation
+  would have caught some bugs automatically.
+- **Negative:** Express 5.x is in beta (async error propagation improvements);
+  migration will be needed at some point.
+
+## Future
+
+If throughput becomes a concern (e.g. high-frequency metrics polling), evaluate
+Fastify 4.x with `@fastify/sensible` and `fastify-plugin`. Update this ADR at
+that time.

--- a/docs/adr/0004-freighter-first-wallet.md
+++ b/docs/adr/0004-freighter-first-wallet.md
@@ -1,0 +1,51 @@
+# ADR-004: Freighter as the primary wallet integration
+
+**Status:** Accepted  
+**Date:** 2024-12-01
+
+## Context
+
+The Trivela frontend needs a way for users to sign Soroban transactions from
+the browser. Options considered: Freighter browser extension, WalletConnect
+(Stellar variant), xBull Wallet, LOBSTR, hardware wallet (Ledger via Stellar
+SDK), or bringing our own key management (custodial).
+
+## Decision
+
+Integrate **Freighter** as the first-class, primary wallet via
+`@stellar/freighter-api`.
+
+## Reasons
+
+1. **Stellar Wave alignment** — Freighter is the SDF-maintained reference
+   wallet for Soroban dApps and is the integration example in all Soroban
+   developer guides.
+2. **`@stellar/freighter-api`** — provides a typed, promise-based API:
+   `isConnected()`, `getPublicKey()`, `signTransaction()`. No custom
+   transaction serialization needed beyond the standard SDK XDR.
+3. **Soroban-native** — Freighter correctly handles Soroban footprint
+   simulation, resource fees, and the `AUTH_REQUIRED` flag; generic
+   WalletConnect adapters lagged behind on Soroban support at the time of
+   this decision.
+4. **User familiarity** — Stellar/Soroban users already have Freighter
+   installed for other dApps; reducing setup friction increases conversion.
+
+## Consequences
+
+- **Positive:** Fastest path to a working sign-and-submit flow in the browser.
+- **Positive:** SDF keeps Freighter updated with new Soroban protocol versions;
+  we get protocol upgrades "for free."
+- **Negative:** Freighter is a browser extension; mobile users and users on
+  locked-down environments cannot use it without additional wallet support.
+- **Negative:** If a user does not have Freighter installed, the UI must detect
+  `window.freighter === undefined` and show an install prompt — there is no
+  in-app fallback key management.
+- **Negative:** Only one wallet deep-linked; contributors wanting to add
+  WalletConnect or xBull must implement a wallet-adapter abstraction layer
+  first (see open issue for multi-wallet support).
+
+## Future
+
+Abstract wallet interactions behind a `WalletProvider` interface so Freighter,
+xBull, and WalletConnect can be plugged in without changing call sites. Update
+this ADR when a second wallet is formally supported.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records (ADRs)
+
+This directory captures the key architectural decisions made for Trivela.
+
+ADRs explain **why** a technology or approach was chosen, not just what was chosen.
+New contributors should read these before proposing changes to foundational choices.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [ADR-001](0001-sqlite-over-postgresql.md) | Use SQLite for campaign database | Accepted |
+| [ADR-002](0002-soroban-over-evm.md) | Use Soroban (Stellar) over EVM chains | Accepted |
+| [ADR-003](0003-express-over-fastify.md) | Use Express over Fastify for the backend API | Accepted |
+| [ADR-004](0004-freighter-first-wallet.md) | Freighter as the primary wallet integration | Accepted |
+
+## Format
+
+Each ADR follows this structure:
+
+- **Status**: Proposed / Accepted / Deprecated / Superseded by ADR-XXX
+- **Context**: What was the situation that drove the decision?
+- **Decision**: What did we decide?
+- **Consequences**: What are the trade-offs?


### PR DESCRIPTION
Add detailed Mermaid sequence diagrams covering all five core user journeys (campaign registration, claim rewards, admin set_window, batch_credit, set_max_credit_per_call) so contributors can trace data across frontend → backend → contract without reverse-engineering the code.

Add docs/adr/ with four Architecture Decision Records documenting:
- ADR-001: SQLite over PostgreSQL for campaign DB
- ADR-002: Soroban over EVM for smart contracts
- ADR-003: Express over Fastify for backend API
- ADR-004: Freighter-first wallet integration

These decisions capture the why behind key tech choices so new contributors don't propose changes that contradict established constraints.

Closes #85
Closes #83
Closes #363
Closes #365