### PR TITLE
feat: prepare GitHub Pages contract API docs deployment (#520)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -38,6 +39,8 @@ jobs:
             ${{ runner.os }}-cargo-docs-
 
       - name: Check for missing documentation on public items
+        env:
+          RUSTDOCFLAGS: --html-root-url https://finessestudiolab.github.io/Trivela/
         run: |
           cargo doc --package trivela-campaign-contract --package trivela-rewards-contract --no-deps --document-private-items 2>&1 | tee cargo-doc-output.txt
           if grep -q "warning: missing documentation for" cargo-doc-output.txt; then
@@ -47,6 +50,8 @@ jobs:
           fi
 
       - name: Generate docs with cargo doc
+        env:
+          RUSTDOCFLAGS: --html-root-url https://finessestudiolab.github.io/Trivela/
         run: |
           cargo doc --package trivela-campaign-contract --package trivela-rewards-contract --no-deps
 
@@ -54,6 +59,13 @@ jobs:
         run: |
           rm -rf docs/contract-api
           cp -r target/doc docs/contract-api
+          touch docs/contract-api/.nojekyll
+          printf '%s\n' \
+            '<!DOCTYPE html>' \
+            '<meta charset="utf-8">' \
+            '<meta http-equiv="refresh" content="0; url=trivela_campaign_contract/">' \
+            '<link rel="canonical" href="trivela_campaign_contract/">' \
+            > docs/contract-api/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,12 @@ See the main [README](README.md) for full setup.
 Open a [Discussion](https://github.com/FinesseStudioLab/Trivela/discussions) or tag maintainers in
 an issue.
 
+## Maintainers
+
+Contract API docs are deployed to GitHub Pages via CI. If the **Deploy Contract API Docs**
+workflow fails with a Pages enablement error, see [docs/GITHUB_PAGES.md](docs/GITHUB_PAGES.md) for
+the one-time repository setup steps.
+
 ## Governance
 
 For information about proposing major changes, RFCs, and decision-making processes, see

--- a/docs/CONTRACTS_API.md
+++ b/docs/CONTRACTS_API.md
@@ -38,10 +38,10 @@ open target/doc/trivela_rewards_contract/index.html
 
 Generated docs are deployed to GitHub Pages on every push to `main`:
 
-| Contract | URL                                                                                  |
-| -------- | ------------------------------------------------------------------------------------ |
-| Campaign | `https://finessestudiolab.github.io/Trivela/contract-api/trivela_campaign_contract/` |
-| Rewards  | `https://finessestudiolab.github.io/Trivela/contract-api/trivela_rewards_contract/`  |
+| Contract | URL                                                                            |
+| -------- | ------------------------------------------------------------------------------ |
+| Campaign | `https://finessestudiolab.github.io/Trivela/trivela_campaign_contract/` |
+| Rewards  | `https://finessestudiolab.github.io/Trivela/trivela_rewards_contract/`  |
 
 ### Regenerating Documentation
 

--- a/docs/GITHUB_PAGES.md
+++ b/docs/GITHUB_PAGES.md
@@ -1,0 +1,44 @@
+# GitHub Pages — Contract API Documentation
+
+The contract API reference (generated via `cargo doc`) is published to GitHub Pages by the
+[Deploy Contract API Docs](../.github/workflows/docs.yml) workflow on every push to `main`.
+
+## Maintainer setup (one-time)
+
+GitHub Pages must be enabled in repository settings before the workflow can deploy. This requires
+**admin or maintainer** access on `FinesseStudioLab/Trivela`.
+
+1. Go to **Settings → Pages** in the repository.
+2. Under **Build and deployment**, set **Source** to **GitHub Actions** (not a branch).
+3. Save.
+
+No further configuration is needed — the existing workflow handles build and deployment.
+
+## Verification
+
+After enabling Pages:
+
+1. Merge to `main` (or re-run the latest failed **Deploy Contract API Docs** workflow).
+2. Confirm the workflow completes successfully in the **Actions** tab.
+3. Visit the published URLs (see [CONTRACTS_API.md](CONTRACTS_API.md#viewing-online)):
+   - `https://finessestudiolab.github.io/Trivela/` — redirects to campaign contract docs
+   - `https://finessestudiolab.github.io/Trivela/trivela_rewards_contract/` — rewards contract docs
+
+## Manual deployment
+
+Maintainers can trigger a deployment without pushing to `main`:
+
+1. Go to **Actions → Deploy Contract API Docs**.
+2. Click **Run workflow** and select the `main` branch.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+| ----- | ----- | --- |
+| `Get Pages site failed` | Pages not enabled | Complete the [one-time setup](#maintainer-setup-one-time) above |
+| Broken cross-links in docs | Incorrect `html-root-url` | The workflow sets `RUSTDOCFLAGS` to `https://finessestudiolab.github.io/Trivela/` — do not change without updating the Pages URL |
+
+## References
+
+- [GitHub Pages publishing source docs](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+- [Using custom workflows with GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)


### PR DESCRIPTION
## Summary
- Documents the one-time maintainer step to enable GitHub Pages (GitHub Actions source)
- Hardens `.github/workflows/docs.yml` for correct rustdoc deployment under `/Trivela/`
- Fixes incorrect published URLs in `docs/CONTRACTS_API.md`

Fixes #520

## Maintainer action required (cannot be done from a contributor PR)
1. Go to **Settings → Pages** on `FinesseStudioLab/Trivela`
2. Set **Source** to **GitHub Actions**
3. Save

## Test plan
- [ ] Maintainer enables Pages (see above)
- [ ] Merge to `main` → **Deploy Contract API Docs** workflow passes
- [ ] `https://finessestudiolab.github.io/Trivela/` redirects to campaign contract docs
- [ ] `https://finessestudiolab.github.io/Trivela/trivela_rewards_contract/` loads with working cross-links
- [ ] Optional: trigger workflow manually via **Actions → Deploy Contract API Docs → Run workflow**