### PR TITLE
feat: multi-wallet support, admin auth guard, campaigns API fix

### DIFF
--- a/frontend/src/About.jsx
+++ b/frontend/src/About.jsx
@@ -2,7 +2,61 @@ import { useEffect, useState } from 'react';
 import { getRuntimeConfig, apiUrl, API_BASE_URL } from './config';
 import Header from './components/Header';
 
-function Row({ label, value, mono = true }) {
+const GITHUB_REPO = 'https://github.com/FinesseStudioLab/Trivela';
+const GITHUB_ISSUES = 'https://github.com/FinesseStudioLab/Trivela/issues';
+const FREIGHTER_URL = 'https://www.freighter.app';
+const STELLAR_DOCS = 'https://developers.stellar.org/docs/build/smart-contracts';
+
+const STACK = [
+  {
+    icon: '⚙️',
+    name: 'Soroban Smart Contracts',
+    desc: 'Two Rust contracts: a campaign contract managing participants and Merkle allowlists, and a rewards contract tracking points and claims — deployed on Stellar testnet.',
+  },
+  {
+    icon: '🗄️',
+    name: 'Node.js REST API',
+    desc: 'Express backend with SQLite (dev) or PostgreSQL (production), OpenTelemetry tracing, rate limiting, S3/local image storage, and webhook delivery.',
+  },
+  {
+    icon: '⚛️',
+    name: 'React Frontend',
+    desc: 'Vite-powered SPA with Freighter wallet integration, campaign browsing, leaderboards, tiered rewards claiming, analytics, and an embedded widget mode.',
+  },
+];
+
+const HOW_TO = [
+  {
+    step: '01',
+    title: 'Install Freighter',
+    desc: 'Add the Freighter browser extension and create or import a Stellar wallet.',
+    href: FREIGHTER_URL,
+    cta: 'Get Freighter',
+  },
+  {
+    step: '02',
+    title: 'Browse campaigns',
+    desc: 'Explore active campaigns on the home page. Each campaign shows its reward pool, participant count, and registration status.',
+    href: '/',
+    cta: 'View campaigns',
+  },
+  {
+    step: '03',
+    title: 'Connect & register',
+    desc: 'Connect your wallet, register for a campaign you qualify for, and earn on-chain points automatically.',
+    href: '/',
+    cta: 'Connect wallet',
+  },
+  {
+    step: '04',
+    title: 'Claim rewards',
+    desc: 'Once points are awarded, use the rewards panel to claim XLM or token payouts directly to your wallet via the Soroban contract.',
+    href: '/',
+    cta: 'Open rewards',
+  },
+];
+
+function ConfigRow({ label, value, mono = true }) {
   return (
     <tr>
       <td
@@ -32,12 +86,12 @@ function Row({ label, value, mono = true }) {
   );
 }
 
-function Section({ title, children }) {
+function ConfigSection({ title, children }) {
   return (
-    <section style={{ marginBottom: '32px' }}>
-      <h2
+    <section style={{ marginBottom: '24px' }}>
+      <h3
         style={{
-          fontSize: '0.75rem',
+          fontSize: '0.7rem',
           fontWeight: 700,
           letterSpacing: '0.1em',
           textTransform: 'uppercase',
@@ -47,7 +101,7 @@ function Section({ title, children }) {
         }}
       >
         {title}
-      </h2>
+      </h3>
       <table
         style={{
           width: '100%',
@@ -77,6 +131,7 @@ export default function About({
   onDisconnectWallet,
 }) {
   const [config, setConfig] = useState(() => getRuntimeConfig());
+  const [showConfig, setShowConfig] = useState(false);
 
   useEffect(() => {
     setConfig(getRuntimeConfig());
@@ -105,54 +160,279 @@ export default function About({
         onDisconnectWallet={onDisconnectWallet}
       />
 
-      <main
+      <main style={{ maxWidth: '860px', margin: '0 auto', padding: '72px 24px 80px' }}>
+        {/* Hero */}
+        <section style={{ textAlign: 'center', marginBottom: '72px' }}>
+          <p
+            style={{
+              fontSize: '0.8rem',
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: 'var(--color-accent, #6366f1)',
+              marginBottom: '12px',
+            }}
+          >
+            Open source · Stellar ecosystem
+          </p>
+          <h1
+            style={{
+              fontSize: 'clamp(2rem, 5vw, 3rem)',
+              fontWeight: 800,
+              lineHeight: 1.15,
+              marginBottom: '20px',
+            }}
+          >
+            On-chain campaigns,
+            <br />
+            real rewards
+          </h1>
+          <p
+            style={{
+              fontSize: '1.1rem',
+              color: 'var(--color-text-secondary, #94a3b8)',
+              maxWidth: '560px',
+              margin: '0 auto 32px',
+              lineHeight: 1.7,
+            }}
+          >
+            Trivela lets projects create Stellar Soroban campaigns, allowlist participants via
+            Merkle proofs, award on-chain points, and pay out rewards automatically — no centralised
+            intermediary.
+          </p>
+          <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
+            <a href="/" className="btn btn-primary">
+              Browse campaigns
+            </a>
+            <a
+              href={GITHUB_REPO}
+              className="btn btn-secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub repository
+            </a>
+          </div>
+        </section>
+
+        {/* Tech stack */}
+        <section style={{ marginBottom: '72px' }}>
+          <h2 style={{ fontSize: '1.35rem', fontWeight: 700, marginBottom: '24px' }}>The stack</h2>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+              gap: '16px',
+            }}
+          >
+            {STACK.map((s) => (
+              <div
+                key={s.name}
+                style={{
+                  background: 'var(--color-surface, #1e293b)',
+                  border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+                  borderRadius: '14px',
+                  padding: '24px',
+                }}
+              >
+                <p style={{ fontSize: '1.6rem', marginBottom: '10px' }}>{s.icon}</p>
+                <h3 style={{ fontWeight: 700, marginBottom: '8px', fontSize: '1rem' }}>{s.name}</h3>
+                <p
+                  style={{
+                    color: 'var(--color-text-secondary, #94a3b8)',
+                    fontSize: '0.9rem',
+                    lineHeight: 1.6,
+                  }}
+                >
+                  {s.desc}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section style={{ marginBottom: '72px' }}>
+          <h2 style={{ fontSize: '1.35rem', fontWeight: 700, marginBottom: '24px' }}>
+            How to get started
+          </h2>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+              gap: '16px',
+            }}
+          >
+            {HOW_TO.map((step) => (
+              <div
+                key={step.step}
+                style={{
+                  background: 'var(--color-surface, #1e293b)',
+                  border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+                  borderRadius: '14px',
+                  padding: '24px',
+                  position: 'relative',
+                }}
+              >
+                <p
+                  style={{
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.1em',
+                    color: 'var(--color-accent, #6366f1)',
+                    marginBottom: '10px',
+                  }}
+                >
+                  {step.step}
+                </p>
+                <h3 style={{ fontWeight: 700, marginBottom: '8px', fontSize: '0.95rem' }}>
+                  {step.title}
+                </h3>
+                <p
+                  style={{
+                    color: 'var(--color-text-secondary, #94a3b8)',
+                    fontSize: '0.85rem',
+                    lineHeight: 1.6,
+                    marginBottom: '16px',
+                  }}
+                >
+                  {step.desc}
+                </p>
+                <a
+                  href={step.href}
+                  style={{
+                    fontSize: '0.8rem',
+                    fontWeight: 600,
+                    color: 'var(--color-accent, #6366f1)',
+                    textDecoration: 'none',
+                  }}
+                  {...(step.href.startsWith('http')
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
+                >
+                  {step.cta} →
+                </a>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Contribute */}
+        <section
+          style={{
+            background: 'var(--color-surface, #1e293b)',
+            border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+            borderRadius: '16px',
+            padding: '36px',
+            marginBottom: '72px',
+            display: 'flex',
+            gap: '32px',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div>
+            <h2 style={{ fontSize: '1.2rem', fontWeight: 700, marginBottom: '8px' }}>
+              Contribute to Trivela
+            </h2>
+            <p
+              style={{
+                color: 'var(--color-text-secondary, #94a3b8)',
+                fontSize: '0.9rem',
+                maxWidth: '420px',
+                lineHeight: 1.6,
+              }}
+            >
+              Trivela is part of the{' '}
+              <a
+                href="https://www.drips.network/wave/stellar"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit', textDecoration: 'underline' }}
+              >
+                Stellar Wave on Drips
+              </a>
+              . Open issues span smart contracts, the backend API, and this React frontend.
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+            <a
+              href={GITHUB_ISSUES}
+              className="btn btn-primary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Browse issues
+            </a>
+            <a
+              href={STELLAR_DOCS}
+              className="btn btn-secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Stellar docs
+            </a>
+          </div>
+        </section>
+
+        {/* Dev config — collapsed by default */}
+        <section>
+          <button
+            type="button"
+            onClick={() => setShowConfig((v) => !v)}
+            style={{
+              background: 'none',
+              border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+              borderRadius: '8px',
+              padding: '10px 18px',
+              color: 'var(--color-text-secondary, #94a3b8)',
+              cursor: 'pointer',
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              marginBottom: '16px',
+            }}
+            aria-expanded={showConfig}
+          >
+            <span>{showConfig ? '▲' : '▼'}</span> Developer config
+          </button>
+
+          {showConfig && (
+            <div>
+              <ConfigSection title="API">
+                <ConfigRow label="API Base URL" value={API_BASE_URL || window.location.origin} />
+                <ConfigRow label="Campaigns endpoint" value={apiUrl('/api/v1/campaigns')} />
+              </ConfigSection>
+              <ConfigSection title="Stellar Network">
+                <ConfigRow label="Network" value={stellar.network} mono={false} />
+                <ConfigRow label="Soroban RPC URL" value={stellar.sorobanRpcUrl} />
+                <ConfigRow label="Horizon URL" value={stellar.horizonUrl} />
+                <ConfigRow label="Source" value={sources.stellar} mono={false} />
+              </ConfigSection>
+              <ConfigSection title="Contract IDs">
+                <ConfigRow label="Rewards contract" value={contracts.rewards} />
+                <ConfigRow label="Campaign contract" value={contracts.campaign} />
+                <ConfigRow label="Source" value={sources.contracts} mono={false} />
+              </ConfigSection>
+            </div>
+          )}
+        </section>
+      </main>
+
+      <footer
         style={{
-          maxWidth: '760px',
-          margin: '0 auto',
-          padding: '80px 24px 60px',
+          borderTop: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+          padding: '32px 24px',
+          textAlign: 'center',
+          color: 'var(--color-text-secondary, #64748b)',
+          fontSize: '0.85rem',
         }}
       >
-        <h1
-          style={{
-            fontSize: '1.75rem',
-            fontWeight: 700,
-            marginBottom: '8px',
-            color: 'var(--color-text, #e2e8f0)',
-          }}
-        >
-          Runtime Configuration
-        </h1>
-        <p
-          style={{
-            color: 'var(--color-text-secondary, #94a3b8)',
-            marginBottom: '40px',
-            fontSize: '0.9rem',
-          }}
-        >
-          Active environment and contract settings. Sources show where each value originated (env,
-          backend, or dev-switcher).
-        </p>
-
-        <Section title="API">
-          <Row label="API Base URL" value={API_BASE_URL || window.location.origin} />
-          <Row label="Campaigns endpoint" value={apiUrl('/api/v1/campaigns')} />
-          <Row label="Config endpoint" value={apiUrl('/api/v1/config')} />
-        </Section>
-
-        <Section title="Stellar Network">
-          <Row label="Network" value={stellar.network} mono={false} />
-          <Row label="Network passphrase" value={stellar.networkPassphrase} />
-          <Row label="Soroban RPC URL" value={stellar.sorobanRpcUrl} />
-          <Row label="Horizon URL" value={stellar.horizonUrl} />
-          <Row label="Source" value={sources.stellar} mono={false} />
-        </Section>
-
-        <Section title="Contract IDs">
-          <Row label="Rewards contract" value={contracts.rewards} />
-          <Row label="Campaign contract" value={contracts.campaign} />
-          <Row label="Source" value={sources.contracts} mono={false} />
-        </Section>
-      </main>
+        <p>Trivela · Apache-2.0 · Built on Stellar Soroban</p>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,10 +9,12 @@ import About from './About';
 import PageMeta from './components/PageMeta';
 import TransactionHistory from './TransactionHistory';
 import EmbedCampaign from './pages/EmbedCampaign';
+import WalletModal from './components/WalletModal';
+import RequireAdmin from './components/RequireAdmin';
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
 import { getRuntimeConfig, initializeRuntimeConfig, setRuntimeStellarNetwork } from './config';
 import {
-  getWalletAddress,
+  connectWallet as connectWalletProvider,
   fetchWalletBalance,
   formatWalletBalance,
   fetchRewardsBalance,
@@ -31,6 +33,7 @@ export default function App() {
   const [isWalletBalanceLoading, setIsWalletBalanceLoading] = useState(false);
   const [isRewardsPointsLoading, setIsRewardsPointsLoading] = useState(false);
   const [walletError, setWalletError] = useState('');
+  const [showWalletModal, setShowWalletModal] = useState(false);
 
   useEffect(() => {
     applyTheme(theme);
@@ -94,19 +97,27 @@ export default function App() {
     }
   };
 
-  const connectWallet = async () => {
+  const openWalletModal = () => {
+    setWalletError('');
+    setShowWalletModal(true);
+  };
+
+  const handleWalletSelect = async (providerName) => {
+    setShowWalletModal(false);
     setIsWalletLoading(true);
     setWalletError('');
 
     try {
-      const address = await getWalletAddress();
+      const { address } = await connectWalletProvider(providerName);
       setWalletAddress(address);
-      logSafeEvent('wallet_connected');
+      logSafeEvent('wallet_connected', { provider: providerName });
       await loadWalletBalance(address);
     } catch (error) {
       setWalletAddress('');
       setWalletBalance('');
-      setWalletError(normalizeError(error));
+      const msg = normalizeError(error);
+      setWalletError(msg);
+      setShowWalletModal(true);
     } finally {
       setIsWalletLoading(false);
     }
@@ -157,7 +168,7 @@ export default function App() {
               isWalletBalanceLoading={isWalletBalanceLoading}
               isRewardsPointsLoading={isRewardsPointsLoading}
               walletError={walletError}
-              onConnectWallet={connectWallet}
+              onConnectWallet={openWalletModal}
               onDisconnectWallet={disconnectWallet}
               onRefreshPoints={() => loadWalletBalance(walletAddress)}
             />
@@ -177,7 +188,7 @@ export default function App() {
               isWalletLoading={isWalletLoading}
               isWalletBalanceLoading={isWalletBalanceLoading}
               isRewardsPointsLoading={isRewardsPointsLoading}
-              onConnectWallet={connectWallet}
+              onConnectWallet={openWalletModal}
               onDisconnectWallet={disconnectWallet}
               onRefreshPoints={() => loadWalletBalance(walletAddress)}
             />
@@ -197,7 +208,7 @@ export default function App() {
               isWalletLoading={isWalletLoading}
               isWalletBalanceLoading={isWalletBalanceLoading}
               isRewardsPointsLoading={isRewardsPointsLoading}
-              onConnectWallet={connectWallet}
+              onConnectWallet={openWalletModal}
               onDisconnectWallet={disconnectWallet}
               onRefreshPoints={() => loadWalletBalance(walletAddress)}
             />
@@ -206,35 +217,47 @@ export default function App() {
         <Route
           path="/admin/campaigns/:id/analytics"
           element={
-            <CampaignAnalytics
-              theme={theme}
-              onToggleTheme={toggleTheme}
-              stellarNetwork={runtimeConfig.stellar.network}
-              onChangeStellarNetwork={handleChangeStellarNetwork}
+            <RequireAdmin
               walletAddress={walletAddress}
-              walletBalance={walletBalance}
+              onConnectWallet={openWalletModal}
               isWalletLoading={isWalletLoading}
-              isWalletBalanceLoading={isWalletBalanceLoading}
-              onConnectWallet={connectWallet}
-              onDisconnectWallet={disconnectWallet}
-            />
+            >
+              <CampaignAnalytics
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            </RequireAdmin>
           }
         />
         <Route
           path="/admin"
           element={
-            <AdminCampaigns
-              theme={theme}
-              onToggleTheme={toggleTheme}
-              stellarNetwork={runtimeConfig.stellar.network}
-              onChangeStellarNetwork={handleChangeStellarNetwork}
+            <RequireAdmin
               walletAddress={walletAddress}
-              walletBalance={walletBalance}
+              onConnectWallet={openWalletModal}
               isWalletLoading={isWalletLoading}
-              isWalletBalanceLoading={isWalletBalanceLoading}
-              onConnectWallet={connectWallet}
-              onDisconnectWallet={disconnectWallet}
-            />
+            >
+              <AdminCampaigns
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            </RequireAdmin>
           }
         />
         <Route
@@ -249,7 +272,7 @@ export default function App() {
               walletBalance={walletBalance}
               isWalletLoading={isWalletLoading}
               isWalletBalanceLoading={isWalletBalanceLoading}
-              onConnectWallet={connectWallet}
+              onConnectWallet={openWalletModal}
               onDisconnectWallet={disconnectWallet}
             />
           }
@@ -266,13 +289,20 @@ export default function App() {
               walletBalance={walletBalance}
               isWalletLoading={isWalletLoading}
               isWalletBalanceLoading={isWalletBalanceLoading}
-              onConnectWallet={connectWallet}
+              onConnectWallet={openWalletModal}
               onDisconnectWallet={disconnectWallet}
             />
           }
         />
         <Route path="/embed/campaign/:id" element={<EmbedCampaign />} />
       </Routes>
+      <WalletModal
+        isOpen={showWalletModal}
+        onClose={() => setShowWalletModal(false)}
+        onConnect={handleWalletSelect}
+        isLoading={isWalletLoading}
+        error={walletError}
+      />
     </>
   );
 }

--- a/frontend/src/Landing.css
+++ b/frontend/src/Landing.css
@@ -81,8 +81,10 @@
   color: var(--text-muted);
 }
 
-.nav-links a:hover {
+.nav-links a:hover,
+.nav-links a.nav-link-active {
   color: var(--accent);
+  font-weight: 600;
 }
 
 .nav-utilities {

--- a/frontend/src/Landing.jsx
+++ b/frontend/src/Landing.jsx
@@ -196,37 +196,32 @@ export default function Landing({
             rewards. Full stack: Rust contracts, Node API, React frontend.
           </p>
           <div className="hero-cta">
-            <a
-              href={GITHUB_REPO}
-              className="btn btn-primary"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View repository
+            <a href="#campaigns" className="btn btn-primary">
+              Browse campaigns
             </a>
-            <a
-              href={GITHUB_ISSUES}
+            <button
+              type="button"
               className="btn btn-secondary"
-              target="_blank"
-              rel="noopener noreferrer"
+              onClick={onConnectWallet}
+              disabled={isWalletLoading}
             >
-              Browse contributor issues
-            </a>
+              {isWalletLoading
+                ? 'Connecting…'
+                : walletAddress
+                  ? 'Wallet connected ✓'
+                  : 'Connect wallet'}
+            </button>
           </div>
           <div className="hero-stats" aria-label="Project summary">
-            <span>
-              <strong>50</strong> open issues
-            </span>
-            <span className="hero-stats-dot" aria-hidden="true">
-              ·
-            </span>
-            <span>
-              <strong>3</strong> stacks
-            </span>
+            <span>Stellar Soroban</span>
             <span className="hero-stats-dot" aria-hidden="true">
               ·
             </span>
             <span>Rust · Node · React</span>
+            <span className="hero-stats-dot" aria-hidden="true">
+              ·
+            </span>
+            <span>Apache-2.0</span>
           </div>
         </header>
 
@@ -282,8 +277,23 @@ export default function Landing({
 
             {(rewardsPoints === 'Unavailable' || walletError) && (
               <p className="rewards-error" role="alert">
-                {walletError ||
-                  'Unable to load your rewards balance. Check your connection or contract deployment.'}
+                {walletError && walletError.toLowerCase().includes('freighter') ? (
+                  <>
+                    Freighter wallet not detected.{' '}
+                    <a
+                      href="https://www.freighter.app"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: 'inherit', textDecoration: 'underline' }}
+                    >
+                      Install Freighter
+                    </a>{' '}
+                    then try again.
+                  </>
+                ) : (
+                  walletError ||
+                  'Unable to load your rewards balance. Check your connection or contract deployment.'
+                )}
               </p>
             )}
 
@@ -443,6 +453,7 @@ export default function Landing({
         </section>
 
         <section
+          id="campaigns"
           className="section campaigns-preview"
           aria-labelledby="campaigns-title"
           data-tour="campaigns"

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import DevNetworkSwitcher from './DevNetworkSwitcher';
 
 function truncateWalletAddress(walletAddress) {
@@ -7,22 +8,9 @@ function truncateWalletAddress(walletAddress) {
 }
 
 const NAV_LINKS = [
-  {
-    href: '/api-docs.html',
-    label: 'API Docs',
-  },
-  {
-    href: 'https://github.com/FinesseStudioLab/Trivela',
-    label: 'GitHub',
-  },
-  {
-    href: 'https://github.com/FinesseStudioLab/Trivela/issues',
-    label: 'Contribute',
-  },
-  {
-    href: 'https://developers.stellar.org/docs',
-    label: 'Stellar',
-  },
+  { href: '/', label: 'Campaigns' },
+  { href: '/about', label: 'About' },
+  { href: '/admin', label: 'Admin' },
 ];
 
 export default function Header({
@@ -39,6 +27,7 @@ export default function Header({
 }) {
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
   const balanceLabel = `${stellarNetwork === 'mainnet' ? 'Mainnet' : 'Testnet'} balance`;
+  const { pathname } = useLocation();
 
   return (
     <header className="site-header">
@@ -52,14 +41,25 @@ export default function Header({
 
         <div className="nav-actions">
           <div className="nav-links">
-            {/* #295 — only show the history link when a wallet is
-                connected; the page itself is per-wallet. */}
-            {walletAddress && <a href="/history">Transaction History</a>}
             {NAV_LINKS.map((link) => (
-              <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer">
+              <a
+                key={link.href}
+                href={link.href}
+                className={pathname === link.href ? 'nav-link-active' : undefined}
+                aria-current={pathname === link.href ? 'page' : undefined}
+              >
                 {link.label}
               </a>
             ))}
+            {walletAddress && (
+              <a
+                href="/history"
+                className={pathname === '/history' ? 'nav-link-active' : undefined}
+                aria-current={pathname === '/history' ? 'page' : undefined}
+              >
+                History
+              </a>
+            )}
           </div>
 
           <div className="nav-utilities">

--- a/frontend/src/components/RequireAdmin.jsx
+++ b/frontend/src/components/RequireAdmin.jsx
@@ -1,0 +1,118 @@
+import { getAdminAddresses } from '../config.js';
+
+const PAGE_STYLE = {
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'var(--color-bg, #0f172a)',
+  padding: '24px',
+};
+
+const CARD_STYLE = {
+  background: 'var(--color-surface, #1e293b)',
+  border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+  borderRadius: '16px',
+  padding: '40px 36px',
+  maxWidth: '420px',
+  width: '100%',
+  textAlign: 'center',
+};
+
+export default function RequireAdmin({
+  walletAddress,
+  onConnectWallet,
+  isWalletLoading,
+  children,
+}) {
+  const adminAddresses = getAdminAddresses();
+
+  if (!walletAddress) {
+    return (
+      <div style={PAGE_STYLE}>
+        <div style={CARD_STYLE}>
+          <p style={{ fontSize: '2rem', marginBottom: '16px' }}>🔐</p>
+          <h1
+            style={{
+              fontSize: '1.2rem',
+              fontWeight: 700,
+              marginBottom: '12px',
+              color: 'var(--color-text, #e2e8f0)',
+            }}
+          >
+            Admin access required
+          </h1>
+          <p
+            style={{
+              color: 'var(--color-text-secondary, #94a3b8)',
+              fontSize: '0.9rem',
+              lineHeight: 1.6,
+              marginBottom: '24px',
+            }}
+          >
+            Connect your authorized wallet to access the admin panel.
+          </p>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onConnectWallet}
+            disabled={isWalletLoading}
+          >
+            {isWalletLoading ? 'Connecting…' : 'Connect wallet'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (adminAddresses.length > 0 && !adminAddresses.includes(walletAddress)) {
+    return (
+      <div style={PAGE_STYLE}>
+        <div style={CARD_STYLE}>
+          <p style={{ fontSize: '2rem', marginBottom: '16px' }}>⛔</p>
+          <h1
+            style={{
+              fontSize: '1.2rem',
+              fontWeight: 700,
+              marginBottom: '12px',
+              color: 'var(--color-text, #e2e8f0)',
+            }}
+          >
+            Access denied
+          </h1>
+          <p
+            style={{
+              color: 'var(--color-text-secondary, #94a3b8)',
+              fontSize: '0.9rem',
+              lineHeight: 1.6,
+              marginBottom: '16px',
+            }}
+          >
+            This page is restricted to authorized administrators. Your connected address is not on
+            the admin list.
+          </p>
+          <code
+            style={{
+              display: 'block',
+              background: 'var(--color-bg, #0f172a)',
+              border: '1px solid var(--color-border, rgba(255,255,255,0.08))',
+              borderRadius: '8px',
+              padding: '10px 14px',
+              fontSize: '0.75rem',
+              color: '#94a3b8',
+              wordBreak: 'break-all',
+              marginBottom: '20px',
+            }}
+          >
+            {walletAddress}
+          </code>
+          <a href="/" className="btn btn-secondary">
+            Back to campaigns
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/frontend/src/components/WalletModal.jsx
+++ b/frontend/src/components/WalletModal.jsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from 'react';
+
+const WALLETS = [
+  {
+    name: 'Freighter',
+    description: 'The official Stellar browser extension wallet',
+    icon: '✦',
+    installUrl: 'https://www.freighter.app',
+    detected: () => !!window.freighterApi,
+    comingSoon: false,
+  },
+  {
+    name: 'xBull',
+    description: 'Feature-rich Stellar wallet with DeFi support',
+    icon: '⊕',
+    installUrl: 'https://xbull.app',
+    detected: () => !!window.xBullSDK,
+    comingSoon: false,
+  },
+  {
+    name: 'Rabet',
+    description: 'Lightweight Stellar browser extension',
+    icon: '◈',
+    installUrl: 'https://rabet.io',
+    detected: () => !!window.rabet,
+    comingSoon: false,
+  },
+  {
+    name: 'Lobstr',
+    description: 'Popular mobile & desktop Stellar wallet',
+    icon: '◎',
+    installUrl: 'https://lobstr.co',
+    detected: () => false,
+    comingSoon: true,
+  },
+];
+
+const OVERLAY_STYLE = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.7)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+  padding: '16px',
+};
+
+const DIALOG_STYLE = {
+  background: 'var(--color-surface, #1e293b)',
+  border: '1px solid var(--color-border, rgba(255,255,255,0.1))',
+  borderRadius: '16px',
+  padding: '28px',
+  width: '100%',
+  maxWidth: '420px',
+};
+
+const ERROR_STYLE = {
+  background: 'rgba(239,68,68,0.1)',
+  border: '1px solid rgba(239,68,68,0.3)',
+  borderRadius: '8px',
+  padding: '10px 14px',
+  marginBottom: '16px',
+  fontSize: '0.85rem',
+  color: '#f87171',
+};
+
+function WalletOption({ wallet, isDetected, isLoading, onConnect }) {
+  const [hovered, setHovered] = useState(false);
+  const disabled = isLoading || wallet.comingSoon;
+
+  const badgeStyle = {
+    fontSize: '0.7rem',
+    fontWeight: 600,
+    padding: '3px 8px',
+    borderRadius: '20px',
+    whiteSpace: 'nowrap',
+    ...(isDetected
+      ? { color: '#4ade80', background: 'rgba(74,222,128,0.1)' }
+      : wallet.comingSoon
+        ? { color: '#94a3b8', background: 'rgba(148,163,184,0.1)' }
+        : { color: '#94a3b8', background: 'rgba(148,163,184,0.1)' }),
+  };
+
+  const rowStyle = {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '14px',
+    padding: '14px 16px',
+    borderRadius: '10px',
+    textAlign: 'left',
+    textDecoration: 'none',
+    transition: 'border-color 0.15s',
+    border: `1px solid ${hovered && isDetected && !disabled ? 'var(--color-accent, #6366f1)' : 'var(--color-border, rgba(255,255,255,0.08))'}`,
+    background: isDetected ? 'var(--color-bg, #0f172a)' : 'transparent',
+    opacity: disabled ? 0.6 : 1,
+    cursor: isDetected && !disabled ? 'pointer' : 'default',
+  };
+
+  const inner = (
+    <>
+      <span style={{ fontSize: '1.4rem', width: '28px', textAlign: 'center' }}>{wallet.icon}</span>
+      <div style={{ flex: 1 }}>
+        <p
+          style={{
+            fontWeight: 600,
+            fontSize: '0.95rem',
+            margin: 0,
+            color: 'var(--color-text, #e2e8f0)',
+          }}
+        >
+          {wallet.name}
+        </p>
+        <p
+          style={{
+            fontSize: '0.78rem',
+            color: 'var(--color-text-secondary, #94a3b8)',
+            margin: '2px 0 0',
+          }}
+        >
+          {wallet.comingSoon ? 'WalletConnect integration coming soon' : wallet.description}
+        </p>
+      </div>
+      <span style={badgeStyle}>
+        {isDetected
+          ? isLoading
+            ? 'Connecting…'
+            : 'Detected'
+          : wallet.comingSoon
+            ? 'Soon'
+            : 'Install →'}
+      </span>
+    </>
+  );
+
+  if (isDetected) {
+    return (
+      <button
+        type="button"
+        onClick={() => onConnect(wallet.name)}
+        disabled={disabled}
+        style={rowStyle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  if (wallet.comingSoon) {
+    return <div style={rowStyle}>{inner}</div>;
+  }
+
+  return (
+    <a
+      href={wallet.installUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={rowStyle}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {inner}
+    </a>
+  );
+}
+
+export default function WalletModal({ isOpen, onClose, onConnect, isLoading, error }) {
+  const [detected, setDetected] = useState({});
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const map = {};
+    for (const w of WALLETS) {
+      try {
+        map[w.name] = w.detected();
+      } catch {
+        map[w.name] = false;
+      }
+    }
+    setDetected(map);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const onKeyDown = (e) => e.key === 'Escape' && onClose();
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={OVERLAY_STYLE}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Choose wallet"
+    >
+      <div style={DIALOG_STYLE} onClick={(e) => e.stopPropagation()}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '20px',
+          }}
+        >
+          <h2
+            style={{
+              fontSize: '1.1rem',
+              fontWeight: 700,
+              margin: 0,
+              color: 'var(--color-text, #e2e8f0)',
+            }}
+          >
+            Connect wallet
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '1.2rem',
+              color: 'var(--color-text-secondary, #94a3b8)',
+              padding: '4px 8px',
+              lineHeight: 1,
+            }}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {error && <div style={ERROR_STYLE}>{error}</div>}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          {WALLETS.map((wallet) => (
+            <WalletOption
+              key={wallet.name}
+              wallet={wallet}
+              isDetected={!!detected[wallet.name]}
+              isLoading={isLoading}
+              onConnect={onConnect}
+            />
+          ))}
+        </div>
+
+        <p
+          style={{
+            marginTop: '16px',
+            fontSize: '0.78rem',
+            color: 'var(--color-text-secondary, #64748b)',
+            textAlign: 'center',
+          }}
+        >
+          New to Stellar?{' '}
+          <a
+            href="https://www.freighter.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'var(--color-accent, #6366f1)', textDecoration: 'none' }}
+          >
+            Install Freighter
+          </a>{' '}
+          to get started.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -230,3 +230,11 @@ export function getCampaignContract() {
   const contractId = getCampaignContractId();
   return contractId ? new Contract(contractId) : null;
 }
+
+export function getAdminAddresses() {
+  const raw = import.meta.env.VITE_ADMIN_ADDRESSES || '';
+  return raw
+    .split(',')
+    .map((a) => a.trim())
+    .filter(Boolean);
+}

--- a/frontend/src/lib/wallet/RabetProvider.js
+++ b/frontend/src/lib/wallet/RabetProvider.js
@@ -1,0 +1,66 @@
+import { WalletProvider } from './WalletProvider.js';
+
+export class RabetProvider extends WalletProvider {
+  constructor() {
+    super();
+    this.name = 'Rabet';
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  getApi() {
+    if (!window.rabet) {
+      throw new Error('Rabet API is unavailable. Install or unlock the Rabet browser extension.');
+    }
+    return window.rabet;
+  }
+
+  async isAvailable() {
+    try {
+      return !!window.rabet;
+    } catch {
+      return false;
+    }
+  }
+
+  async isConnected() {
+    try {
+      return !!window.rabet;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect() {
+    const api = this.getApi();
+    const result = await api.connect();
+    if (!result?.publicKey) {
+      throw new Error('Rabet did not return a wallet address.');
+    }
+    return result.publicKey;
+  }
+
+  async disconnect() {
+    return true;
+  }
+
+  async getAddress() {
+    const api = this.getApi();
+    const result = await api.connect();
+    if (!result?.publicKey) {
+      throw new Error('No address available. Please connect your wallet first.');
+    }
+    return result.publicKey;
+  }
+
+  async signTransaction(xdr, options = {}) {
+    const api = this.getApi();
+    const result = await api.sign(xdr, options.networkPassphrase);
+    if (!result?.xdr) {
+      throw new Error('Rabet did not return a signed transaction.');
+    }
+    return result.xdr;
+  }
+}

--- a/frontend/src/lib/wallet/XBullProvider.js
+++ b/frontend/src/lib/wallet/XBullProvider.js
@@ -1,0 +1,68 @@
+import { WalletProvider } from './WalletProvider.js';
+
+export class XBullProvider extends WalletProvider {
+  constructor() {
+    super();
+    this.name = 'xBull';
+  }
+
+  getName() {
+    return this.name;
+  }
+
+  getApi() {
+    if (!window.xBullSDK) {
+      throw new Error('xBull SDK is unavailable. Install or unlock the xBull browser extension.');
+    }
+    return window.xBullSDK;
+  }
+
+  async isAvailable() {
+    try {
+      return !!window.xBullSDK;
+    } catch {
+      return false;
+    }
+  }
+
+  async isConnected() {
+    try {
+      return !!window.xBullSDK;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect() {
+    const api = this.getApi();
+    await api.connect();
+    const publicKey = await api.getPublicKey();
+    if (!publicKey) {
+      throw new Error('xBull did not return a wallet address.');
+    }
+    return publicKey;
+  }
+
+  async disconnect() {
+    return true;
+  }
+
+  async getAddress() {
+    const api = this.getApi();
+    const publicKey = await api.getPublicKey();
+    if (!publicKey) {
+      throw new Error('No address available. Please connect your wallet first.');
+    }
+    return publicKey;
+  }
+
+  async signTransaction(xdr, options = {}) {
+    const api = this.getApi();
+    const network = options.networkPassphrase?.includes('Test SDF') ? 'TESTNET' : 'PUBLIC';
+    const signedXdr = await api.signXDR(xdr, { network });
+    if (!signedXdr) {
+      throw new Error('xBull did not return a signed transaction.');
+    }
+    return signedXdr;
+  }
+}

--- a/frontend/src/lib/wallet/index.js
+++ b/frontend/src/lib/wallet/index.js
@@ -1,9 +1,13 @@
 import { WalletManager } from './WalletManager.js';
 import { FreighterProvider } from './FreighterProvider.js';
+import { XBullProvider } from './XBullProvider.js';
+import { RabetProvider } from './RabetProvider.js';
 
 const walletManager = new WalletManager();
 
 walletManager.registerProvider(new FreighterProvider());
+walletManager.registerProvider(new XBullProvider());
+walletManager.registerProvider(new RabetProvider());
 
-export { walletManager, WalletManager, FreighterProvider };
+export { walletManager, WalletManager, FreighterProvider, XBullProvider, RabetProvider };
 export { WalletProvider } from './WalletProvider.js';


### PR DESCRIPTION
## Summary

- **Fix campaigns not loading** — removed `VITE_API_URL` override so API calls use relative URLs through the Vite proxy, eliminating the CORS rejection when the frontend and backend run on different ports
- **Admin page protection** — added `RequireAdmin` guard wrapping `/admin` routes; unauthenticated users see a connect-wallet prompt, unauthorized wallets see an access-denied card; admin addresses are configured via `VITE_ADMIN_ADDRESSES` env var
- **Multi-wallet selector modal** — replaced the single Freighter connect button with a wallet picker modal supporting Freighter, xBull, and Rabet (auto-detected from browser extensions); Lobstr shown as coming soon; non-installed wallets show install links

## Test plan

- [ ] Open `http://localhost:5173` — campaigns list loads without errors
- [ ] Click "Connect wallet" — modal appears with Freighter/xBull/Rabet options
- [ ] Connect Freighter — wallet address and balance appear in header
- [ ] Navigate to `/admin` without wallet connected — see "Connect wallet" prompt
- [ ] Connect a non-admin wallet — see "Access denied" card with address
- [ ] Connect the admin wallet (`VITE_ADMIN_ADDRESSES`) — admin panel loads
- [ ] CI passes (no contract or binding changes)