### PR TITLE
feat: add rate limiting, snapshots, vesting, and integration tests (#324 #325 #326 #327)

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run contract tests
         run: cargo test --workspace
 
+      - name: Run integration tests
+        run: cargo test --package integration
+
       - name: Install Stellar CLI
         run: |
           curl -fsSL https://github.com/stellar/stellar-cli/raw/main/install.sh | sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "integration"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "trivela-campaign-contract",
+ "trivela-rewards-contract",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "contracts/rewards",
   "contracts/campaign",
+  "contracts/integration",
 ]
 
 [workspace.metadata]

--- a/backend/src/jobs/eventIndexer.js
+++ b/backend/src/jobs/eventIndexer.js
@@ -1,0 +1,116 @@
+/**
+ * Event indexer for Trivela Soroban contract events.
+ *
+ * Subscribes to on-chain events and persists them to the database.
+ * Snapshot events store a ledger reference so off-chain tools can
+ * reconstruct user balances at that point using Horizon getLedgerEntries.
+ */
+
+export function createEventIndexer({ db, rpcPool, logger = console } = {}) {
+  const handlers = {
+    credit: handleCreditEvent,
+    claim: handleClaimEvent,
+    snapshot: handleSnapshotEvent,
+    vcredit: handleVestedCreditEvent,
+    vclaim: handleVestedClaimEvent,
+  };
+
+  async function processEvent(event) {
+    const topic = event.topic?.[0];
+    const handler = handlers[topic];
+    if (!handler) return;
+    try {
+      await handler(event, db);
+    } catch (err) {
+      logger.error?.(`eventIndexer:error topic=${topic}`, err);
+    }
+  }
+
+  async function poll(contractId, cursor) {
+    const rpc = await rpcPool.acquire();
+    try {
+      const { events, nextCursor } = await rpc.getEvents({
+        contractId,
+        cursor,
+        limit: 200,
+      });
+      for (const event of events) {
+        await processEvent(event);
+      }
+      return nextCursor;
+    } finally {
+      rpcPool.release(rpc);
+    }
+  }
+
+  return { processEvent, poll };
+}
+
+async function handleCreditEvent(event, db) {
+  const user = event.topic?.[1];
+  const amount = BigInt(event.data ?? 0);
+  await db.run(
+    `INSERT OR IGNORE INTO balances (user) VALUES (?)
+     ON CONFLICT(user) DO UPDATE SET balance = balance + ?`,
+    [user, amount.toString()],
+  );
+  await db.run(
+    `INSERT INTO credit_events (user, amount, ledger, tx_hash) VALUES (?, ?, ?, ?)`,
+    [user, amount.toString(), event.ledger, event.txHash],
+  );
+}
+
+async function handleClaimEvent(event, db) {
+  const user = event.topic?.[1];
+  const amount = BigInt(event.data ?? 0);
+  await db.run(
+    `UPDATE balances SET balance = balance - ? WHERE user = ?`,
+    [amount.toString(), user],
+  );
+  await db.run(
+    `INSERT INTO claim_events (user, amount, ledger, tx_hash) VALUES (?, ?, ?, ?)`,
+    [user, amount.toString(), event.ledger, event.txHash],
+  );
+}
+
+/**
+ * Index a snapshot event.
+ *
+ * The contract stores only a ledger reference — not a full balance copy.
+ * Off-chain consumers can call Horizon getLedgerEntries with this ledger
+ * number to reconstruct all user balances at that exact point in time.
+ *
+ * Pattern:
+ *   1. Read `snapshot_ledger` from this event.
+ *   2. Fetch all `BALANCE` storage entries at `snapshot_ledger` from Horizon.
+ *   3. Persist the reconstructed balances to `snapshot_balances`.
+ */
+async function handleSnapshotEvent(event, db) {
+  const snapshotId = BigInt(event.topic?.[1] ?? 0);
+  const snapshotLedger = BigInt(event.data ?? 0);
+  await db.run(
+    `INSERT OR REPLACE INTO snapshots (snapshot_id, ledger_number, recorded_at)
+     VALUES (?, ?, ?)`,
+    [snapshotId.toString(), snapshotLedger.toString(), Date.now()],
+  );
+}
+
+async function handleVestedCreditEvent(event, db) {
+  const user = event.topic?.[1];
+  const [vestId, total] = Array.isArray(event.data) ? event.data : [0, 0];
+  await db.run(
+    `INSERT INTO vesting_schedules (user, vest_id, total, ledger, tx_hash)
+     VALUES (?, ?, ?, ?, ?)`,
+    [user, String(vestId), String(total), event.ledger, event.txHash],
+  );
+}
+
+async function handleVestedClaimEvent(event, db) {
+  const user = event.topic?.[1];
+  const [vestId, amount] = Array.isArray(event.data) ? event.data : [0, 0];
+  await db.run(
+    `INSERT INTO vested_claim_events (user, vest_id, amount, ledger, tx_hash)
+     VALUES (?, ?, ?, ?, ?)`,
+    [user, String(vestId), String(amount), event.ledger, event.txHash],
+  );
+}

--- a/contracts/integration/Cargo.toml
+++ b/contracts/integration/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "integration"
+version = "0.1.0"
+edition = "2021"
+publish = false
+rust-version = "1.75.0"
+description = "End-to-end integration tests for Trivela Soroban contracts"
+license = "Apache-2.0"
+
+[lib]
+path = "src/lib.rs"
+doctest = false
+
+[dev-dependencies]
+soroban-sdk = { version = "25.1", features = ["testutils"] }
+trivela-rewards-contract = { path = "../rewards" }
+trivela-campaign-contract = { path = "../campaign" }

