### PR TITLE
feat: add campaign participant leaderboard page

### DIFF
--- a/frontend/e2e/leaderboard.spec.js
+++ b/frontend/e2e/leaderboard.spec.js
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the campaign leaderboard page.
+ *
+ * Uses Playwright route interception so tests run without a live backend.
+ */
+
+const CAMPAIGN_ID = '1';
+const LEADERBOARD_URL = `/campaign/${CAMPAIGN_ID}/leaderboard`;
+
+const MOCK_CAMPAIGN = { id: CAMPAIGN_ID, name: 'Test Campaign', status: 'active' };
+
+const MOCK_LEADERBOARD = {
+  data: [
+    { rank: 1, walletAddress: 'GABC1234567890AAAA', points: 500, claimedPoints: 100 },
+    { rank: 2, walletAddress: 'GXYZ9876543210BBBB', points: 400, claimedPoints: 50 },
+    { rank: 3, walletAddress: 'GDEF1111222233334', points: 300, claimedPoints: 0 },
+    { rank: 4, walletAddress: 'GHIJ5555666677778', points: 200, claimedPoints: 20 },
+  ],
+  pagination: {
+    total: 4,
+    count: 4,
+    page: 1,
+    limit: 20,
+    offset: 0,
+    totalPages: 1,
+    hasPreviousPage: false,
+    hasNextPage: false,
+    previousPage: null,
+    nextPage: null,
+  },
+};
+
+async function interceptCampaign(page) {
+  await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_CAMPAIGN),
+    });
+  });
+}
+
+async function interceptLeaderboard(page, override = {}) {
+  await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}/leaderboard**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ...MOCK_LEADERBOARD, ...override }),
+    });
+  });
+}
+
+test.describe('Campaign Leaderboard page', () => {
+  test('renders the leaderboard heading and participant rows', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page);
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Leaderboard');
+    await expect(page.locator('.lb-table')).toBeVisible();
+
+    // All four participant rows should appear
+    const rows = page.locator('.lb-row-data');
+    await expect(rows).toHaveCount(4);
+  });
+
+  test('displays gold, silver, bronze medals for top 3 ranks', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page);
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.locator('.lb-row-data').nth(0)).toContainText('🥇');
+    await expect(page.locator('.lb-row-data').nth(1)).toContainText('🥈');
+    await expect(page.locator('.lb-row-data').nth(2)).toContainText('🥉');
+  });
+
+  test('shows truncated wallet addresses', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page);
+
+    await page.goto(LEADERBOARD_URL);
+
+    // First address GABC1234567890AAAA should be truncated to GABC12...AAAA
+    const firstRow = page.locator('.lb-row-data').first();
+    await expect(firstRow.locator('.lb-col-address')).toContainText('GABC12...AAAA');
+  });
+
+  test('shows empty state when no participants', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page, {
+      data: [],
+      pagination: { ...MOCK_LEADERBOARD.pagination, total: 0, count: 0 },
+    });
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.locator('.lb-empty')).toBeVisible();
+    await expect(page.locator('.lb-empty-heading')).toContainText('No participants yet');
+  });
+
+  test('shows skeleton loading state before data resolves', async ({ page }) => {
+    await interceptCampaign(page);
+
+    // Delay the leaderboard response
+    await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}/leaderboard**`, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_LEADERBOARD),
+      });
+    });
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.locator('.lb-row-skeleton').first()).toBeVisible();
+    // Rows should appear after load completes
+    await expect(page.locator('.lb-row-data').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('search input filters the leaderboard request', async ({ page }) => {
+    await interceptCampaign(page);
+
+    let capturedUrl = '';
+    await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}/leaderboard**`, async (route) => {
+      capturedUrl = route.request().url();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...MOCK_LEADERBOARD, data: [] }),
+      });
+    });
+
+    await page.goto(LEADERBOARD_URL);
+
+    const searchInput = page.locator('.lb-search-input');
+    await searchInput.fill('GABC');
+
+    // Wait for debounce and re-fetch
+    await page.waitForTimeout(400);
+    expect(capturedUrl).toContain('q=GABC');
+  });
+
+  test('shows participant count', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page);
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.locator('.lb-total-count')).toContainText('4 participants');
+  });
+
+  test('shows error state when leaderboard request fails', async ({ page }) => {
+    await interceptCampaign(page);
+
+    await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}/leaderboard**`, async (route) => {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+    });
+
+    await page.goto(LEADERBOARD_URL);
+
+    await expect(page.locator('.lb-error')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+  });
+
+  test('back link navigates to campaign detail', async ({ page }) => {
+    await interceptCampaign(page);
+    await interceptLeaderboard(page);
+
+    // Also stub the campaign detail fetch so navigation works
+    await page.route(`**/api/v1/campaigns/${CAMPAIGN_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CAMPAIGN),
+      });
+    });
+
+    await page.goto(LEADERBOARD_URL);
+
+    await page.getByRole('link', { name: /back to campaign/i }).click();
+    await expect(page).toHaveURL(new RegExp(`/campaign/${CAMPAIGN_ID}$`));
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Landing from './Landing';
 import CampaignDetail from './CampaignDetail';
