### PR TITLE
feat(devops): Add Kubernetes manifests and Helm chart (#359)

### DIFF
--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -1,0 +1,150 @@
+# Kubernetes Deployment Guide
+
+This document covers deploying Trivela to a Kubernetes cluster using either the raw manifests in `k8s/` or the Helm chart in `helm/trivela/`.
+
+---
+
+## Architecture Overview
+
+```
+Internet
+   │
+   ▼
+┌──────────────────────────────────┐
+│        NGINX Ingress             │  (TLS termination via cert-manager)
+└─────────────┬────────────────────┘
+              │
+    ┌─────────┴──────────┐
+    │                    │
+    ▼                    ▼
+┌─────────┐        ┌──────────┐
+│ Frontend│        │ Backend  │  ← HPA (min 2, max 10 replicas, CPU 70%)
+│ (nginx) │        │ (Node.js)│
+└─────────┘        └────┬─────┘
+                        │
+                   ┌────▼─────┐
+                   │PostgreSQL│
+                   └──────────┘
+```
+
+---
+
+## Option A – Raw Kubernetes Manifests (`k8s/`)
+
+### Prerequisites
+
+- `kubectl` configured against your cluster
+- cert-manager installed: `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml`
+- ingress-nginx installed: `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.10.0/deploy/static/provider/cloud/deploy.yaml`
+
+### 1. Configure Secrets
+
+Edit `k8s/secret.yaml` and replace the placeholder values:
+
+```bash
+# Or supply values directly:
+kubectl create secret generic trivela-secrets \
+  --from-literal=DATABASE_URL="postgresql://user:pass@host:5432/trivela_db" \
+  --from-literal=JWT_SECRET="your-strong-secret-here" \
+  --from-literal=SOROBAN_RPC_URL="https://soroban-testnet.stellar.org"
+```
+
+> ⚠️ **Never commit real secrets.** The `k8s/secret.yaml` file contains placeholders only.
+
+### 2. Deploy All Resources
+
+```bash
+# Apply in dependency order
+kubectl apply -f k8s/configmap.yaml
+kubectl apply -f k8s/secret.yaml
+kubectl apply -f k8s/deployment-backend.yaml
+kubectl apply -f k8s/deployment-frontend.yaml
+kubectl apply -f k8s/service-backend.yaml
+kubectl apply -f k8s/service-frontend.yaml
+kubectl apply -f k8s/hpa.yaml
+kubectl apply -f k8s/ingress.yaml
+
+# Or apply the entire directory at once:
+kubectl apply -f k8s/
+```
+
+### 3. Verify Rollout
+
+```bash
+kubectl rollout status deployment/trivela-backend
+kubectl rollout status deployment/trivela-frontend
+kubectl get pods -l app=trivela
+kubectl get ingress trivela-ingress
+```
+
+---
+
+## Option B – Helm Chart (`helm/trivela/`)
+
+See [helm/trivela/README.md](../helm/trivela/README.md) for full Helm instructions.
+
+```bash
+helm install trivela ./helm/trivela \
+  --set secrets.databaseUrl="postgresql://user:pass@host:5432/trivela_db" \
+  --set secrets.jwtSecret="your-strong-secret" \
+  --set ingress.host="trivela.yourdomain.com"
+```
+
+---
+
+## Files Reference
+
+| File | Purpose |
+|------|---------|
+| `k8s/deployment-backend.yaml` | Backend Deployment (2 replicas, liveness/readiness probes) |
+| `k8s/deployment-frontend.yaml` | Frontend Deployment served by nginx |
+| `k8s/service-backend.yaml` | ClusterIP Service for backend on port 3001 |
+| `k8s/service-frontend.yaml` | ClusterIP or LoadBalancer Service for frontend on port 80 |
+| `k8s/ingress.yaml` | NGINX Ingress with TLS (cert-manager annotation) |
+| `k8s/configmap.yaml` | Non-secret environment variables + nginx config |
+| `k8s/secret.yaml` | Secret template (values NOT committed) |
+| `k8s/hpa.yaml` | HorizontalPodAutoscaler (min 2 / max 10 replicas, CPU 70%) |
+
+---
+
+## Scaling
+
+The HPA automatically scales the backend between **2 and 10 replicas** based on CPU utilisation (threshold: 70%).
+
+To manually scale:
+```bash
+kubectl scale deployment trivela-backend --replicas=5
+```
+
+---
+
+## Rolling Updates
+
+```bash
+# Update backend image tag
+kubectl set image deployment/trivela-backend backend=trivela-backend:v1.2.0
+
+# Watch rollout
+kubectl rollout status deployment/trivela-backend
+
+# Roll back if needed
+kubectl rollout undo deployment/trivela-backend
+```
+
+---
+
+## Troubleshooting
+
+```bash
+# View pod logs
+kubectl logs -l app=trivela,component=backend --tail=100
+
+# Describe a pod for events
+kubectl describe pod -l app=trivela,component=backend
+
+# Check HPA status
+kubectl get hpa trivela-backend-hpa
+
+# Port-forward backend locally for debugging
+kubectl port-forward svc/trivela-backend 3001:3001
+```

--- a/helm/trivela/Chart.yaml
+++ b/helm/trivela/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: trivela
+description: >
+  Helm chart for deploying the Trivela platform – a Soroban-powered
+  sports data and wagering application.  Includes backend API, nginx-served
+  frontend, HPA autoscaling, and NGINX Ingress with TLS.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - trivela
+  - soroban
+  - stellar
+  - sports
+home: https://github.com/FinesseStudioLab/Trivela
+sources:
+  - https://github.com/FinesseStudioLab/Trivela
+maintainers:
+  - name: FinesseStudioLab
+    url: https://github.com/FinesseStudioLab

--- a/helm/trivela/README.md
+++ b/helm/trivela/README.md
@@ -1,0 +1,70 @@
+# Trivela Helm Chart
+
+Deploy the full Trivela stack (backend API + nginx frontend + autoscaling) to any Kubernetes cluster using this Helm chart.
+
+## Prerequisites
+
+- Kubernetes ≥ 1.23
+- Helm ≥ 3.10
+- [cert-manager](https://cert-manager.io/) installed (for automatic TLS)
+- [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) installed
+
+## Quick Start
+
+```bash
+# 1. Add any chart dependencies (none currently)
+helm dependency update helm/trivela
+
+# 2. Install with default values (review values.yaml first!)
+helm install trivela ./helm/trivela \
+  --set secrets.databaseUrl="postgresql://user:pass@host:5432/trivela_db" \
+  --set secrets.jwtSecret="your-super-secret-32-char-minimum" \
+  --set ingress.host="trivela.yourdomain.com"
+
+# 3. Upgrade
+helm upgrade trivela ./helm/trivela -f my-production-values.yaml
+
+# 4. Uninstall
+helm uninstall trivela
+```
+
+## Configuration
+
+All configurable values are in [values.yaml](values.yaml). Key overrides:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `backend.replicaCount` | `2` | Initial backend pod count |
+| `backend.image.repository` | `trivela-backend` | Backend image |
+| `backend.image.tag` | `latest` | Backend image tag |
+| `frontend.replicaCount` | `2` | Initial frontend pod count |
+| `ingress.host` | `trivela.example.com` | Public hostname |
+| `ingress.tls.enabled` | `true` | Enable TLS via cert-manager |
+| `autoscaling.minReplicas` | `2` | HPA minimum replicas |
+| `autoscaling.maxReplicas` | `10` | HPA maximum replicas |
+| `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU threshold for scale-out |
+| `secrets.databaseUrl` | *(placeholder)* | PostgreSQL connection string |
+| `secrets.jwtSecret` | *(placeholder)* | JWT signing secret |
+
+## Secrets Management
+
+**Never commit real secrets to version control.**  
+Use one of the following patterns for production:
+
+```bash
+# Option A – pass at install time
+helm install trivela ./helm/trivela --set secrets.databaseUrl="postgresql://..."
+
+# Option B – use an external secrets manager (e.g. External Secrets Operator)
+# and override the secret.yaml template accordingly.
+```
+
+## Autoscaling
+
+HPA is enabled by default.  The backend scales between 2 and 10 replicas based on CPU (70%) and memory (80%) utilisation.  Adjust via:
+
+```bash
+helm upgrade trivela ./helm/trivela \
+  --set autoscaling.maxReplicas=20 \
+  --set autoscaling.targetCPUUtilizationPercentage=60
+```

--- a/helm/trivela/templates/_helpers.tpl
+++ b/helm/trivela/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trivela.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "trivela.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "trivela.labels" -}}
+helm.sh/chart: {{ include "trivela.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "trivela.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "trivela.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trivela.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/trivela/templates/configmap.yaml
+++ b/helm/trivela/templates/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trivela.fullname" . }}-config
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  CORS_ORIGIN: {{ .Values.config.corsOrigin | quote }}
+  nginx.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /api/ {
+            proxy_pass http://{{ include "trivela.fullname" . }}-backend:{{ .Values.backend.port }}/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+    }

--- a/helm/trivela/templates/deployment-backend.yaml
+++ b/helm/trivela/templates/deployment-backend.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trivela.fullname" . }}-backend
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+    component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "trivela.selectorLabels" . | nindent 6 }}
+      component: backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "trivela.selectorLabels" . | nindent 8 }}
+        component: backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.backend.port }}
+              name: http
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "trivela.fullname" . }}-config
+                  key: NODE_ENV
+            - name: PORT
+              value: {{ .Values.backend.port | quote }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "trivela.fullname" . }}-secrets
+                  key: DATABASE_URL
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "trivela.fullname" . }}-secrets
+                  key: JWT_SECRET
+            - name: SOROBAN_RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "trivela.fullname" . }}-secrets
+                  key: SOROBAN_RPC_URL
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.livenessProbe.path }}
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: {{ .Values.backend.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.readinessProbe.path }}
+              port: {{ .Values.backend.port }}
+            initialDelaySeconds: {{ .Values.backend.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.readinessProbe.periodSeconds }}

--- a/helm/trivela/templates/deployment-frontend.yaml
+++ b/helm/trivela/templates/deployment-frontend.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trivela.fullname" . }}-frontend
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+    component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "trivela.selectorLabels" . | nindent 6 }}
+      component: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "trivela.selectorLabels" . | nindent 8 }}
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.frontend.port }}
+              name: http
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.frontend.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "trivela.fullname" . }}-config
+            items:
+              - key: nginx.conf
+                path: default.conf

--- a/helm/trivela/templates/hpa.yaml
+++ b/helm/trivela/templates/hpa.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trivela.fullname" . }}-backend-hpa
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+    component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trivela.fullname" . }}-backend
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+{{- end }}

--- a/helm/trivela/templates/ingress.yaml
+++ b/helm/trivela/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "trivela.fullname" . }}-ingress
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- if .Values.ingress.tls.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "trivela.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "trivela.fullname" . }}-frontend
+                port:
+                  number: {{ .Values.frontend.port }}
+{{- end }}

--- a/helm/trivela/templates/secret.yaml
+++ b/helm/trivela/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trivela.fullname" . }}-secrets
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DATABASE_URL: {{ .Values.secrets.databaseUrl | quote }}
+  JWT_SECRET: {{ .Values.secrets.jwtSecret | quote }}
+  SOROBAN_RPC_URL: {{ .Values.secrets.sorobanRpcUrl | quote }}

--- a/helm/trivela/templates/service-backend.yaml
+++ b/helm/trivela/templates/service-backend.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trivela.fullname" . }}-backend
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+    component: backend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "trivela.selectorLabels" . | nindent 4 }}
+    component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.port }}
+      targetPort: {{ .Values.backend.port }}
+      protocol: TCP

--- a/helm/trivela/templates/service-frontend.yaml
+++ b/helm/trivela/templates/service-frontend.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trivela.fullname" . }}-frontend
+  labels:
+    {{- include "trivela.labels" . | nindent 4 }}
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "trivela.selectorLabels" . | nindent 4 }}
+    component: frontend
+  ports:
+    - name: http
+      port: {{ .Values.frontend.port }}
+      targetPort: {{ .Values.frontend.port }}
+      protocol: TCP

--- a/helm/trivela/values.yaml
+++ b/helm/trivela/values.yaml
@@ -1,0 +1,76 @@
+# Default values for trivela Helm chart.
+# Override these values using -f my-values.yaml or --set key=value.
+
+# ─── Global ───────────────────────────────────────────────────────────────────
+nameOverride: ""
+fullnameOverride: ""
+
+# ─── Backend ─────────────────────────────────────────────────────────────────
+backend:
+  image:
+    repository: trivela-backend
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 2
+  port: 3001
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  livenessProbe:
+    path: /health
+    initialDelaySeconds: 15
+    periodSeconds: 20
+  readinessProbe:
+    path: /health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# ─── Frontend ────────────────────────────────────────────────────────────────
+frontend:
+  image:
+    repository: nginx
+    tag: 1.25-alpine
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+  port: 80
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+
+# ─── Ingress ─────────────────────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: nginx
+  host: trivela.example.com
+  tls:
+    enabled: true
+    secretName: trivela-tls
+    clusterIssuer: letsencrypt-prod
+
+# ─── HPA ─────────────────────────────────────────────────────────────────────
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# ─── Config (non-secret env vars) ────────────────────────────────────────────
+config:
+  nodeEnv: production
+  logLevel: info
+  corsOrigin: "https://trivela.example.com"
+
+# ─── Secrets (provide real values at deploy time; never commit real data) ────
+secrets:
+  databaseUrl: "postgresql://trivela_user:CHANGE_ME@postgres:5432/trivela_db"
+  jwtSecret: "CHANGE_ME_USE_A_STRONG_RANDOM_SECRET"
+  sorobanRpcUrl: "https://soroban-testnet.stellar.org"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivela-config
+  labels:
+    app: trivela
+data:
+  NODE_ENV: "production"
+  LOG_LEVEL: "info"
+  CORS_ORIGIN: "https://trivela.example.com"
+  nginx.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # SPA fallback — serve index.html for all non-file routes
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Proxy API requests to backend service
+        location /api/ {
+            proxy_pass http://trivela-backend:3001/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Cache static assets aggressively
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+    }

--- a/k8s/deployment-backend.yaml
+++ b/k8s/deployment-backend.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivela-backend
+  labels:
+    app: trivela
+    component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: trivela
+      component: backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: trivela
+        component: backend
+    spec:
+      containers:
+        - name: backend
+          image: trivela-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3001
+              name: http
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: trivela-config
+                  key: NODE_ENV
+            - name: PORT
+              value: "3001"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: trivela-secrets
+                  key: DATABASE_URL
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: trivela-secrets
+                  key: JWT_SECRET
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3

--- a/k8s/deployment-frontend.yaml
+++ b/k8s/deployment-frontend.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trivela-frontend
+  labels:
+    app: trivela
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: trivela
+      component: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: trivela
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - name: frontend-dist
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: frontend-dist
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: trivela-config
+            items:
+              - key: nginx.conf
+                path: default.conf

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,40 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: trivela-backend-hpa
+  labels:
+    app: trivela
+    component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: trivela-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: trivela-ingress
+  labels:
+    app: trivela
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - trivela.example.com
+      secretName: trivela-tls
+  rules:
+    - host: trivela.example.com
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: trivela-backend
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: trivela-frontend
+                port:
+                  number: 80

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trivela-secrets
+  labels:
+    app: trivela
+type: Opaque
+# IMPORTANT: Values below are base64-encoded PLACEHOLDERS.
+# Replace with actual base64-encoded secrets before deploying.
+# Generate with: echo -n 'your-value' | base64
+#
+# stringData can be used instead of data for plain-text values
+# in local/dev environments (never commit real credentials).
+stringData:
+  DATABASE_URL: "postgresql://trivela_user:CHANGE_ME@postgres:5432/trivela_db"
+  JWT_SECRET: "CHANGE_ME_USE_A_STRONG_RANDOM_SECRET_AT_LEAST_32_CHARS"
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"

--- a/k8s/service-backend.yaml
+++ b/k8s/service-backend.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trivela-backend
+  labels:
+    app: trivela
+    component: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: trivela
+    component: backend
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+      protocol: TCP

--- a/k8s/service-frontend.yaml
+++ b/k8s/service-frontend.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trivela-frontend
+  labels:
+    app: trivela
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: trivela
+    component: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP


### PR DESCRIPTION
## Summary

Adds full cloud-native deployment support for Trivela via raw Kubernetes manifests (`k8s/`) and a Helm chart (`helm/trivela/`), replacing Docker Compose as the primary production deployment method.

---

## Changes

### Kubernetes Manifests (`k8s/`)

| File | Description |
|------|-------------|
| `deployment-backend.yaml` | Deployment — 2 replicas, RollingUpdate, resource limits, liveness/readiness probes on `/health` |
| `deployment-frontend.yaml` | Deployment — nginx:1.25-alpine serving built frontend, ConfigMap-mounted `nginx.conf` |
| `service-backend.yaml` | ClusterIP Service on port 3001 |
| `service-frontend.yaml` | ClusterIP Service on port 80 |
| `ingress.yaml` | NGINX Ingress with TLS (cert-manager `letsencrypt-prod` annotation) |
| `configmap.yaml` | Non-secret env vars + nginx server block (SPA fallback + /api proxy) |
| `secret.yaml` | Template with `stringData` placeholders — **values NOT committed** |
| `hpa.yaml` | HorizontalPodAutoscaler: min 2 / max 10 replicas, CPU 70%, memory 80% |

### Helm Chart (`helm/trivela/`)

| File | Description |
|------|-------------|
| `Chart.yaml` | Chart metadata — version 0.1.0, appVersion 1.0.0 |
| `values.yaml` | All configurable defaults (image tags, resource limits, ingress host, autoscaling thresholds) |
| `templates/_helpers.tpl` | `trivela.fullname`, `trivela.labels`, `trivela.selectorLabels` helpers |
| `templates/deployment-backend.yaml` | Helm-parameterised backend Deployment |
| `templates/deployment-frontend.yaml` | Helm-parameterised frontend Deployment |
| `templates/service-backend.yaml` | Helm-parameterised backend Service |
| `templates/service-frontend.yaml` | Helm-parameterised frontend Service |
| `templates/ingress.yaml` | Conditional Ingress (`ingress.enabled`) with TLS toggle |
| `templates/configmap.yaml` | Helm-parameterised ConfigMap |
| `templates/secret.yaml` | Helm-parameterised Secret |
| `templates/hpa.yaml` | Conditional HPA (`autoscaling.enabled`) |
| `README.md` | helm install / upgrade / uninstall instructions + secrets management guide |

### Documentation

`docs/KUBERNETES.md` — full deployment guide with:
- Architecture diagram
- Step-by-step raw-manifest deploy
- Helm quick-start
- Files reference table
- Scaling + rolling-update instructions
- Troubleshooting section

---

## Acceptance Criteria

- [x] `k8s/deployment-backend.yaml` — Deployment with 2 replicas, resource requests/limits, liveness/readiness probes
- [x] `k8s/deployment-frontend.yaml` — nginx serving built frontend
- [x] `k8s/service-backend.yaml` — ClusterIP Service
- [x] `k8s/service-frontend.yaml` — ClusterIP Service
- [x] `k8s/ingress.yaml` — NGINX Ingress with TLS (cert-manager annotation)
- [x] `k8s/configmap.yaml` — Non-secret env vars
- [x] `k8s/secret.yaml` — Template with stringData (values NOT committed)
- [x] `k8s/hpa.yaml` — HPA: min 2, max 10 replicas, CPU 70%
- [x] `helm/trivela/Chart.yaml` — with version and description
- [x] `helm/trivela/values.yaml` — all configurable values and defaults
- [x] Helm templates covering all manifests with `{{ .Values }}` substitution
- [x] `helm/trivela/README.md` — with helm install instructions
- [x] `docs/KUBERNETES.md` — deployment guide

---

## Closes

Closes #359
Closes #355
Closes #356
Closes #362