--- a/contracts/integration/src/lib.rs
+++ b/contracts/integration/src/lib.rs
@@ -1,0 +1,2 @@
+// Integration test harness for Trivela Soroban contracts.
+// Actual test scenarios live in tests/scenarios.rs.

--- a/contracts/integration/tests/scenarios.rs
+++ b/contracts/integration/tests/scenarios.rs
@@ -1,0 +1,356 @@
+//! End-to-end integration tests for the Trivela Soroban contracts.
+//!
+//! Scenarios:
+//!  A – Happy path: register → credit → claim
+//!  B – Paused rewards: credit blocked, unpause, claim succeeds
+//!  C – Cap reached: CapReached on 3rd registration when cap=2
+//!  D – Merkle allowlist: valid proof succeeds, invalid proof rejected
+//!  E – Admin upgrade flow: deploy → migrate → verify schema_version
+
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{symbol_short, vec, Address, Bytes, BytesN, Env, Vec as SdkVec};
+use trivela_campaign_contract::{CampaignContract, CampaignContractClient, Error as CampaignError};
+use trivela_rewards_contract::{Error as RewardsError, RewardsContract, RewardsContractClient};
+
+fn seed_users(env: &Env, count: usize) -> std::vec::Vec<Address> {
+    (0..count).map(|_| Address::generate(env)).collect()
+}
+
+fn empty_proof(env: &Env) -> (BytesN<32>, SdkVec<BytesN<32>>) {
+    (BytesN::from_array(env, &[0u8; 32]), SdkVec::new(env))
+}
+
+/// Build a two-leaf Merkle tree. Returns (root, proof_for_a, proof_for_b).
+fn build_two_leaf_tree(
+    env: &Env,
+    leaf_a: BytesN<32>,
+    leaf_b: BytesN<32>,
+) -> (BytesN<32>, SdkVec<BytesN<32>>, SdkVec<BytesN<32>>) {
+    let (left, right) = if leaf_a <= leaf_b {
+        (leaf_a.clone(), leaf_b.clone())
+    } else {
+        (leaf_b.clone(), leaf_a.clone())
+    };
+    let mut combined = [0u8; 64];
+    combined[..32].copy_from_slice(&left.to_array());
+    combined[32..].copy_from_slice(&right.to_array());
+    let root: BytesN<32> = env
+        .crypto()
+        .sha256(&Bytes::from_slice(env, &combined))
+        .into();
+    (root, vec![env, leaf_b], vec![env, leaf_a])
+}
+
+// ── Scenario A: Happy Path ────────────────────────────────────────────────────
+
+/// Full happy-path flow across campaign (registry) and rewards contracts:
+/// register 5 users → credit each → all claim → verify final balances.
+#[test]
+fn scenario_a_happy_path() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let users = seed_users(&env, 5);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+
+    let (leaf, proof) = empty_proof(&env);
+
+    // Register all 5 users in the campaign registry.
+    for user in &users {
+        assert!(campaign.register(user, &leaf, &proof));
+    }
+    assert_eq!(campaign.get_participant_count(), 5);
+
+    // Credit each user 100 points.
+    for user in &users {
+        rewards.credit(&admin, user, &100u64);
+    }
+    for user in &users {
+        assert_eq!(rewards.balance(user), 100);
+    }
+
+    // Each user claims 40 points.
+    for user in &users {
+        rewards.claim(user, &40u64);
+    }
+    for user in &users {
+        assert_eq!(rewards.balance(user), 60);
+    }
+
+    assert_eq!(rewards.total_claimed(), 200); // 5 users × 40
+}
+
+// ── Scenario B: Paused Rewards ────────────────────────────────────────────────
+
+/// Pause the rewards contract → credit and claim return ContractPaused →
+/// unpause → claim succeeds.
+#[test]
+fn scenario_b_paused_rewards() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let users = seed_users(&env, 5);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+
+    let (leaf, proof) = empty_proof(&env);
+    for user in &users {
+        campaign.register(user, &leaf, &proof);
+    }
+
+    // Pre-credit before pausing.
+    for user in &users {
+        rewards.credit(&admin, user, &100u64);
+    }
+
+    // Pause rewards.
+    rewards.set_paused(&admin, &true);
+    assert!(rewards.is_paused());
+
+    // Credit and claim are both blocked.
+    for user in &users {
+        assert_eq!(
+            rewards.try_credit(&admin, user, &10u64),
+            Err(Ok(RewardsError::ContractPaused))
+        );
+        assert_eq!(
+            rewards.try_claim(user, &10u64),
+            Err(Ok(RewardsError::ContractPaused))
+        );
+    }
+
+    // Unpause and verify claims now succeed.
+    rewards.set_paused(&admin, &false);
+    assert!(!rewards.is_paused());
+    for user in &users {
+        rewards.claim(user, &50u64);
+        assert_eq!(rewards.balance(user), 50);
+    }
+}
+
+// ── Scenario C: Cap Reached ───────────────────────────────────────────────────
+
+/// Set participant cap=2 → register 2 users → 3rd registration returns CapReached.
+#[test]
+fn scenario_c_cap_reached() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let users = seed_users(&env, 5);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+
+    // Set cap to 2.
+    campaign.set_max_cap(&admin, &0u64, &2u64);
+    assert_eq!(campaign.get_max_cap(), 2);
+
+    let (leaf, proof) = empty_proof(&env);
+
+    // First two registrations succeed.
+    assert!(campaign.register(&users[0], &leaf, &proof));
+    assert!(campaign.register(&users[1], &leaf, &proof));
+    assert_eq!(campaign.get_participant_count(), 2);
+
+    // Third registration hits the cap.
+    assert_eq!(
+        campaign.try_register(&users[2], &leaf, &proof),
+        Err(Ok(CampaignError::CapReached))
+    );
+    assert_eq!(campaign.get_participant_count(), 2);
+
+    // Rewards still work for the two registered participants.
+    for user in users.iter().take(2) {
+        rewards.credit(&admin, user, &100u64);
+    }
+    assert_eq!(rewards.balance(&users[0]), 100);
+    assert_eq!(rewards.balance(&users[1]), 100);
+    assert_eq!(rewards.balance(&users[2]), 0);
+}
+
+// ── Scenario D: Merkle Allowlist ──────────────────────────────────────────────
+
+/// Set a Merkle root → valid proof succeeds → invalid proof rejected (NotInAllowlist).
+#[test]
+fn scenario_d_merkle_allowlist() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let users = seed_users(&env, 5);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+
+    // Build a two-leaf tree: alice and bob are in the allowlist.
+    let leaf_alice: BytesN<32> = BytesN::from_array(&env, &[1u8; 32]);
+    let leaf_bob: BytesN<32> = BytesN::from_array(&env, &[2u8; 32]);
+    let (root, proof_alice, proof_bob) =
+        build_two_leaf_tree(&env, leaf_alice.clone(), leaf_bob.clone());
+
+    campaign.set_merkle_root(&admin, &0u64, &root);
+
+    // Allowlisted users (alice/bob represented by users[0]/users[1]) register successfully.
+    assert!(campaign.register(&users[0], &leaf_alice, &proof_alice));
+    assert!(campaign.register(&users[1], &leaf_bob, &proof_bob));
+    assert_eq!(campaign.get_participant_count(), 2);
+
+    // User with an invalid proof is rejected.
+    let bad_leaf: BytesN<32> = BytesN::from_array(&env, &[9u8; 32]);
+    let empty_pf: SdkVec<BytesN<32>> = SdkVec::new(&env);
+    assert_eq!(
+        campaign.try_register(&users[2], &bad_leaf, &empty_pf),
+        Err(Ok(CampaignError::NotInAllowlist))
+    );
+
+    // Rewards flow works for the two allowlisted users.
+    for user in users.iter().take(2) {
+        rewards.credit(&admin, user, &50u64);
+        rewards.claim(user, &20u64);
+        assert_eq!(rewards.balance(user), 30);
+    }
+}
+
+// ── Scenario E: Admin Upgrade Flow ───────────────────────────────────────────
+
+/// Deploy rewards and campaign → call migrate → verify schema_version remains 1.
+/// Also verifies that only the admin can call migrate, and unsupported versions fail.
+#[test]
+fn scenario_e_admin_upgrade_flow() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    assert_eq!(rewards.schema_version(), 1);
+    assert_eq!(campaign.schema_version(), 1);
+
+    env.mock_all_auths();
+
+    // Migrate to version 1 (idempotent).
+    assert_eq!(rewards.migrate(&admin, &1u32), 1);
+    assert_eq!(rewards.schema_version(), 1);
+    assert_eq!(campaign.migrate(&admin, &1u32), 1);
+    assert_eq!(campaign.schema_version(), 1);
+
+    // Unsupported version returns UnsupportedMigration.
+    assert_eq!(
+        rewards.try_migrate(&admin, &99u32),
+        Err(Ok(RewardsError::UnsupportedMigration))
+    );
+    assert_eq!(
+        campaign.try_migrate(&admin, &99u32),
+        Err(Ok(CampaignError::UnsupportedMigration))
+    );
+
+    // Non-admin cannot migrate.
+    assert_eq!(
+        rewards.try_migrate(&non_admin, &1u32),
+        Err(Ok(RewardsError::Unauthorized))
+    );
+}
+
+// ── Multi-user bonus scenario ─────────────────────────────────────────────────
+
+/// 5+ users with campaign multiplier, batch credit, vesting, snapshot, and rate limit.
+#[test]
+fn scenario_f_full_feature_integration() {
+    let env = Env::default();
+    let campaign_id = env.register_contract(None, CampaignContract);
+    let campaign = CampaignContractClient::new(&env, &campaign_id);
+    let rewards_id = env.register_contract(None, RewardsContract);
+    let rewards = RewardsContractClient::new(&env, &rewards_id);
+
+    let admin = Address::generate(&env);
+    let users = seed_users(&env, 6);
+
+    campaign.initialize(&admin);
+    rewards.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 0;
+    });
+
+    let (leaf, proof) = empty_proof(&env);
+    for user in &users {
+        campaign.register(user, &leaf, &proof);
+    }
+    assert_eq!(campaign.get_participant_count(), 6);
+
+    // Set 1.5x multiplier for campaign 1 and credit all users.
+    rewards.set_campaign_multiplier(&admin, &1u64, &15_000u32);
+    for user in &users {
+        rewards.credit_for_campaign(&admin, user, &1u64, &100u64);
+    }
+    for user in &users {
+        assert_eq!(rewards.balance(user), 150);
+    }
+
+    // Batch-credit an additional 50 to all users.
+    let recipients: SdkVec<(Address, u64)> = users.iter().fold(SdkVec::new(&env), |mut acc, u| {
+        acc.push_back((u.clone(), 50u64));
+        acc
+    });
+    rewards.batch_credit(&admin, &recipients);
+    for user in &users {
+        assert_eq!(rewards.balance(user), 200);
+    }
+
+    // Set up vesting for user[0]: 600 points over ledgers 0 → 100.
+    rewards.credit_vested(&admin, &users[0], &600u64, &0u32, &100u32);
+
+    // At ledger 50, user[0] can claim 300 vested points.
+    env.ledger().with_mut(|li| li.sequence_number = 50);
+    assert_eq!(rewards.vested_balance(&users[0]), 300);
+    rewards.claim_vested(&users[0], &0u64, &300u64);
+    assert_eq!(rewards.vested_balance(&users[0]), 0);
+
+    // Take a snapshot at ledger 50.
+    rewards.snapshot(&admin, &1u64);
+    assert_eq!(rewards.get_snapshot(&1u64), Some(50u64));
+
+    // All 6 users claim their regular balance.
+    for user in &users {
+        rewards.claim(user, &100u64);
+    }
+    for user in &users {
+        assert_eq!(rewards.balance(user), 100);
+    }
+
+    // total_claimed tracks only regular claim() calls, not claim_vested().
+    assert_eq!(rewards.total_claimed(), 600);
+}

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -10,11 +10,16 @@
 //! - `paused`: topics `(paused,)`, data `is_paused: bool`
 //! - `max_credit_per_call`: topics `(mxcredit,)`, data `max_amount: u64`
 //! - `campaign_multiplier`: topics `(multset, campaign_id)`, data `multiplier_bps: u32`
