### PR TITLE
feat: add mainnet deployment guide and security checklist (#522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ You can also build and deploy both contracts with the helper script:
 STELLAR_SOURCE=alice npm run deploy:testnet
 ```
 
+For **mainnet** deployment, see the full production walkthrough in
+[`docs/MAINNET_DEPLOY.md`](docs/MAINNET_DEPLOY.md) (pre-flight checks, env config, smoke tests) and
+[`docs/SECURITY.md`](docs/SECURITY.md) (key rotation and incident response). Quick entry point:
+
+```bash
+STELLAR_SOURCE=<mainnet-identity> npm run deploy:mainnet
+```
+
 Optional environment variables:
 
 - `STELLAR_NETWORK`: Stellar CLI network alias to deploy against (defaults to `testnet`)

--- a/docs/MAINNET_CHECKLIST.md
+++ b/docs/MAINNET_CHECKLIST.md
@@ -50,5 +50,7 @@ etc.) before the launch is approved.
 
 ## References
 
+- [MAINNET_DEPLOY.md](./MAINNET_DEPLOY.md) — step-by-step mainnet deployment guide
+- [SECURITY.md](./SECURITY.md) — key rotation and compromise procedures
 - [DEPLOYMENT.md](./DEPLOYMENT.md)
 - Issues: #278, #279, #280, #281, #282, #283, #284, #286, #288, #289, #290, #292

--- a/docs/MAINNET_DEPLOY.md
+++ b/docs/MAINNET_DEPLOY.md
@@ -146,8 +146,42 @@ set — this prevents accidental mainnet deploys from a mistyped env var.
 ### After deployment
 
 1. Record both contract IDs and the deployment transaction hashes.
-2. Call `initialize` on each contract with your admin address (if not done in a separate step).
+2. Call `initialize` on each contract with your admin address (see below).
 3. Copy contract IDs into backend and frontend production env (see below).
+
+#### Initialize contracts (Stellar CLI)
+
+Replace `<ADMIN_IDENTITY>`, `<REWARDS_ID>`, and `<CAMPAIGN_ID>` with your values. The admin identity
+must match the keypair that will control the contracts in production.
+
+```bash
+# Rewards contract — requires admin, name, and symbol
+stellar contract invoke \
+  --id <REWARDS_ID> \
+  --source <ADMIN_IDENTITY> \
+  --network mainnet \
+  -- initialize \
+  --admin <ADMIN_IDENTITY> \
+  --name "Trivela_Rewards" \
+  --symbol "TVL"
+
+# Campaign contract — requires admin only
+stellar contract invoke \
+  --id <CAMPAIGN_ID> \
+  --source <ADMIN_IDENTITY> \
+  --network mainnet \
+  -- initialize \
+  --admin <ADMIN_IDENTITY>
+```
+
+Verify initialization:
+
+```bash
+stellar contract invoke --id <REWARDS_ID> --network mainnet -- admin
+stellar contract invoke --id <CAMPAIGN_ID> --network mainnet -- admin
+```
+
+Both should return your admin public key (`G...`).
 
 ---
 
@@ -169,7 +203,7 @@ Set every production value — do not rely on defaults.
 | `REWARDS_CONTRACT_ID` | `C...` | From deploy script output |
 | `CAMPAIGN_CONTRACT_ID` | `C...` | From deploy script output |
 | `CORS_ALLOWED_ORIGINS` | `https://app.yourdomain.com` | **Must** match your production frontend origin |
-| `TRIVELA_API_KEYS` | `sk_prod_...` | Comma-separated write/admin API keys (generate strong random values) |
+| `TRIVELA_API_KEYS` | `sk_prod_...` | Comma-separated write/admin API keys (generate strong random values). This is the production API secret referenced in deployment checklists — there is no separate `API_KEY_SECRET` variable in this repo. |
 | `TRIVELA_MASTER_KEY` | `mk_prod_...` | Master key for API key management endpoints |
 
 ### Strongly recommended for production

--- a/docs/MAINNET_DEPLOY.md
+++ b/docs/MAINNET_DEPLOY.md
@@ -1,0 +1,371 @@
+# Mainnet Deployment Guide
+
+This guide walks through deploying Trivela to Stellar mainnet end-to-end: contracts, backend, frontend,
+and infrastructure. Complete the [Mainnet Launch Readiness Checklist](MAINNET_CHECKLIST.md) before
+going live.
+
+For network presets and endpoint defaults, see [STELLAR_NETWORKS.md](STELLAR_NETWORKS.md).
+
+---
+
+## Table of Contents
+
+1. [Pre-flight checks](#1-pre-flight-checks)
+2. [Wallet and key setup](#2-wallet-and-key-setup)
+3. [Contract deployment](#3-contract-deployment)
+4. [Backend configuration](#4-backend-configuration)
+5. [Frontend configuration](#5-frontend-configuration)
+6. [Kubernetes / Helm](#6-kubernetes--helm)
+7. [SSL and Nginx](#7-ssl-and-nginx)
+8. [Smoke test](#8-smoke-test)
+9. [Post-launch](#9-post-launch)
+
+---
+
+## 1. Pre-flight checks
+
+Run these from the repository root before touching mainnet.
+
+### Contract tests
+
+```bash
+npm run test:contracts
+```
+
+All workspace contract tests must pass. Fix failures before deploying.
+
+### TypeScript bindings in sync
+
+Regenerate bindings from the current WASM artifacts and confirm there are no uncommitted changes:
+
+```bash
+npm run contracts:build-bindings
+git diff --exit-code frontend/src/contracts/
+```
+
+If `git diff` reports changes, commit the updated bindings or rebuild contracts first.
+
+### Dependency audit
+
+Install and run `cargo-audit` against the contract workspace:
+
+```bash
+cargo install cargo-audit
+cargo audit
+```
+
+Resolve any reported vulnerabilities (or document accepted risks in your launch review) before
+mainnet deployment.
+
+### Launch checklist
+
+Review [MAINNET_CHECKLIST.md](MAINNET_CHECKLIST.md) and confirm security audit, TTL, admin rotation,
+and infrastructure items are complete.
+
+---
+
+## 2. Wallet and key setup
+
+### Generate a dedicated admin keypair
+
+1. Create a **new** keypair used only for Trivela contract administration — never reuse a personal
+   wallet.
+2. Prefer a **hardware wallet** (Ledger + Freighter) or a cold key stored offline.
+3. Record the public key (`G...`) — this becomes the contract `admin` at `initialize` time.
+
+> Do not paste secret keys into chat, tickets, or CI logs. See [SECURITY.md](SECURITY.md) for
+> rotation and compromise procedures.
+
+### Fund the deploy account
+
+The `STELLAR_SOURCE` identity must hold enough **XLM** on mainnet to:
+
+- Pay transaction fees for WASM uploads and contract deployments (typically a few XLM; keep ≥ 5 XLM
+  as buffer).
+- Cover any follow-up initialization or admin transactions.
+
+Verify balance on [Stellar Expert](https://stellar.expert/explorer/public) or via Horizon:
+
+```bash
+stellar account balance --address <G...> --network mainnet
+```
+
+### Configure the Stellar CLI identity
+
+```bash
+# Option A: named identity (recommended)
+stellar keys add trivela-mainnet-deploy --secret-key <S...>
+export STELLAR_SOURCE=trivela-mainnet-deploy
+
+# Option B: public key only (signing via hardware wallet / external signer)
+export STELLAR_SOURCE=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+---
+
+## 3. Contract deployment
+
+Trivela ships two Soroban contracts: **rewards** and **campaign**. The deploy script builds both
+WASM artifacts and writes contract IDs to env files.
+
+### Recommended: use the mainnet wrapper
+
+```bash
+export STELLAR_SOURCE=trivela-mainnet-deploy   # or your G... address
+export TRIVELA_BACKEND_ENV=.env.mainnet       # optional backend env output
+
+npm run deploy:mainnet
+```
+
+This sets `STELLAR_NETWORK=mainnet`, requires explicit mainnet confirmation, and writes
+`.env.mainnet` with `VITE_*` contract IDs.
+
+### Manual invocation
+
+```bash
+STELLAR_NETWORK=mainnet \
+TRIVELA_CONFIRM_MAINNET=yes \
+STELLAR_SOURCE=trivela-mainnet-deploy \
+TRIVELA_ENV_OUT=.env.mainnet \
+TRIVELA_BACKEND_ENV=.env.mainnet \
+./scripts/deploy-testnet.sh
+```
+
+### Mainnet safety guard
+
+`scripts/deploy-testnet.sh` defaults to **testnet**. Deploying to mainnet requires **both**:
+
+| Variable | Value | Purpose |
+| -------- | ----- | ------- |
+| `STELLAR_NETWORK` | `mainnet` | Selects the mainnet network preset |
+| `TRIVELA_CONFIRM_MAINNET` | `yes` | Explicit operator acknowledgement |
+
+Without `TRIVELA_CONFIRM_MAINNET=yes`, the script exits with an error even if `STELLAR_NETWORK` is
+set — this prevents accidental mainnet deploys from a mistyped env var.
+
+### After deployment
+
+1. Record both contract IDs and the deployment transaction hashes.
+2. Call `initialize` on each contract with your admin address (if not done in a separate step).
+3. Copy contract IDs into backend and frontend production env (see below).
+
+---
+
+## 4. Backend configuration
+
+Copy [`backend/.env.example`](../backend/.env.example) to your secrets manager or deployment config.
+Set every production value — do not rely on defaults.
+
+### Required variables
+
+| Variable | Mainnet value | Notes |
+| -------- | ------------- | ----- |
+| `NODE_ENV` | `production` | Enables production logging and error handling |
+| `PORT` | `3001` | Internal listen port (behind reverse proxy) |
+| `DATABASE_URL` | `postgresql://...` | **PostgreSQL required** for multi-instance production |
+| `STELLAR_NETWORK` | `mainnet` | Must match deployed contracts |
+| `SOROBAN_RPC_URL` | `https://soroban-mainnet.stellar.org` | See [STELLAR_NETWORKS.md](STELLAR_NETWORKS.md) |
+| `HORIZON_URL` | `https://horizon.stellar.org` | Used for account/transaction reads |
+| `REWARDS_CONTRACT_ID` | `C...` | From deploy script output |
+| `CAMPAIGN_CONTRACT_ID` | `C...` | From deploy script output |
+| `CORS_ALLOWED_ORIGINS` | `https://app.yourdomain.com` | **Must** match your production frontend origin |
+| `TRIVELA_API_KEYS` | `sk_prod_...` | Comma-separated write/admin API keys (generate strong random values) |
+| `TRIVELA_MASTER_KEY` | `mk_prod_...` | Master key for API key management endpoints |
+
+### Strongly recommended for production
+
+| Variable | Purpose |
+| -------- | ------- |
+| `REDIS_URL` | Shared rate-limit state across backend replicas |
+| `RATE_LIMIT_MAX_REQUESTS` | Tune for expected traffic (default `60`/min may be low or high) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Distributed tracing / monitoring |
+| `STORAGE_BACKEND` | `s3` or `ipfs` for durable campaign images (not `local`) |
+| `S3_BUCKET` / `AWS_REGION` | When using S3 image storage |
+| `JOB_MAX_RETRIES` | Background job retry policy |
+
+### Secrets handling
+
+- Store secrets in your platform's secret manager (Kubernetes Secret, AWS SSM, Vault, etc.).
+- **Rotate all values** that were used on testnet — never reuse testnet API keys on mainnet.
+- Run `npm run env:validate` locally against a sanitized copy to catch missing required keys.
+
+### Verify backend
+
+```bash
+curl -s https://api.yourdomain.com/health | jq .
+curl -s https://api.yourdomain.com/api/v1/config | jq .
+```
+
+Confirm `stellarNetwork` is `mainnet` and contract IDs match your deployment.
+
+---
+
+## 5. Frontend configuration
+
+Build-time variables (set in your CI/CD or hosting dashboard):
+
+| Variable | Mainnet value |
+| -------- | ------------- |
+| `VITE_STELLAR_NETWORK` | `mainnet` |
+| `VITE_REWARDS_CONTRACT_ID` | `C...` |
+| `VITE_CAMPAIGN_CONTRACT_ID` | `C...` |
+| `VITE_API_URL` | `https://api.yourdomain.com` |
+| `VITE_SITE_URL` | `https://app.yourdomain.com` |
+
+The frontend also fetches `/api/v1/config` at boot and prefers backend-provided network settings
+when available — keep backend and frontend contract IDs aligned.
+
+Build and deploy:
+
+```bash
+cd frontend
+npm ci
+npm run build
+# Deploy dist/ to your static host or container image
+```
+
+---
+
+## 6. Kubernetes / Helm
+
+Trivela can be deployed with raw manifests (`k8s/`) or the Helm chart (`helm/trivela/`). See
+[KUBERNETES.md](KUBERNETES.md) for cluster prerequisites.
+
+### Values you must override for mainnet
+
+Edit a production values file (e.g. `helm/production-values.yaml`) — **never commit real secrets**.
+
+| Key | Testnet default | Mainnet override |
+| --- | --------------- | ---------------- |
+| `backend.image.tag` | `latest` | Pin to a **specific release tag** (e.g. `v1.2.0`) |
+| `frontend.image.tag` | `1.25-alpine` | Pin to your built frontend image tag |
+| `backend.replicaCount` | `2` | `≥ 2` for HA (scale per load) |
+| `frontend.replicaCount` | `2` | `≥ 2` for HA |
+| `backend.resources.limits` | `512Mi` / `500m` | Increase for production traffic |
+| `ingress.host` | `trivela.example.com` | Your production domain |
+| `ingress.tls.enabled` | `true` | Keep enabled; use `letsencrypt-prod` issuer |
+| `config.corsOrigin` | `https://trivela.example.com` | Your production frontend URL |
+| `secrets.databaseUrl` | placeholder | Production PostgreSQL connection string |
+| `secrets.jwtSecret` | placeholder | Strong random secret (≥ 32 chars) |
+| `secrets.sorobanRpcUrl` | testnet RPC | `https://soroban-mainnet.stellar.org` |
+
+Deploy:
+
+```bash
+helm upgrade --install trivela ./helm/trivela \
+  -f helm/production-values.yaml \
+  --namespace trivela --create-namespace
+```
+
+### Raw `k8s/` manifests
+
+Update the same values in:
+
+- [`k8s/secret.yaml`](../k8s/secret.yaml) — `DATABASE_URL`, `JWT_SECRET`, `SOROBAN_RPC_URL`
+- [`k8s/configmap.yaml`](../k8s/configmap.yaml) — `CORS_ORIGIN`, `NODE_ENV`
+- [`k8s/ingress.yaml`](../k8s/ingress.yaml) — host and TLS settings
+- [`k8s/hpa.yaml`](../k8s/hpa.yaml) — `minReplicas` / `maxReplicas` for expected load
+
+---
+
+## 7. SSL and Nginx
+
+### Ingress TLS (Kubernetes)
+
+The Helm chart and `k8s/ingress.yaml` use **cert-manager** with a `ClusterIssuer` (e.g.
+`letsencrypt-prod`). Confirm your issuer is configured and the certificate reaches `Ready` status:
+
+```bash
+kubectl describe certificate trivela-tls
+```
+
+### Standalone Nginx (`nginx/`)
+
+For blue/green or VM deployments, use [`nginx/trivela.conf.template`](../nginx/trivela.conf.template).
+`scripts/deploy-blue-green.sh` substitutes `TRIVELA_BACKEND_HOST` and `TRIVELA_BACKEND_PORT`, then
+reloads Nginx.
+
+Production checklist:
+
+- Terminate TLS at the load balancer or Nginx (`listen 443 ssl`).
+- Set `CORS_ALLOWED_ORIGINS` on the **backend** to your production frontend domain (e.g.
+  `https://app.yourdomain.com`). The backend enforces CORS — Nginx does not replace this.
+- Security headers (`X-Content-Type-Options`, `HSTS`, etc.) are included in the template.
+- `/embed/*` routes allow framing for campaign widgets; all other routes deny framing.
+
+---
+
+## 8. Smoke test
+
+Complete this checklist before announcing the mainnet launch. All steps should pass without manual
+workarounds.
+
+### Infrastructure
+
+- [ ] `GET /health` returns `{"status":"ok"}` on the production API URL
+- [ ] `GET /api/v1/config` reports `stellarNetwork: "mainnet"` and correct contract IDs
+- [ ] Frontend loads over HTTPS with no mixed-content warnings
+- [ ] CORS: frontend can call the API (no browser CORS errors in DevTools)
+
+### Contracts (on-chain)
+
+- [ ] Rewards contract `admin()` returns the expected admin address
+- [ ] Campaign contract `admin()` returns the expected admin address
+- [ ] `is_active()` (or equivalent) reflects intended launch state
+
+### API flows
+
+- [ ] `GET /api/v1/campaigns` returns a valid paginated response
+- [ ] Create a **private test campaign** via `POST /api/v1/campaigns` with an admin API key
+- [ ] Upload or attach a campaign image (if using S3/IPFS storage)
+- [ ] Delete or deactivate the test campaign after verification
+
+### Wallet flows (manual)
+
+- [ ] Connect Freighter on mainnet in the production frontend
+- [ ] Register for a test campaign (small XLM fee transaction succeeds)
+- [ ] Confirm participant count increments on-chain and in the UI
+- [ ] (If enabled) Credit and claim rewards for a test account
+
+### Monitoring
+
+- [ ] Alerts configured for `/health` failures and elevated 5xx rates
+- [ ] Error tracking / tracing receiving events (OTel endpoint configured)
+- [ ] Runbook accessible to on-call: [RUNBOOK.md](RUNBOOK.md)
+
+### Rollback readiness
+
+- [ ] Previous backend image tag documented and redeployable
+- [ ] Database backup verified within the last 24 hours
+- [ ] Blue/green or canary procedure tested in staging
+
+---
+
+## 9. Post-launch
+
+- Monitor `/health`, RPC error rates, and wallet transaction failures for the first 48 hours.
+- Keep deployment transaction hashes and contract IDs in your internal runbook.
+- Schedule admin key rotation using the two-step procedure in [SECURITY.md](SECURITY.md).
+- Update [MAINNET_CHECKLIST.md](MAINNET_CHECKLIST.md) with evidence links as items are completed.
+
+---
+
+## Quick reference
+
+| Task | Command |
+| ---- | ------- |
+| Run contract tests | `npm run test:contracts` |
+| Sync bindings | `npm run contracts:build-bindings` |
+| Audit dependencies | `cargo audit` |
+| Deploy to mainnet | `npm run deploy:mainnet` |
+| Validate env file | `npm run env:validate` |
+| Helm deploy | `helm upgrade --install trivela ./helm/trivela -f production-values.yaml` |
+
+## Related docs
+
+- [MAINNET_CHECKLIST.md](MAINNET_CHECKLIST.md) — launch readiness checklist
+- [SECURITY.md](SECURITY.md) — key rotation and incident response
+- [STELLAR_NETWORKS.md](STELLAR_NETWORKS.md) — network presets and endpoints
+- [KUBERNETES.md](KUBERNETES.md) — cluster deployment details
+- [DEPLOYMENT.md](DEPLOYMENT.md) — blue/green and admin rotation overview
+- [E2E_TESTING.md](E2E_TESTING.md) — automated lifecycle tests (adapt for staging/mainnet)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,182 @@
+# Security Guide
+
+Operational security procedures for Trivela mainnet deployments: key management, rotation, compromise
+response, and on-chain admin transfers.
+
+For the full mainnet deployment walkthrough, see [MAINNET_DEPLOY.md](MAINNET_DEPLOY.md).
+
+---
+
+## Key types and scope
+
+| Key / secret | Where used | Impact if compromised |
+| ------------ | ---------- | --------------------- |
+| Contract admin keypair (`G...` / `S...`) | Soroban `propose_admin`, `credit`, campaign config | Full on-chain control of rewards and campaign contracts |
+| `TRIVELA_API_KEYS` / `TRIVELA_MASTER_KEY` | Backend REST API write/admin routes | Off-chain campaign metadata, credits via backend, API key management |
+| `JWT_SECRET` | Session/token signing (if enabled) | Forged auth tokens |
+| `DATABASE_URL` credentials | PostgreSQL | Read/write all campaign and user metadata |
+| Deploy identity (`STELLAR_SOURCE`) | WASM upload and contract deploy | Deploy malicious contracts, drain XLM for fees |
+
+**Principle of least privilege:** use separate keys for contract admin, API admin, and deployment.
+Never store secrets in git, CI logs, or plaintext tickets.
+
+---
+
+## Key generation best practices
+
+1. Generate contract admin keys on a **hardware wallet** or air-gapped machine.
+2. Use cryptographically random API keys (≥ 32 bytes, base64 or hex encoded).
+3. Store production secrets in a dedicated secret manager (Kubernetes Secrets + ESO, AWS SSM, Vault).
+4. Restrict production secret access to on-call engineers and CI deploy roles only.
+
+---
+
+## API key rotation (backend)
+
+Trivela supports multiple API keys via `TRIVELA_API_KEYS` (comma-separated). Rotation without
+downtime:
+
+1. **Generate** a new key: `sk_prod_<random>`.
+2. **Add** the new key to `TRIVELA_API_KEYS` alongside the old key:
+   ```
+   TRIVELA_API_KEYS=sk_prod_old,sk_prod_new
+   ```
+3. **Deploy** the backend with the updated env (blue/green recommended — see [DEPLOYMENT.md](DEPLOYMENT.md)).
+4. **Update** all clients, CI jobs, and admin tools to use `sk_prod_new`.
+5. **Remove** the old key from `TRIVELA_API_KEYS` and redeploy.
+6. **Revoke** the old key in your internal access log / secret manager.
+
+For the master admin key (`TRIVELA_MASTER_KEY`), schedule rotation during a maintenance window —
+there is no multi-key grace period for master key operations.
+
+### JWT secret rotation
+
+1. Generate a new `JWT_SECRET`.
+2. Deploy with the new secret during low traffic.
+3. Existing tokens signed with the old secret become invalid immediately — plan for user re-auth if
+   JWT sessions are in use.
+
+---
+
+## Contract admin rotation (two-step)
+
+Both `trivela-rewards-contract` and `trivela-campaign-contract` use a **propose-then-accept**
+pattern. A one-step transfer is not supported — this prevents bricking the contract if the wrong
+address is entered.
+
+### Read current state
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <admin-identity> \
+  --network mainnet \
+  -- propose_admin --help   # inspect available functions
+
+# Or use stellar contract read for view functions:
+# admin() -> Address
+# pending_admin() -> Option<Address>
+```
+
+### Rotation procedure
+
+Perform these steps on **both** the rewards and campaign contracts.
+
+| Step | Actor | Action |
+| ---- | ----- | ------ |
+| 1 | Operator | Generate new admin keypair on target signer (hardware wallet). Verify it can sign on mainnet. |
+| 2 | Current admin | Call `propose_admin(current_admin, new_admin)` |
+| 3 | Operator | Confirm `pending_admin()` returns the new address; verify `aproposed` event on-chain |
+| 4 | New admin | Call `accept_admin(new_admin)` — **must** sign from the new keypair (`require_auth`) |
+| 5 | Operator | Verify `admin()` returns new address and `pending_admin()` is `None` |
+
+To cancel a mistaken proposal before acceptance:
+
+```bash
+# Current admin only
+cancel_admin_transfer(current_admin)
+```
+
+### Operator checklist
+
+- [ ] New keypair generated and tested on the correct network
+- [ ] `propose_admin` called on **rewards** contract
+- [ ] `propose_admin` called on **campaign** contract
+- [ ] `accept_admin` called on **rewards** contract from new keypair
+- [ ] `accept_admin` called on **campaign** contract from new keypair
+- [ ] Old admin key material securely destroyed or archived offline
+- [ ] Deployment runbook and secret manager updated with new admin public key
+
+> Complete `accept_admin` within the contract instance-storage TTL window (see contract TTL
+> constants). If the pending proposal expires, repeat from step 2.
+
+---
+
+## Compromised admin keypair (on-chain)
+
+If the **contract admin secret key** is suspected compromised:
+
+### Immediate actions (first 30 minutes)
+
+1. **Assess exposure** — check recent on-chain transactions for the admin address on
+   [Stellar Expert](https://stellar.expert/explorer/public).
+2. If the attacker has **not** yet called `propose_admin` to take over:
+   - Generate a new secure admin keypair immediately.
+   - From the **current uncompromised admin**, call `propose_admin` then `accept_admin` from the new
+     keypair on both contracts (see rotation procedure above).
+3. If the attacker **has** proposed themselves as admin:
+   - Call `cancel_admin_transfer` from the current admin if still in control.
+   - If admin slot is already lost, escalate to contract upgrade/migration (see below).
+
+### If admin control is lost
+
+1. Halt public announcements and disable new campaign creation via backend (`TRIVELA_API_KEYS`
+   rotation + maintenance mode if available).
+2. Document all malicious transactions (tx hashes, timestamps, affected accounts).
+3. Evaluate `migrate()` / contract upgrade path if implemented (see [MAINNET_CHECKLIST.md](MAINNET_CHECKLIST.md)
+   item on `upgrade()` entrypoint).
+4. Deploy new contracts with a secure admin if migration is not available; update
+   `REWARDS_CONTRACT_ID` / `CAMPAIGN_CONTRACT_ID` in production env.
+5. Publish a transparent incident summary to stakeholders.
+
+---
+
+## Compromised API keys (off-chain)
+
+If `TRIVELA_API_KEYS` or `TRIVELA_MASTER_KEY` is leaked:
+
+1. **Immediately remove** the compromised key from `TRIVELA_API_KEYS` and redeploy the backend.
+2. Rotate `TRIVELA_MASTER_KEY` if it was exposed.
+3. Audit `audit_log` / application logs for unauthorized `POST`/`PUT`/`DELETE` requests during the
+   exposure window.
+4. Invalidate any CI/CD or third-party integrations still using the old key.
+5. File an internal incident report; rotate adjacent secrets (database password, `JWT_SECRET`) if
+   the leak vector could have exposed broader env access.
+
+---
+
+## Compromised deploy identity
+
+If `STELLAR_SOURCE` secret is leaked:
+
+1. Transfer remaining XLM out of the deploy account to a new secure account.
+2. Remove the identity from CI/CD and local `stellar keys` stores.
+3. Audit recent contract deployments — verify no unauthorized WASM was deployed from this identity.
+4. Create a new deploy identity for future releases.
+
+---
+
+## Reporting security issues
+
+Do **not** open public GitHub issues for undisclosed vulnerabilities. Contact maintainers via
+[GitHub Security Advisories](https://github.com/FinesseStudioLab/Trivela/security/advisories/new)
+or the channel listed in the repository security policy.
+
+---
+
+## Related docs
+
+- [MAINNET_DEPLOY.md](MAINNET_DEPLOY.md) — production deployment walkthrough
+- [DEPLOYMENT.md](DEPLOYMENT.md) — admin rotation overview and blue/green deploys
+- [MAINNET_CHECKLIST.md](MAINNET_CHECKLIST.md) — launch readiness including audit and `SECURITY.md`
+- [RUNBOOK.md](RUNBOOK.md) — incident response and rollback

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:backend": "npm run test --workspace=backend",
     "test:frontend": "npm run test --workspace=frontend",
     "deploy:testnet": "bash ./scripts/deploy-testnet.sh",
+    "deploy:mainnet": "bash ./scripts/deploy-mainnet.sh",
     "contracts:build-bindings": "node scripts/build-bindings.js",
     "env:validate": "node ./scripts/validate-env.mjs",
     "labels:sync": "node ./scripts/sync-github-labels.js",

--- a/scripts/deploy-mainnet.sh
+++ b/scripts/deploy-mainnet.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Deploy Trivela contracts to Stellar mainnet.
+# Wrapper around deploy-testnet.sh that sets required mainnet env vars.
+#
+# Required env:
+#   STELLAR_SOURCE  Stellar account/identity to fund and sign the deploy.
+#
+# Optional env:
+#   TRIVELA_ENV_OUT       Frontend env file (default: .env.mainnet)
+#   TRIVELA_BACKEND_ENV   Backend env file (optional)
+
+set -euo pipefail
+
+export STELLAR_NETWORK=mainnet
+export TRIVELA_CONFIRM_MAINNET=yes
+export TRIVELA_ENV_OUT="${TRIVELA_ENV_OUT:-.env.mainnet}"
+
+exec "$(dirname "$0")/deploy-testnet.sh"

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -22,6 +22,7 @@ NETWORK="${STELLAR_NETWORK:-testnet}"
 SOURCE="${STELLAR_SOURCE:-}"
 ENV_OUT="${TRIVELA_ENV_OUT:-.env.testnet}"
 BACKEND_ENV_OUT="${TRIVELA_BACKEND_ENV:-}"
+CONFIRM_MAINNET="${TRIVELA_CONFIRM_MAINNET:-}"
 REWARDS_WASM="target/wasm32-unknown-unknown/release/trivela_rewards_contract.wasm"
 CAMPAIGN_WASM="target/wasm32-unknown-unknown/release/trivela_campaign_contract.wasm"
 
@@ -32,6 +33,15 @@ err() {
 
 if [ -z "$SOURCE" ]; then
   err "STELLAR_SOURCE is required (set it to a funded Stellar identity or secret key)"
+fi
+
+if [ "$NETWORK" = "mainnet" ]; then
+  if [ "$CONFIRM_MAINNET" != "yes" ]; then
+    err "mainnet deployment requires STELLAR_NETWORK=mainnet and TRIVELA_CONFIRM_MAINNET=yes (use ./scripts/deploy-mainnet.sh or npm run deploy:mainnet)"
+  fi
+  echo "WARNING: deploying to MAINNET — real XLM fees will be charged."
+elif [ "$NETWORK" != "testnet" ]; then
+  echo "WARNING: deploying to non-default network '${NETWORK}'."
 fi
 
 if ! command -v cargo >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add `docs/MAINNET_DEPLOY.md` -  step-by-step mainnet deployment guide covering pre-flight checks, wallet setup, contract deployment, backend/frontend config, Kubernetes/Helm, Nginx/SSL, and smoke tests
- Add `docs/SECURITY.md` - key rotation, compromise response, and two-step contract admin transfer procedures
- Add `scripts/deploy-mainnet.sh` and `npm run deploy:mainnet` alias
- Harden `scripts/deploy-testnet.sh` with a mainnet guard (`TRIVELA_CONFIRM_MAINNET=yes` required)

Fixes #522

## Test plan
- [ ] Follow `docs/MAINNET_DEPLOY.md` pre-flight section locally (`npm run test:contracts`, `npm run contracts:build-bindings`, `cargo audit`)
- [ ] Verify `STELLAR_NETWORK=mainnet` without `TRIVELA_CONFIRM_MAINNET=yes` exits with an error
- [ ] Verify `npm run deploy:mainnet` passes the guard (dry-run on testnet identity should still fail at stellar CLI network mismatch     
     ,do not deploy to mainnet in CI)
- [ ] Confirm `docs/MAINNET_CHECKLIST.md` links resolve
- [ ] Review `docs/SECURITY.md` admin rotation steps against contract `propose_admin` / `accept_admin` API