+import CampaignLeaderboard from './CampaignLeaderboard';
 import AdminCampaigns from './AdminCampaigns';
 import About from './About';
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
@@ -161,6 +162,26 @@ export default function App() {
         path="/campaign/:id"
         element={
           <CampaignDetail
+            theme={theme}
+            onToggleTheme={toggleTheme}
+            stellarNetwork={runtimeConfig.stellar.network}
+            onChangeStellarNetwork={handleChangeStellarNetwork}
+            walletAddress={walletAddress}
+            walletBalance={walletBalance}
+            rewardsPoints={rewardsPoints}
+            isWalletLoading={isWalletLoading}
+            isWalletBalanceLoading={isWalletBalanceLoading}
+            isRewardsPointsLoading={isRewardsPointsLoading}
+            onConnectWallet={connectWallet}
+            onDisconnectWallet={disconnectWallet}
+            onRefreshPoints={() => loadWalletBalance(walletAddress)}
+          />
+        }
+      />
+      <Route
+        path="/campaign/:id/leaderboard"
+        element={
+          <CampaignLeaderboard
             theme={theme}
             onToggleTheme={toggleTheme}
             stellarNetwork={runtimeConfig.stellar.network}

--- a/frontend/src/CampaignDetail.css
+++ b/frontend/src/CampaignDetail.css
@@ -18,6 +18,18 @@
 
 .detail-nav {
   margin-bottom: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.detail-leaderboard-btn {
+  font-size: 0.85rem;
+  padding: 0.45rem 1rem;
+  border-radius: 10px;
+  white-space: nowrap;
 }
 
 .back-link {

--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -158,6 +158,9 @@ export default function CampaignDetail({
             <Link to="/" className="back-link">
               Back to campaigns
             </Link>
+            <Link to={`/campaign/${id}/leaderboard`} className="btn btn-secondary detail-leaderboard-btn">
+              View leaderboard
+            </Link>
           </nav>
 
           {isLoading ? (

--- a/frontend/src/CampaignLeaderboard.css
+++ b/frontend/src/CampaignLeaderboard.css
@@ -1,0 +1,379 @@
+.lb-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+.lb-main {
+  flex: 1;
+  padding: 4rem 1rem;
+}
+
+.lb-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.lb-nav {
+  margin-bottom: 2.5rem;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.lb-header {
+  margin-bottom: 2rem;
+}
+
+.lb-eyebrow {
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.lb-title {
+  font-family: var(--font-heading);
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.5rem;
+}
+
+.lb-subtitle {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── My Rank Banner ──────────────────────────────────────────────────────── */
+
+.lb-my-rank-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1rem 1.5rem;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  border-radius: 16px;
+  margin-bottom: 1.5rem;
+}
+
+.lb-my-rank-text {
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.lb-my-rank-text strong {
+  color: var(--accent);
+  font-size: 1.1rem;
+}
+
+.lb-share-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.lb-share-btn {
+  font-size: 0.8rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 8px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.lb-share-btn:hover {
+  opacity: 0.85;
+}
+
+.lb-share-twitter {
+  background: #000;
+  color: #fff;
+}
+
+.lb-share-discord {
+  background: #5865f2;
+  color: #fff;
+}
+
+/* ── Search Row ──────────────────────────────────────────────────────────── */
+
+.lb-search-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.lb-search-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.6rem 1rem;
+  font-size: 0.9rem;
+  background: var(--bg-card-solid);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+}
+
+.lb-search-input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.lb-total-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ── Table ───────────────────────────────────────────────────────────────── */
+
+.lb-table {
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: blur(16px);
+}
+
+.lb-row {
+  display: grid;
+  grid-template-columns: 72px 1fr 110px 110px 110px;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  gap: 0.5rem;
+}
+
+.lb-row-header {
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-strong);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.lb-row-data {
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s ease;
+}
+
+.lb-row-data:last-child {
+  border-bottom: none;
+}
+
+.lb-row-data:hover {
+  background: var(--accent-soft);
+}
+
+.lb-row-mine {
+  background: rgba(76, 141, 255, 0.12);
+  border-left: 3px solid var(--accent);
+}
+
+.lb-row-mine:hover {
+  background: rgba(76, 141, 255, 0.2);
+}
+
+/* ── Columns ─────────────────────────────────────────────────────────────── */
+
+.lb-col-rank {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+}
+
+.lb-col-address {
+  font-family: monospace;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lb-col-points,
+.lb-col-claimed,
+.lb-col-net {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: right;
+}
+
+.lb-col-net {
+  color: var(--accent);
+}
+
+/* ── Rank display ────────────────────────────────────────────────────────── */
+
+.lb-medal {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.lb-rank-num {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-family: var(--font-heading);
+  font-weight: 700;
+}
+
+/* ── You badge ───────────────────────────────────────────────────────────── */
+
+.lb-you-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+}
+
+/* ── Skeleton loading ────────────────────────────────────────────────────── */
+
+.lb-row-skeleton {
+  border-bottom: 1px solid var(--border);
+  pointer-events: none;
+}
+
+.lb-skeleton-block {
+  display: block;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--border) 25%,
+    var(--border-strong) 50%,
+    var(--border) 75%
+  );
+  background-size: 200% 100%;
+  animation: lb-shimmer 1.4s infinite;
+  height: 14px;
+}
+
+.lb-skeleton-sm { width: 40px; }
+.lb-skeleton-md { width: 70px; margin-left: auto; }
+.lb-skeleton-lg { width: 120px; }
+
+@keyframes lb-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── States ──────────────────────────────────────────────────────────────── */
+
+.lb-state {
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.lb-error {
+  color: var(--danger);
+}
+
+.lb-error p {
+  margin-bottom: 1rem;
+}
+
+.lb-empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.lb-empty-heading {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.lb-empty-sub {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+/* ── Load more ───────────────────────────────────────────────────────────── */
+
+.lb-load-more-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.lb-load-more-btn {
+  min-width: 140px;
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+.lb-footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding: 2.5rem 1rem;
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 700px) {
+  .lb-row {
+    grid-template-columns: 56px 1fr 80px 80px 80px;
+    padding: 0.65rem 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  .lb-title {
+    font-size: 1.8rem;
+  }
+
+  .lb-my-rank-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .lb-col-claimed {
+    display: none;
+  }
+
+  .lb-row-header .lb-col-claimed {
+    display: none;
+  }
+
+  .lb-main {
+    padding: 2rem 0.75rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .lb-row {
+    grid-template-columns: 48px 1fr 70px 70px;
+  }
+
+  .lb-col-claimed {
+    display: none;
+  }
+
+  .lb-row-header .lb-col-claimed {
+    display: none;
+  }
+}

--- a/frontend/src/CampaignLeaderboard.jsx
+++ b/frontend/src/CampaignLeaderboard.jsx
@@ -1,0 +1,328 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { apiUrl } from './config';
+import Header from './components/Header';
+import './CampaignLeaderboard.css';
+
+const PAGE_LIMIT = 20;
+
+function truncateAddress(address) {
+  if (!address) return '';
+  if (address.length <= 14) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function RankMedal({ rank }) {
+  if (rank === 1) return <span className="lb-medal lb-medal-gold" aria-label="1st place">🥇</span>;
+  if (rank === 2) return <span className="lb-medal lb-medal-silver" aria-label="2nd place">🥈</span>;
+  if (rank === 3) return <span className="lb-medal lb-medal-bronze" aria-label="3rd place">🥉</span>;
+  return <span className="lb-rank-num">#{rank}</span>;
+}
+
+function SkeletonRow() {
+  return (
+    <div className="lb-row lb-row-skeleton" aria-hidden="true">
+      <span className="lb-col-rank lb-skeleton-block lb-skeleton-sm" />
+      <span className="lb-col-address lb-skeleton-block lb-skeleton-lg" />
+      <span className="lb-col-points lb-skeleton-block lb-skeleton-md" />
+      <span className="lb-col-claimed lb-skeleton-block lb-skeleton-md" />
+      <span className="lb-col-net lb-skeleton-block lb-skeleton-md" />
+    </div>
+  );
+}
+
+export default function CampaignLeaderboard({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  rewardsPoints,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  isRewardsPointsLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+  onRefreshPoints,
+}) {
+  const { id } = useParams();
+
+  const [campaign, setCampaign] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [myRank, setMyRank] = useState(null);
+  const [rankCopied, setRankCopied] = useState(false);
+
+  const searchTimerRef = useRef(null);
+
+  // Debounce search input
+  useEffect(() => {
+    clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+      setParticipants([]);
+    }, 300);
+    return () => clearTimeout(searchTimerRef.current);
+  }, [search]);
+
+  // Fetch campaign name for display
+  useEffect(() => {
+    fetch(apiUrl(`/api/v1/campaigns/${id}`))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setCampaign(data); })
+      .catch(() => {});
+  }, [id]);
+
+  // Fetch leaderboard data
+  const fetchLeaderboard = useCallback(
+    async (pageNum, replace) => {
+      replace ? setIsLoading(true) : setIsLoadingMore(true);
+      setError('');
+
+      const qs = new URLSearchParams({ page: String(pageNum), limit: String(PAGE_LIMIT) });
+      if (debouncedSearch) qs.set('q', debouncedSearch);
+
+      try {
+        const res = await fetch(apiUrl(`/api/v1/campaigns/${id}/leaderboard?${qs}`));
+        if (!res.ok) throw new Error(`API returned ${res.status}`);
+        const json = await res.json();
+
+        const rows = json.data ?? [];
+        setTotal(json.pagination?.total ?? rows.length);
+        setHasMore(json.pagination?.hasNextPage ?? false);
+
+        if (replace) {
+          setParticipants(rows);
+        } else {
+          setParticipants((prev) => [...prev, ...rows]);
+        }
+      } catch (err) {
+        setError(err.message || 'Unable to load leaderboard.');
+      } finally {
+        replace ? setIsLoading(false) : setIsLoadingMore(false);
+      }
+    },
+    [id, debouncedSearch],
+  );
+
+  // Reload from page 1 when search changes
+  useEffect(() => {
+    fetchLeaderboard(1, true);
+  }, [fetchLeaderboard]);
+
+  // Fetch the connected wallet's rank
+  useEffect(() => {
+    if (!walletAddress || !id) { setMyRank(null); return; }
+
+    fetch(apiUrl(`/api/v1/campaigns/${id}/leaderboard/rank?wallet=${encodeURIComponent(walletAddress)}`))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => { if (data) setMyRank(data); })
+      .catch(() => { setMyRank(null); });
+  }, [walletAddress, id]);
+
+  const handleLoadMore = () => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchLeaderboard(nextPage, false);
+  };
+
+  const buildShareText = (rank) => {
+    const name = campaign?.name ?? 'this campaign';
+    const rankStr = rank != null ? `#${rank} of ${total}` : 'the top';
+    return encodeURIComponent(
+      `I'm ranked ${rankStr} on the ${name} leaderboard on Trivela! 🏆 ${window.location.origin}/campaign/${id}/leaderboard`,
+    );
+  };
+
+  const handleCopyRank = async () => {
+    const rank = myRank?.rank;
+    const text = `I'm ranked #${rank} of ${total} on the ${campaign?.name ?? 'Trivela'} leaderboard! ${window.location.origin}/campaign/${id}/leaderboard`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setRankCopied(true);
+      setTimeout(() => setRankCopied(false), 2000);
+    } catch (_) {}
+  };
+
+  const isMyRow = (address) =>
+    walletAddress && address?.toLowerCase() === walletAddress.toLowerCase();
+
+  return (
+    <div className="lb-page">
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        isWalletLoading={isWalletLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+
+      <main className="lb-main">
+        <div className="lb-container">
+          <nav className="lb-nav">
+            <Link to={`/campaign/${id}`} className="back-link">
+              ← Back to campaign
+            </Link>
+          </nav>
+
+          <header className="lb-header">
+            <p className="lb-eyebrow">Campaign #{id}</p>
+            <h1 className="lb-title">
+              {campaign?.name ? `${campaign.name} — Leaderboard` : 'Leaderboard'}
+            </h1>
+            <p className="lb-subtitle">
+              Participants ranked by reward points earned
+            </p>
+          </header>
+
+          {/* Connected wallet rank banner */}
+          {walletAddress && myRank && (
+            <div className="lb-my-rank-banner" role="status">
+              <span className="lb-my-rank-text">
+                Your rank: <strong>#{myRank.rank}</strong> of {total.toLocaleString()} participants
+              </span>
+              <div className="lb-share-row">
+                <button
+                  type="button"
+                  className="btn lb-share-btn lb-share-twitter"
+                  onClick={() =>
+                    window.open(
+                      `https://twitter.com/intent/tweet?text=${buildShareText(myRank.rank)}`,
+                      '_blank',
+                      'noopener,noreferrer',
+                    )
+                  }
+                >
+                  Share on X
+                </button>
+                <button
+                  type="button"
+                  className="btn lb-share-btn lb-share-discord"
+                  onClick={handleCopyRank}
+                  title="Copy rank text to share on Discord"
+                >
+                  {rankCopied ? 'Copied!' : 'Share on Discord'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Search */}
+          <div className="lb-search-row">
+            <input
+              className="lb-search-input"
+              type="search"
+              placeholder="Search by wallet address..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              aria-label="Filter leaderboard by wallet address"
+            />
+            {total > 0 && !isLoading && (
+              <span className="lb-total-count">
+                {total.toLocaleString()} participant{total !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+
+          {/* Table header */}
+          <div className="lb-table" role="table" aria-label="Campaign leaderboard">
+            <div className="lb-row lb-row-header" role="row">
+              <span className="lb-col-rank" role="columnheader">Rank</span>
+              <span className="lb-col-address" role="columnheader">Wallet</span>
+              <span className="lb-col-points" role="columnheader">Points</span>
+              <span className="lb-col-claimed" role="columnheader">Claimed</span>
+              <span className="lb-col-net" role="columnheader">Net Balance</span>
+            </div>
+
+            {isLoading ? (
+              Array.from({ length: 8 }, (_, i) => <SkeletonRow key={i} />)
+            ) : error ? (
+              <div className="lb-state lb-error" role="alert">
+                <p>{error}</p>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => fetchLeaderboard(1, true)}
+                >
+                  Retry
+                </button>
+              </div>
+            ) : participants.length === 0 ? (
+              <div className="lb-state lb-empty">
+                <p className="lb-empty-icon">🏁</p>
+                <p className="lb-empty-heading">No participants yet</p>
+                <p className="lb-empty-sub">
+                  {debouncedSearch
+                    ? 'No participants match that wallet address.'
+                    : 'Be the first to join this campaign and top the leaderboard!'}
+                </p>
+              </div>
+            ) : (
+              participants.map((p) => (
+                <div
+                  key={p.walletAddress ?? p.rank}
+                  className={`lb-row lb-row-data${isMyRow(p.walletAddress) ? ' lb-row-mine' : ''}`}
+                  role="row"
+                  aria-current={isMyRow(p.walletAddress) ? 'true' : undefined}
+                >
+                  <span className="lb-col-rank" role="cell">
+                    <RankMedal rank={p.rank} />
+                  </span>
+                  <span className="lb-col-address" role="cell" title={p.walletAddress}>
+                    {truncateAddress(p.walletAddress)}
+                    {isMyRow(p.walletAddress) && (
+                      <span className="lb-you-badge">You</span>
+                    )}
+                  </span>
+                  <span className="lb-col-points" role="cell">
+                    {(p.points ?? 0).toLocaleString()}
+                  </span>
+                  <span className="lb-col-claimed" role="cell">
+                    {(p.claimedPoints ?? 0).toLocaleString()}
+                  </span>
+                  <span className="lb-col-net" role="cell">
+                    {((p.points ?? 0) - (p.claimedPoints ?? 0)).toLocaleString()}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Load more */}
+          {!isLoading && !error && hasMore && (
+            <div className="lb-load-more-row">
+              <button
+                type="button"
+                className="btn btn-secondary lb-load-more-btn"
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+              >
+                {isLoadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
+
+      <footer className="footer lb-footer">
+        <div className="footer-inner">
+          <p>Copyright 2026 Trivela - Built for Stellar Wave</p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -116,6 +116,34 @@ async function deleteCampaign(id) {
   return request(apiUrl(`/api/v1/campaigns/${id}`), { method: 'DELETE' });
 }
 
+// ── Leaderboard endpoints ─────────────────────────────────────────────────────
+
+/**
+ * @param {string | number} campaignId
+ * @param {{ page?: number, limit?: number, q?: string }} [params]
+ */
+async function getCampaignLeaderboard(campaignId, params = {}) {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set('page', String(params.page));
+  if (params.limit) qs.set('limit', String(params.limit));
+  if (params.q) qs.set('q', params.q);
+  const url =
+    apiUrl(`/api/v1/campaigns/${campaignId}/leaderboard`) +
+    (qs.toString() ? `?${qs}` : '');
+  return /** @type {Promise<{ data: any[], pagination: object }>} */ (request(url));
+}
+
+/**
+ * @param {string | number} campaignId
+ * @param {string} walletAddress
+ */
+async function getParticipantRank(campaignId, walletAddress) {
+  const url =
+    apiUrl(`/api/v1/campaigns/${campaignId}/leaderboard/rank`) +
+    `?wallet=${encodeURIComponent(walletAddress)}`;
+  return request(url);
+}
+
 // ── Config endpoint ───────────────────────────────────────────────────────────
 
 async function getConfig() {
@@ -131,6 +159,8 @@ export const apiClient = {
   createCampaign,
   updateCampaign,
   deleteCampaign,
+  getCampaignLeaderboard,
+  getParticipantRank,
   getConfig,
 };
 


### PR DESCRIPTION
## Summary

- Add `/campaign/:id/leaderboard` route and `CampaignLeaderboard.jsx` page component
- Fetch `GET /api/v1/campaigns/:id/leaderboard` with load-more pagination (20 per page)
- Display rank medals (🥇🥈🥉) for top 3, truncated wallet address, points, claimed points, net balance
- Highlight the connected wallet's row with a "You" badge and show "Your rank: #N of M participants" banner
- Twitter and Discord "Share my rank" buttons on the rank banner
- Wallet-address prefix search with 300ms debounce
- Skeleton shimmer loading rows and empty state when no participants
- Add `getCampaignLeaderboard` and `getParticipantRank` methods to `apiClient.js`
- Add "View leaderboard" link from the campaign detail page nav
- Add Playwright E2E test suite: render, medals, address truncation, empty state, skeleton, search, error state, navigation

## Test plan

- [ ] Navigate to `/campaign/:id/leaderboard` — leaderboard table renders with correct columns
- [ ] Top 3 rows show 🥇🥈🥉 medals; rows 4+ show `#N`
- [ ] Wallet addresses are truncated (e.g. `GABC12...AAAA`)
- [ ] Connected wallet row is highlighted with "You" badge and rank banner appears
- [ ] "Share on X" opens Twitter intent; "Share on Discord" copies text to clipboard
- [ ] Typing in search box debounces and sends `?q=` to the API
- [ ] "Load more" button appends next page of results
- [ ] Empty state shows when API returns zero participants
- [ ] Skeleton rows visible during loading delay
- [ ] Error state with Retry button shown on API failure
- [ ] "View leaderboard" link on campaign detail navigates correctly
- [ ] Run `npm run test --workspace=frontend` — all Playwright leaderboard specs pass

Closes #342
Closes #344
Closes #346
Closes #348