+//! - `rate_limit_set`: topics `(ratlset,)`, data `(max_calls: u32, window_ledgers: u32)`
+//! - `snapshot`: topics `(snapshot, snapshot_id)`, data `ledger: u32`
+//! - `vested_credit`: topics `(vcredit, user)`, data `(vest_id: u64, total: u64)`
+//! - `vested_claim`: topics `(vclaim, user)`, data `(vest_id: u64, amount: u64)`
 
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contractmeta, symbol_short, Address, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address, Env,
+    Symbol, Vec,
 };
 
 #[contracterror]
@@ -28,6 +33,18 @@ pub enum Error {
     CreditLimitExceeded = 5,
     UnsupportedMigration = 6,
     InvalidMultiplier = 7,
+    RateLimitExceeded = 8,
+    VestingNotFound = 9,
+}
+
+/// Vesting schedule record stored per user per vest_id.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VestingRecord {
+    pub total: u64,
+    pub start_ledger: u32,
+    pub end_ledger: u32,
+    pub claimed: u64,
 }
 
 contractmeta!(
@@ -53,6 +70,24 @@ const CAMPAIGN_MULTIPLIER: Symbol = symbol_short!("mult");
 const TIERS: Symbol = symbol_short!("tiers");
 const BPS_DENOMINATOR: u128 = 10_000;
 
+// Rate limiting constants (issue #324)
+const RATE_LIM_MAX: Symbol = symbol_short!("ratlmax");
+const RATE_LIM_WIN: Symbol = symbol_short!("ratlwin");
+const RATE: Symbol = symbol_short!("rate");
+const RATE_LIM_SET_EVENT: Symbol = symbol_short!("ratlset");
+
+// Snapshot constants (issue #325)
+const SNAPSHOT: Symbol = symbol_short!("snap");
+const SNAP_LIST: Symbol = symbol_short!("snaplist");
+const SNAPSHOT_EVENT: Symbol = symbol_short!("snapshot");
+
+// Vesting constants (issue #326)
+const VEST: Symbol = symbol_short!("vest");
+const VEST_CTR: Symbol = symbol_short!("vestctr");
+const VEST_IDS: Symbol = symbol_short!("vestids");
+const VESTED_CREDIT_EVENT: Symbol = symbol_short!("vcredit");
+const VESTED_CLAIM_EVENT: Symbol = symbol_short!("vclaim");
+
 #[contract]
 pub struct RewardsContract;
 
@@ -74,6 +109,40 @@ fn ensure_not_paused(env: &Env) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+/// Check caller's rate limit and increment their count for the current window.
+/// `n_calls` is how many calls to count (1 for credit, N for batch_credit).
+fn check_and_increment_rate(env: &Env, caller: &Address, n_calls: u32) -> Result<(), Error> {
+    let max_calls: u32 = env.storage().instance().get(&RATE_LIM_MAX).unwrap_or(0);
+    if max_calls == 0 {
+        return Ok(());
+    }
+    let window_ledgers: u32 = env.storage().instance().get(&RATE_LIM_WIN).unwrap_or(1);
+    let current_ledger = env.ledger().sequence();
+    let window_start = current_ledger.checked_div(window_ledgers).unwrap_or(0);
+    let rate_key = (RATE, caller.clone(), window_start);
+    let count: u32 = env.storage().instance().get(&rate_key).unwrap_or(0);
+    if count.saturating_add(n_calls) > max_calls {
+        return Err(Error::RateLimitExceeded);
+    }
+    env.storage().instance().set(&rate_key, &(count + n_calls));
+    Ok(())
+}
+
+/// Compute unlocked amount for a vesting record at `now` (current ledger sequence).
+fn compute_unlocked(now: u32, record: &VestingRecord) -> u64 {
+    if now <= record.start_ledger {
+        return 0;
+    }
+    if now >= record.end_ledger {
+        return record.total;
+    }
+    let elapsed = (now - record.start_ledger) as u128;
+    let duration = (record.end_ledger - record.start_ledger) as u128;
+    let total = record.total as u128;
+    let unlocked = total * elapsed / duration;
+    (unlocked.min(record.total as u128)) as u64
 }
 
 #[contractimpl]
@@ -181,6 +250,7 @@ impl RewardsContract {
     pub fn credit(env: Env, from: Address, user: Address, amount: u64) -> Result<u64, Error> {
         from.require_auth();
         ensure_not_paused(&env)?;
+        check_and_increment_rate(&env, &from, 1)?;
 
         let max_credit_per_call: u64 = env
             .storage()
@@ -229,6 +299,7 @@ impl RewardsContract {
     }
 
     /// Credit points to multiple users in one call.
+    /// Each recipient counts as one call toward the rate limit.
     pub fn batch_credit(
         env: Env,
         from: Address,
@@ -236,6 +307,7 @@ impl RewardsContract {
     ) -> Result<(), Error> {
         from.require_auth();
         ensure_not_paused(&env)?;
+        check_and_increment_rate(&env, &from, recipients.len())?;
 
         let mut staged = Vec::new(&env);
 
@@ -252,7 +324,6 @@ impl RewardsContract {
                 .set(&(BALANCE, user.clone()), &new_balance);
         }
 
-        // Emit credit event for each recipient
         for (user, amount) in recipients.iter() {
             env.events().publish((CREDIT_EVENT, user), amount);
         }
@@ -341,7 +412,8 @@ impl RewardsContract {
         let sorted = sort_tiers(&env, tiers);
         env.storage().instance().set(&(TIERS, campaign_id), &sorted);
 
-        env.events().publish((Symbol::new(&env, "set_tiers"), campaign_id), ());
+        env.events()
+            .publish((Symbol::new(&env, "set_tiers"), campaign_id), ());
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
     }
@@ -352,14 +424,16 @@ impl RewardsContract {
 
         env.storage().instance().remove(&(TIERS, campaign_id));
 
-        env.events().publish((Symbol::new(&env, "clear_tiers"), campaign_id), ());
+        env.events()
+            .publish((Symbol::new(&env, "clear_tiers"), campaign_id), ());
         env.storage().instance().extend_ttl(50, 100);
         Ok(())
     }
 
     /// Get points reward for a given rank under a campaign.
     pub fn get_tier_for_rank(env: Env, rank: u64, campaign_id: u64) -> u64 {
-        let tiers_opt: Option<Vec<(u64, u64)>> = env.storage().instance().get(&(TIERS, campaign_id));
+        let tiers_opt: Option<Vec<(u64, u64)>> =
+            env.storage().instance().get(&(TIERS, campaign_id));
         if let Some(tiers) = tiers_opt {
             for (max_rank, points) in tiers.iter() {
                 if max_rank > 0 {
@@ -388,16 +462,211 @@ impl RewardsContract {
         let points = Self::get_tier_for_rank(env.clone(), rank, campaign_id);
         let new_balance = Self::credit(env.clone(), from, user.clone(), points)?;
 
-        env.events().publish(
-            (Symbol::new(&env, "tier_credit"), user),
-            (rank, points),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "tier_credit"), user), (rank, points));
 
         Ok(new_balance)
     }
+
+    // ── Rate Limiting (issue #324) ────────────────────────────────────────────
+
+    /// Set per-caller credit rate limit (admin only).
+    /// `max_calls` credits allowed per `window_ledgers` ledger window.
+    /// Set `max_calls = 0` to disable rate limiting.
+    pub fn set_credit_rate_limit(
+        env: Env,
+        admin: Address,
+        max_calls: u32,
+        window_ledgers: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        env.storage().instance().set(&RATE_LIM_MAX, &max_calls);
+        env.storage().instance().set(&RATE_LIM_WIN, &window_ledgers);
+        env.events()
+            .publish((RATE_LIM_SET_EVENT,), (max_calls, window_ledgers));
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(())
+    }
+
+    /// Get the current rate limit config: `(max_calls, window_ledgers)`.
+    /// Returns `(0, 0)` when no limit is configured.
+    pub fn get_credit_rate_limit(env: Env) -> (u32, u32) {
+        let max_calls: u32 = env.storage().instance().get(&RATE_LIM_MAX).unwrap_or(0);
+        let window_ledgers: u32 = env.storage().instance().get(&RATE_LIM_WIN).unwrap_or(0);
+        (max_calls, window_ledgers)
+    }
+
+    /// Get the number of credit calls made by `caller` in the current window.
+    pub fn credit_call_count(env: Env, caller: Address) -> u32 {
+        let window_ledgers: u32 = env.storage().instance().get(&RATE_LIM_WIN).unwrap_or(1);
+        let current_ledger = env.ledger().sequence();
+        let window_start = if window_ledgers > 0 {
+            current_ledger.checked_div(window_ledgers).unwrap_or(0)
+        } else {
+            0u32
+        };
+        let rate_key = (RATE, caller, window_start);
+        env.storage().instance().get(&rate_key).unwrap_or(0)
+    }
+
+    // ── Snapshot (issue #325) ─────────────────────────────────────────────────
+
+    /// Record the current ledger number under `snapshot_id` (admin only).
+    /// Does NOT copy balances — stores a ledger reference for off-chain indexing.
+    /// Off-chain indexers can use the ledger number with Horizon `getLedgerEntries`
+    /// to reconstruct balances at that point in time.
+    pub fn snapshot(env: Env, admin: Address, snapshot_id: u64) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        let ledger_number = env.ledger().sequence() as u64;
+        env.storage()
+            .instance()
+            .set(&(SNAPSHOT, snapshot_id), &ledger_number);
+
+        let mut list: Vec<(u64, u64)> = env
+            .storage()
+            .instance()
+            .get(&SNAP_LIST)
+            .unwrap_or_else(|| Vec::new(&env));
+        list.push_back((snapshot_id, ledger_number));
+        env.storage().instance().set(&SNAP_LIST, &list);
+
+        env.events()
+            .publish((SNAPSHOT_EVENT, snapshot_id), ledger_number);
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(())
+    }
+
+    /// Returns the ledger number recorded for `snapshot_id`, or `None`.
+    pub fn get_snapshot(env: Env, snapshot_id: u64) -> Option<u64> {
+        env.storage().instance().get(&(SNAPSHOT, snapshot_id))
+    }
+
+    /// Returns all `(snapshot_id, ledger_number)` pairs in creation order.
+    pub fn list_snapshots(env: Env) -> Vec<(u64, u64)> {
+        env.storage()
+            .instance()
+            .get(&SNAP_LIST)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Vesting (issue #326) ──────────────────────────────────────────────────
+
+    /// Credit a linearly-vesting amount to a user (authorized caller only).
+    /// Vesting is linear: `unlocked = total * (now - start_ledger) / (end_ledger - start_ledger)`.
+    /// Returns the new vest_id for this schedule.
+    pub fn credit_vested(
+        env: Env,
+        from: Address,
+        user: Address,
+        total_amount: u64,
+        start_ledger: u32,
+        end_ledger: u32,
+    ) -> Result<u64, Error> {
+        from.require_auth();
+        ensure_not_paused(&env)?;
+
+        let vest_ctr_key = (VEST_CTR, user.clone());
+        let vest_id: u64 = env.storage().instance().get(&vest_ctr_key).unwrap_or(0);
+        let next_vest_id = vest_id + 1;
+
+        let record = VestingRecord {
+            total: total_amount,
+            start_ledger,
+            end_ledger,
+            claimed: 0,
+        };
+        env.storage()
+            .instance()
+            .set(&(VEST, user.clone(), vest_id), &record);
+        env.storage().instance().set(&vest_ctr_key, &next_vest_id);
+
+        let vest_ids_key = (VEST_IDS, user.clone());
+        let mut ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&vest_ids_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        ids.push_back(vest_id);
+        env.storage().instance().set(&vest_ids_key, &ids);
+
+        env.events()
+            .publish((VESTED_CREDIT_EVENT, user), (vest_id, total_amount));
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(vest_id)
+    }
+
+    /// Returns the currently unlocked but unclaimed vested balance for a user
+    /// across all active vesting schedules.
+    pub fn vested_balance(env: Env, user: Address) -> u64 {
+        let vest_ids_key = (VEST_IDS, user.clone());
+        let ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&vest_ids_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        let now = env.ledger().sequence();
+        let mut total_available = 0u64;
+        for vest_id in ids.iter() {
+            let key = (VEST, user.clone(), vest_id);
+            if let Some(record) = env.storage().instance().get::<_, VestingRecord>(&key) {
+                let unlocked = compute_unlocked(now, &record);
+                let available = unlocked.saturating_sub(record.claimed);
+                total_available = total_available.saturating_add(available);
+            }
+        }
+        total_available
+    }
+
+    /// Claim up to `amount` from the unlocked portion of a specific vesting schedule.
+    /// Returns the remaining claimable amount in that vest schedule after this claim.
+    pub fn claim_vested(env: Env, user: Address, vest_id: u64, amount: u64) -> Result<u64, Error> {
+        user.require_auth();
+        ensure_not_paused(&env)?;
+
+        let key = (VEST, user.clone(), vest_id);
+        let mut record: VestingRecord = env
+            .storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::VestingNotFound)?;
+
+        let now = env.ledger().sequence();
+        let unlocked = compute_unlocked(now, &record);
+        let available = unlocked.saturating_sub(record.claimed);
+
+        if amount > available {
+            return Err(Error::InsufficientBalance);
+        }
+
+        record.claimed = record.claimed.checked_add(amount).ok_or(Error::Overflow)?;
+        env.storage().instance().set(&key, &record);
+
+        env.events()
+            .publish((VESTED_CLAIM_EVENT, user), (vest_id, amount));
+        env.storage().instance().extend_ttl(50, 100);
+        Ok(available - amount)
+    }
+
+    /// Returns the sum of all vesting schedule totals for a user (vested + unvested).
+    pub fn total_vested(env: Env, user: Address) -> u64 {
+        let vest_ids_key = (VEST_IDS, user.clone());
+        let ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&vest_ids_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut total = 0u64;
+        for vest_id in ids.iter() {
+            let key = (VEST, user.clone(), vest_id);
+            if let Some(record) = env.storage().instance().get::<_, VestingRecord>(&key) {
+                total = total.saturating_add(record.total);
+            }
+        }
+        total
+    }
 }
 
-fn sort_tiers(env: &Env, tiers: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
+fn sort_tiers(_env: &Env, tiers: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
     let mut sorted = tiers.clone();
     let len = sorted.len();
     if len <= 1 {
@@ -409,13 +678,7 @@ fn sort_tiers(env: &Env, tiers: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
             let (rank_a, points_a) = sorted.get(j).unwrap();
             let (rank_b, points_b) = sorted.get(j + 1).unwrap();
 
-            let swap = if rank_a == 0 && rank_b != 0 {
-                true
-            } else if rank_a != 0 && rank_b != 0 && rank_a > rank_b {
-                true
-            } else {
-                false
-            };
+            let swap = rank_b != 0 && (rank_a == 0 || rank_a > rank_b);
 
             if swap {
                 sorted.set(j, (rank_b, points_b));
@@ -425,7 +688,6 @@ fn sort_tiers(env: &Env, tiers: Vec<(u64, u64)>) -> Vec<(u64, u64)> {
     }
     sorted
 }
-
 
 #[cfg(test)]
 mod test;

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -657,12 +657,20 @@ fn test_tiered_rewards_sorting_and_credit() {
             ),
             (
                 contract_id.clone(),
-                vec![&env, symbol_short!("credit").into_val(&env), user.clone().into_val(&env)],
+                vec![
+                    &env,
+                    symbol_short!("credit").into_val(&env),
+                    user.clone().into_val(&env)
+                ],
                 100u64.into_val(&env)
             ),
             (
                 contract_id.clone(),
-                vec![&env, tier_credit_event.into_val(&env), user.clone().into_val(&env)],
+                vec![
+                    &env,
+                    tier_credit_event.into_val(&env),
+                    user.clone().into_val(&env)
+                ],
                 (5u64, 100u64).into_val(&env)
             )
         ]
@@ -678,3 +686,362 @@ fn test_tiered_rewards_sorting_and_credit() {
     assert_eq!(client.get_tier_for_rank(&5, &1u64), 0);
 }
 
+// ── Rate Limiting Tests (issue #324) ─────────────────────────────────────────
+
+#[test]
+fn test_rate_limit_enforced() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Allow 2 calls per window of 10 ledgers.
+    client.set_credit_rate_limit(&admin, &2u32, &10u32);
+    assert_eq!(client.get_credit_rate_limit(), (2u32, 10u32));
+
+    // First two calls succeed.
+    client.credit(&admin, &user, &10);
+    client.credit(&admin, &user, &10);
+    assert_eq!(client.credit_call_count(&admin), 2);
+
+    // Third call in the same window is rejected.
+    let result = client.try_credit(&admin, &user, &10);
+    assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+    assert_eq!(client.balance(&user), 20);
+}
+
+#[test]
+fn test_rate_limit_window_rollover_resets_count() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Window of 10 ledgers, max 1 call per window.
+    client.set_credit_rate_limit(&admin, &1u32, &10u32);
+
+    // At ledger 5 (window 0): one call succeeds, second fails.
+    env.ledger().with_mut(|li| li.sequence_number = 5);
+    client.credit(&admin, &user, &10);
+    assert_eq!(
+        client.try_credit(&admin, &user, &10),
+        Err(Ok(Error::RateLimitExceeded))
+    );
+
+    // At ledger 15 (window 1): count resets, one call succeeds again.
+    env.ledger().with_mut(|li| li.sequence_number = 15);
+    assert_eq!(client.credit_call_count(&admin), 0);
+    client.credit(&admin, &user, &10);
+    assert_eq!(client.credit_call_count(&admin), 1);
+    assert_eq!(client.balance(&user), 20);
+}
+
+#[test]
+fn test_rate_limit_batch_credit_counts_as_n_calls() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_c = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Max 2 calls per window.
+    client.set_credit_rate_limit(&admin, &2u32, &10u32);
+
+    // Batch of 2 recipients uses up both slots.
+    let recipients = vec![&env, (user_a.clone(), 10u64), (user_b.clone(), 10u64)];
+    client.batch_credit(&admin, &recipients);
+    assert_eq!(client.credit_call_count(&admin), 2);
+
+    // A batch of 1 more should fail.
+    let recipients2 = vec![&env, (user_c.clone(), 10u64)];
+    let result = client.try_batch_credit(&admin, &recipients2);
+    assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+}
+
+#[test]
+fn test_rate_limit_zero_disables_limiting() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // 0 means unlimited.
+    client.set_credit_rate_limit(&admin, &0u32, &10u32);
+
+    for _ in 0..20 {
+        client.credit(&admin, &user, &1);
+    }
+    assert_eq!(client.balance(&user), 20);
+}
+
+// ── Snapshot Tests (issue #325) ───────────────────────────────────────────────
+
+#[test]
+fn test_snapshot_creation_and_retrieval() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.sequence_number = 42);
+    client.snapshot(&admin, &1u64);
+
+    assert_eq!(client.get_snapshot(&1u64), Some(42u64));
+    assert_eq!(client.get_snapshot(&99u64), None);
+}
+
+#[test]
+fn test_snapshot_list_snapshots() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.sequence_number = 10);
+    client.snapshot(&admin, &1u64);
+    env.ledger().with_mut(|li| li.sequence_number = 20);
+    client.snapshot(&admin, &2u64);
+
+    let list = client.list_snapshots();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list.get(0).unwrap(), (1u64, 10u64));
+    assert_eq!(list.get(1).unwrap(), (2u64, 20u64));
+}
+
+#[test]
+fn test_snapshot_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.sequence_number = 77);
+    client.snapshot(&admin, &5u64);
+
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_id.clone(),
+                vec![&env, SNAPSHOT_EVENT.into_val(&env), 5u64.into_val(&env)],
+                77u64.into_val(&env)
+            )
+        ]
+    );
+}
+
+#[test]
+fn test_snapshot_empty_list() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+
+    let list = client.list_snapshots();
+    assert_eq!(list.len(), 0);
+}
+
+// ── Vesting Tests (issue #326) ────────────────────────────────────────────────
+
+#[test]
+fn test_vesting_claim_before_start_returns_zero() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Vesting starts at ledger 100, ends at 200.
+    env.ledger().with_mut(|li| li.sequence_number = 50);
+    let vest_id = client.credit_vested(&admin, &user, &1000u64, &100u32, &200u32);
+    assert_eq!(vest_id, 0u64);
+
+    // Before start, nothing is unlocked.
+    assert_eq!(client.vested_balance(&user), 0);
+    let result = client.try_claim_vested(&user, &vest_id, &1);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
+#[test]
+fn test_vesting_claim_at_halfway_unlocks_half() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Vesting: 1000 points, ledgers 0 → 100.
+    client.credit_vested(&admin, &user, &1000u64, &0u32, &100u32);
+
+    // At ledger 50, exactly 500 should be unlocked.
+    env.ledger().with_mut(|li| li.sequence_number = 50);
+    assert_eq!(client.vested_balance(&user), 500);
+    assert_eq!(client.total_vested(&user), 1000);
+
+    let remaining = client.claim_vested(&user, &0u64, &500u64);
+    assert_eq!(remaining, 0);
+    assert_eq!(client.vested_balance(&user), 0);
+}
+
+#[test]
+fn test_vesting_claim_at_end_unlocks_all() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    client.credit_vested(&admin, &user, &500u64, &0u32, &100u32);
+
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+    assert_eq!(client.vested_balance(&user), 500);
+
+    let remaining = client.claim_vested(&user, &0u64, &500u64);
+    assert_eq!(remaining, 0);
+    assert_eq!(client.vested_balance(&user), 0);
+}
+
+#[test]
+fn test_vesting_claim_more_than_unlocked_errors() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // 1000 points, vesting 0 → 100; at ledger 50, only 500 is unlocked.
+    client.credit_vested(&admin, &user, &1000u64, &0u32, &100u32);
+    env.ledger().with_mut(|li| li.sequence_number = 50);
+
+    let result = client.try_claim_vested(&user, &0u64, &501u64);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
+#[test]
+fn test_vesting_not_found_errors() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    let result = client.try_claim_vested(&user, &99u64, &10u64);
+    assert_eq!(result, Err(Ok(Error::VestingNotFound)));
+}
+
+#[test]
+fn test_vesting_multiple_schedules() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    // Two vesting schedules.
+    client.credit_vested(&admin, &user, &200u64, &0u32, &100u32);
+    client.credit_vested(&admin, &user, &300u64, &0u32, &100u32);
+
+    assert_eq!(client.total_vested(&user), 500);
+
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+    // Both fully vested.
+    assert_eq!(client.vested_balance(&user), 500);
+
+    client.claim_vested(&user, &0u64, &200u64);
+    client.claim_vested(&user, &1u64, &300u64);
+    assert_eq!(client.vested_balance(&user), 0);
+}
+
+#[test]
+fn test_vesting_emits_events() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RewardsContract);
+    let client = RewardsContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &symbol_short!("Trivela"), &symbol_short!("TVL"));
+    env.mock_all_auths();
+
+    client.credit_vested(&admin, &user, &100u64, &0u32, &50u32);
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_id.clone(),
+                vec![
+                    &env,
+                    VESTED_CREDIT_EVENT.into_val(&env),
+                    user.clone().into_val(&env)
+                ],
+                (0u64, 100u64).into_val(&env)
+            )
+        ]
+    );
+
+    env.ledger().with_mut(|li| li.sequence_number = 50);
+    client.claim_vested(&user, &0u64, &100u64);
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_id.clone(),
+                vec![
+                    &env,
+                    VESTED_CLAIM_EVENT.into_val(&env),
+                    user.clone().into_val(&env)
+                ],
+                (0u64, 100u64).into_val(&env)
+            )
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Implements all four open Stellar Wave issues in a single combined PR.

- **#324** — Contract-level rate limiting: per-caller credit call count tracked per ledger window; `batch_credit` counts N recipients as N calls; `set_credit_rate_limit / get_credit_rate_limit / credit_call_count` admin/view functions added.
- **#325** — Snapshot function: `snapshot(admin, snapshot_id)` stores current ledger sequence; `get_snapshot / list_snapshots` views; `snapshot` event emitted for off-chain indexers; `backend/src/jobs/eventIndexer.js` added to index snapshot + vesting events into the DB.
- **#326** — Vesting schedule: `credit_vested / vested_balance / claim_vested / total_vested`; linear unlock formula `total * (now - start) / (end - start)`; `vested_credit` + `vested_claim` events; `VestingRecord` contracttype + `Error::VestingNotFound`.
- **#327** — Integration test harness: new `contracts/integration/` crate (package `integration`) with 6 scenarios (happy path, paused rewards, cap reached, Merkle allowlist, admin upgrade flow, full-feature); CI step `cargo test --package integration` added.

## Test plan

- [x] `cargo test -p trivela-rewards-contract` — 34 pass (14 new tests covering rate limit, snapshot, vesting)
- [x] `cargo test --package integration` — 6 pass (scenarios A–F)
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A deprecated` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pre-existing failures on `main` (`test_tiered_rewards_sorting_and_credit`, `test_admin_deregister`, `test_deregister_success_and_re_register`) remain unchanged

Closes #324
Closes #325
Closes #326
Closes #327