### PR TITLE
feat(backend): brute-force / lockout protection on auth endpoints (#588)

### DIFF
--- a/.github/workflows/alertingrules.yml
+++ b/.github/workflows/alertingrules.yml
@@ -35,6 +35,38 @@ groups:
             'The backend process restarted at {{ $value }}. Verify deployment or investigate crash.'
           runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#backend-restart'
 
+      # Brute-force / credential-stuffing: spike in failed auth attempts (#588)
+      - alert: AuthFailureSpike
+        expr: |
+          sum(rate(trivela_auth_failures_total{job="trivela-backend"}[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: 'Spike in failed authentication attempts'
+          description:
+            'Failed auth attempts are averaging {{ $value | humanize }}/s over the last 5 minutes —
+            possible brute-force or credential-stuffing. Check the trivela_auth_lockouts_total
+            counter and backend warn logs.'
+          runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#auth-brute-force-lockout'
+
+      # Brute-force lockout actively triggering (#588)
+      - alert: AuthLockoutTriggered
+        expr: |
+          increase(trivela_auth_lockouts_total{job="trivela-backend"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: backend
+        annotations:
+          summary: 'Authentication lockout triggered'
+          description:
+            '{{ $value }} brute-force lockout(s) triggered in the last 5 minutes. One or more
+            clients are being temporarily locked out of auth endpoints. Investigate source IPs in
+            the backend warn logs.'
+          runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#auth-brute-force-lockout'
+
       # Backend is down (no scrape)
       - alert: BackendDown
         expr: up{job="trivela-backend"} == 0

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -74,6 +74,15 @@ UPLOAD_PUBLIC_BASE_URL=http://localhost:3001/uploads
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=60
 
+# Auth Brute-Force / Lockout Configuration (#588)
+# Failed auth attempts on guarded routes are tracked per client IP. After
+# AUTH_LOCKOUT_SOFT_THRESHOLD consecutive failures, requests are progressively
+# delayed; after AUTH_LOCKOUT_HARD_THRESHOLD, the client is temporarily locked
+# out (HTTP 429) for AUTH_LOCKOUT_BASE_MS, backing off exponentially on repeat.
+AUTH_LOCKOUT_SOFT_THRESHOLD=5
+AUTH_LOCKOUT_HARD_THRESHOLD=10
+AUTH_LOCKOUT_BASE_MS=60000
+
 # Redis Configuration (optional)
 # When set, rate limiting state is stored in Redis for horizontal scaling
 # Leave empty to use in-memory rate limiter (default for local dev)

--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -82,6 +82,13 @@ export function validateBackendEnv(env = process.env) {
   record(() => normalizePositiveInteger(env.RATE_LIMIT_WINDOW_MS, 'RATE_LIMIT_WINDOW_MS'));
   record(() => normalizePositiveInteger(env.RATE_LIMIT_MAX_REQUESTS, 'RATE_LIMIT_MAX_REQUESTS'));
   record(() => normalizePositiveInteger(env.SHORT_CACHE_TTL_MS, 'SHORT_CACHE_TTL_MS'));
+  record(() =>
+    normalizePositiveInteger(env.AUTH_LOCKOUT_SOFT_THRESHOLD, 'AUTH_LOCKOUT_SOFT_THRESHOLD'),
+  );
+  record(() =>
+    normalizePositiveInteger(env.AUTH_LOCKOUT_HARD_THRESHOLD, 'AUTH_LOCKOUT_HARD_THRESHOLD'),
+  );
+  record(() => normalizePositiveInteger(env.AUTH_LOCKOUT_BASE_MS, 'AUTH_LOCKOUT_BASE_MS'));
 
   record(() =>
     resolveStellarNetworkConfig({

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -19,6 +19,7 @@ import { pathToFileURL } from 'node:url';
 import Redis from 'ioredis';
 import createApiKeyAuth, { createMasterKeyAuth } from './middleware/apiKeyAuth.js';
 import { createRateLimiter, createRedisStore } from './middleware/rateLimit.js';
+import { createAuthLockout } from './middleware/authLockout.js';
 import requestLogger, { log } from './middleware/logger.js';
 import requestId from './middleware/requestId.js';
 import securityHeaders from './middleware/securityHeaders.js';
@@ -52,6 +53,9 @@ import { createEmbedRoute } from './routes/embed.js';
 const DEFAULT_PORT = 3001;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 60;
+const DEFAULT_AUTH_LOCKOUT_SOFT_THRESHOLD = 5;
+const DEFAULT_AUTH_LOCKOUT_HARD_THRESHOLD = 10;
+const DEFAULT_AUTH_LOCKOUT_BASE_LOCKOUT_MS = 60_000;
 const DEFAULT_SHORT_CACHE_TTL_MS = 5_000;
 const DEFAULT_JSON_BODY_LIMIT = '100kb';
 const DEFAULT_RPC_POLL_INTERVAL_MS = 60_000;
@@ -202,6 +206,20 @@ export async function createApp(options = {}) {
     DEFAULT_RATE_LIMIT_MAX_REQUESTS,
   );
 
+  const authLockoutOptions = /** @type {any} */ (options.authLockout) ?? {};
+  const authLockoutSoftThreshold = normalizePositiveInteger(
+    authLockoutOptions.softThreshold ?? process.env.AUTH_LOCKOUT_SOFT_THRESHOLD,
+    DEFAULT_AUTH_LOCKOUT_SOFT_THRESHOLD,
+  );
+  const authLockoutHardThreshold = normalizePositiveInteger(
+    authLockoutOptions.hardThreshold ?? process.env.AUTH_LOCKOUT_HARD_THRESHOLD,
+    DEFAULT_AUTH_LOCKOUT_HARD_THRESHOLD,
+  );
+  const authLockoutBaseMs = normalizePositiveInteger(
+    authLockoutOptions.baseLockoutMs ?? process.env.AUTH_LOCKOUT_BASE_MS,
+    DEFAULT_AUTH_LOCKOUT_BASE_LOCKOUT_MS,
+  );
+
   const seed = /** @type {any[]} */ (options.campaigns) ?? defaultSeed();
   const dbPath = /** @type {string} */ (options.dbPath) ?? process.env.DB_PATH ?? './trivela.db';
   const dal = await createDal({
@@ -256,6 +274,8 @@ export async function createApp(options = {}) {
     requestTotal: 0,
     requestErrors: 0,
     routeHits: new Map(),
+    authFailures: 0,
+    authLockouts: 0,
   };
 
   /**
@@ -273,18 +293,51 @@ export async function createApp(options = {}) {
     next();
   });
 
-  const requireApiKey = createApiKeyAuth({
-    apiKeys:
-      /** @type {string} */ (options.apiKeys) ??
-      /** @type {string} */ (options.apiKey) ??
-      process.env.TRIVELA_API_KEYS ??
-      process.env.TRIVELA_API_KEY ??
-      '',
-    apiKeyRepository: options.apiKeyRepository ?? apiKeyRepository,
+  // Brute-force / credential-stuffing guard (#588). Runs immediately before the
+  // auth middleware on every protected route; a spike in failures/lockouts is
+  // surfaced via the trivela_auth_* counters and structured warn logs.
+  const authGuard = createAuthLockout({
+    softThreshold: authLockoutSoftThreshold,
+    hardThreshold: authLockoutHardThreshold,
+    baseLockoutMs: authLockoutBaseMs,
+    timeProvider: authLockoutOptions.timeProvider,
+    delayFn: authLockoutOptions.delayFn,
+    store: authLockoutOptions.store,
+    onFailure: ({ key, failures }) => {
+      metrics.authFailures += 1;
+      log.warn({ key, failures }, 'Failed authentication attempt');
+    },
+    onLockout: ({ key, failures, lockoutMs, lockoutCount }) => {
+      metrics.authLockouts += 1;
+      log.warn(
+        { key, failures, lockoutMs, lockoutCount },
+        'Authentication lockout triggered (possible brute-force)',
+      );
+    },
   });
-  const requireMasterKey = createMasterKeyAuth({
-    masterKey: /** @type {string} */ (options.masterKey) ?? process.env.TRIVELA_MASTER_KEY ?? '',
-  });
+
+  // Auth middlewares are exposed as [authGuard, requireX] arrays; Express
+  // flattens nested handler arrays, so existing route registrations pick up the
+  // guard with no change. Only auth-bearing routes are guarded, which keeps a
+  // 200 on a public route from ever resetting an attacker's failure counter.
+  const requireApiKey = [
+    authGuard,
+    createApiKeyAuth({
+      apiKeys:
+        /** @type {string} */ (options.apiKeys) ??
+        /** @type {string} */ (options.apiKey) ??
+        process.env.TRIVELA_API_KEYS ??
+        process.env.TRIVELA_API_KEY ??
+        '',
+      apiKeyRepository: options.apiKeyRepository ?? apiKeyRepository,
+    }),
+  ];
+  const requireMasterKey = [
+    authGuard,
+    createMasterKeyAuth({
+      masterKey: /** @type {string} */ (options.masterKey) ?? process.env.TRIVELA_MASTER_KEY ?? '',
+    }),
+  ];
   const requireAdminMasterKey = requireMasterKey;
 
   let rateLimitStore = null;
@@ -520,6 +573,12 @@ export async function createApp(options = {}) {
       '# HELP trivela_request_errors_total Total HTTP requests with status >= 400.',
       '# TYPE trivela_request_errors_total counter',
       `trivela_request_errors_total ${metrics.requestErrors}`,
+      '# HELP trivela_auth_failures_total Total failed authentication attempts on guarded routes.',
+      '# TYPE trivela_auth_failures_total counter',
+      `trivela_auth_failures_total ${metrics.authFailures}`,
+      '# HELP trivela_auth_lockouts_total Total brute-force lockouts triggered on guarded routes.',
+      '# TYPE trivela_auth_lockouts_total counter',
+      `trivela_auth_lockouts_total ${metrics.authLockouts}`,
       '# HELP trivela_process_uptime_seconds Node.js process uptime.',
       '# TYPE trivela_process_uptime_seconds gauge',
       `trivela_process_uptime_seconds ${uptimeSeconds.toFixed(3)}`,
@@ -580,6 +639,12 @@ export async function createApp(options = {}) {
         keying: 'per API key when present, otherwise per IP address',
         windowMs: rateLimitWindowMs,
         maxRequests: rateLimitMaxRequests,
+      },
+      authLockout: {
+        keying: 'per client IP address',
+        softThreshold: authLockoutSoftThreshold,
+        hardThreshold: authLockoutHardThreshold,
+        baseLockoutMs: authLockoutBaseMs,
       },
       body: {
         jsonLimit: jsonBodyLimit,

--- a/backend/src/integration/authLockout.test.js
+++ b/backend/src/integration/authLockout.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import request from 'supertest';
+import { createApp } from '../index.js';
+
+// End-to-end coverage for the brute-force lockout (#588): drive real HTTP
+// requests through the full middleware stack against a protected route.
+//
+// `delayFn` is stubbed to a no-op so the progressive delay doesn't slow the
+// suite; thresholds are lowered so a handful of requests reach the lockout.
+function createTestApp(options = {}) {
+  return createApp({
+    dbPath: ':memory:',
+    campaigns: [],
+    disableJobs: true,
+    disableRedis: true,
+    skipEnvValidation: true,
+    apiKeys: 'test-key-123',
+    authLockout: {
+      softThreshold: 2,
+      hardThreshold: 3,
+      delayFn: async () => {},
+      ...(options.authLockout ?? {}),
+    },
+    ...options,
+  });
+}
+
+test('repeated bad API keys lock the client out with 429 + Retry-After', async () => {
+  const app = await createTestApp();
+  const payload = { name: 'X', description: 'Y', rewardPerAction: 1 };
+
+  // Three rejected attempts (the configured hard threshold).
+  for (let i = 0; i < 3; i += 1) {
+    await request(app)
+      .post('/api/v1/campaigns')
+      .set('X-API-Key', 'wrong-key')
+      .send(payload)
+      .expect(401);
+  }
+
+  // The next attempt is locked out before auth even runs.
+  const locked = await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'wrong-key')
+    .send(payload)
+    .expect(429);
+
+  assert.equal(locked.body.code, 'AUTH_LOCKED_OUT');
+  assert.ok(Number(locked.headers['retry-after']) > 0);
+  assert.equal(locked.headers['x-auth-lockout'], 'active');
+});
+
+test('a locked-out client is blocked even when presenting the correct key', async () => {
+  const app = await createTestApp();
+  const payload = { name: 'X', description: 'Y', rewardPerAction: 1 };
+
+  for (let i = 0; i < 3; i += 1) {
+    await request(app).post('/api/v1/campaigns').set('X-API-Key', 'wrong-key').send(payload);
+  }
+
+  // Even the valid key can't get through while the lockout is active.
+  await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'test-key-123')
+    .send(payload)
+    .expect(429);
+});
+
+test('a successful auth before the threshold clears accumulated failures', async () => {
+  const app = await createTestApp();
+  const payload = { name: 'X', description: 'Y', rewardPerAction: 1 };
+
+  // Two failures (below the hard threshold of 3)...
+  await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'wrong-key')
+    .send(payload)
+    .expect(401);
+  await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'wrong-key')
+    .send(payload)
+    .expect(401);
+
+  // ...then a success resets the counter.
+  await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'test-key-123')
+    .send(payload)
+    .expect(201);
+
+  // A fresh failure should be treated as the first again (still 401, not 429).
+  await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', 'wrong-key')
+    .send(payload)
+    .expect(401);
+});
+
+test('/metrics surfaces the auth failure and lockout counters', async () => {
+  const app = await createTestApp();
+  const payload = { name: 'X', description: 'Y', rewardPerAction: 1 };
+
+  for (let i = 0; i < 3; i += 1) {
+    await request(app).post('/api/v1/campaigns').set('X-API-Key', 'wrong-key').send(payload);
+  }
+
+  const metrics = await request(app).get('/metrics').expect(200);
+  assert.match(metrics.text, /trivela_auth_failures_total \d+/);
+  assert.match(metrics.text, /trivela_auth_lockouts_total [1-9]\d*/);
+});
+
+test('GET /api/v1 advertises the auth-lockout policy', async () => {
+  const app = await createTestApp();
+  const response = await request(app).get('/api/v1').expect(200);
+  assert.equal(response.body.authLockout.keying, 'per client IP address');
+  assert.equal(response.body.authLockout.softThreshold, 2);
+  assert.equal(response.body.authLockout.hardThreshold, 3);
+});

--- a/backend/src/middleware/authLockout.js
+++ b/backend/src/middleware/authLockout.js
@@ -1,0 +1,238 @@
+// @ts-check
+//
+// Brute-force / credential-stuffing protection for auth-bearing endpoints (#588).
+//
+// This middleware sits *in front of* the API-key and master-key auth
+// middleware. It never inspects credentials itself — instead it observes the
+// response status of each guarded request:
+//
+//   - a 401 (auth rejected) counts as a failed attempt for the client key
+//   - a 2xx/3xx (auth accepted, or a no-op when auth is unconfigured) clears
+//     the client's failure record
+//
+// Escalation:
+//   1. After `softThreshold` consecutive failures it injects a progressive,
+//      exponentially-growing delay before the request is processed. This slows
+//      automated guessing to a crawl without hard-locking a fat-fingered human.
+//   2. After `hardThreshold` failures it issues a temporary lockout: further
+//      attempts are rejected immediately with 429 + Retry-After until the
+//      lockout expires. Repeat lockout episodes from the same key back off
+//      exponentially (capped at `maxLockoutMs`).
+//
+// A spike in failures/lockouts is observable two ways: the `onFailure` /
+// `onLockout` hooks (wired to structured warn logs + the trivela_auth_*
+// counters on /metrics) and the lockout headers on blocked responses. Alert
+// rules live in .github/workflows/alertingrules.yml.
+//
+// The store is pluggable and the clock/delay are injectable, mirroring the
+// rate-limit middleware so the whole thing is deterministically unit-testable.
+
+const DEFAULT_SOFT_THRESHOLD = 5;
+const DEFAULT_HARD_THRESHOLD = 10;
+const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 5_000;
+const DEFAULT_BASE_LOCKOUT_MS = 60_000; // 1 minute
+const DEFAULT_MAX_LOCKOUT_MS = 3_600_000; // 1 hour
+const DEFAULT_FAILURE_WINDOW_MS = 900_000; // 15 minutes
+const DEFAULT_MAX_TRACKED_KEYS = 10_000;
+
+/**
+ * Default key: the client IP. Brute-force / credential-stuffing presents many
+ * *different* (invalid) credentials from one origin, so keying by the presented
+ * credential would never accumulate — IP is the right axis to throttle.
+ *
+ * @param {import('express').Request} req
+ * @returns {string}
+ */
+function defaultKeyGenerator(req) {
+  return `ip:${req.ip || req.socket?.remoteAddress || 'unknown'}`;
+}
+
+/**
+ * In-memory lockout store. Bounded so a distributed attack across many IPs
+ * can't grow it without limit — when full, the oldest-inserted key is evicted.
+ *
+ * @param {{ maxEntries?: number }} [options]
+ */
+export function createLockoutMemoryStore({ maxEntries = DEFAULT_MAX_TRACKED_KEYS } = {}) {
+  /** @type {Map<string, LockoutRecord>} */
+  const entries = new Map();
+
+  return {
+    /** @param {string} key @returns {LockoutRecord | undefined} */
+    get(key) {
+      return entries.get(key);
+    },
+    /** @param {string} key @param {LockoutRecord} record */
+    set(key, record) {
+      // Re-insert so Map iteration order reflects recency (for eviction).
+      entries.delete(key);
+      entries.set(key, record);
+      if (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest !== undefined) {
+          entries.delete(oldest);
+        }
+      }
+    },
+    /** @param {string} key */
+    delete(key) {
+      entries.delete(key);
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}
+
+/**
+ * @typedef {{
+ *   failures: number,
+ *   firstFailureAt: number,
+ *   lockedUntil: number,
+ *   lockoutCount: number,
+ *   lastSeen: number,
+ * }} LockoutRecord
+ */
+
+/**
+ * @param {{
+ *   softThreshold?: number,
+ *   hardThreshold?: number,
+ *   baseDelayMs?: number,
+ *   maxDelayMs?: number,
+ *   baseLockoutMs?: number,
+ *   maxLockoutMs?: number,
+ *   failureWindowMs?: number,
+ *   timeProvider?: () => number,
+ *   keyGenerator?: (req: import('express').Request) => string,
+ *   store?: ReturnType<typeof createLockoutMemoryStore>,
+ *   delayFn?: (ms: number) => Promise<void>,
+ *   onFailure?: ((info: { key: string, failures: number }) => void) | null,
+ *   onLockout?: ((info: { key: string, failures: number, lockoutMs: number, lockoutCount: number }) => void) | null,
+ *   isAuthFailure?: (res: import('express').Response) => boolean,
+ *   isAuthSuccess?: (res: import('express').Response) => boolean,
+ * }} [options]
+ */
+export function createAuthLockout({
+  softThreshold = DEFAULT_SOFT_THRESHOLD,
+  hardThreshold = DEFAULT_HARD_THRESHOLD,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  baseLockoutMs = DEFAULT_BASE_LOCKOUT_MS,
+  maxLockoutMs = DEFAULT_MAX_LOCKOUT_MS,
+  failureWindowMs = DEFAULT_FAILURE_WINDOW_MS,
+  timeProvider = () => Date.now(),
+  keyGenerator = defaultKeyGenerator,
+  store = createLockoutMemoryStore(),
+  delayFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  onFailure = null,
+  onLockout = null,
+  isAuthFailure = (res) => res.statusCode === 401,
+  isAuthSuccess = (res) => res.statusCode >= 200 && res.statusCode < 400,
+} = {}) {
+  /**
+   * Fold the outcome of a finished request into the key's failure record.
+   * @param {string} key
+   * @param {import('express').Response} res
+   */
+  function recordOutcome(key, res) {
+    const now = timeProvider();
+
+    if (isAuthSuccess(res)) {
+      // A genuine success wipes the slate clean for this key.
+      if (store.get(key)) {
+        store.delete(key);
+      }
+      return;
+    }
+
+    if (!isAuthFailure(res)) {
+      // Neither an auth pass nor an auth rejection (e.g. a 400/404/500 or the
+      // 429 we ourselves emitted while locked) — don't let it move the counter.
+      return;
+    }
+
+    const existing = store.get(key);
+    /** @type {LockoutRecord} */
+    const record = existing ?? {
+      failures: 0,
+      firstFailureAt: now,
+      lockedUntil: 0,
+      lockoutCount: 0,
+      lastSeen: now,
+    };
+
+    record.failures += 1;
+    record.lastSeen = now;
+    if (!record.firstFailureAt) {
+      record.firstFailureAt = now;
+    }
+
+    onFailure?.({ key, failures: record.failures });
+
+    if (record.failures >= hardThreshold) {
+      record.lockoutCount += 1;
+      const lockoutMs = Math.min(maxLockoutMs, baseLockoutMs * 2 ** (record.lockoutCount - 1));
+      record.lockedUntil = now + lockoutMs;
+      onLockout?.({ key, failures: record.failures, lockoutMs, lockoutCount: record.lockoutCount });
+    }
+
+    store.set(key, record);
+  }
+
+  return async function authLockout(req, res, next) {
+    const now = timeProvider();
+    const key = keyGenerator(req);
+    let record = store.get(key);
+
+    // Forget a key once it's no longer locked and its failure window has
+    // elapsed — a sliding reset so transient mistakes don't accumulate forever.
+    if (
+      record &&
+      record.lockedUntil <= now &&
+      record.firstFailureAt &&
+      now - record.firstFailureAt > failureWindowMs
+    ) {
+      store.delete(key);
+      record = undefined;
+    }
+
+    // Hard lockout in effect → reject before the auth middleware even runs.
+    if (record && record.lockedUntil > now) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((record.lockedUntil - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      res.setHeader('X-Auth-Lockout', 'active');
+      return res.status(429).json({
+        error: 'Too many failed authentication attempts. Try again later.',
+        code: 'AUTH_LOCKED_OUT',
+        retryAfterSeconds,
+      });
+    }
+
+    // Observe how this request resolves so we can update the record. `finish`
+    // fires once the response is fully sent, exactly like the request-metrics
+    // middleware in index.js.
+    res.on('finish', () => {
+      try {
+        recordOutcome(key, res);
+      } catch {
+        // Never let bookkeeping break a response that already went out.
+      }
+    });
+
+    // Progressive delay once past the soft threshold. The Nth failure beyond
+    // the threshold waits baseDelayMs * 2^(N-1), capped at maxDelayMs.
+    const failures = record?.failures ?? 0;
+    if (failures >= softThreshold) {
+      const over = failures - softThreshold + 1;
+      const delay = Math.min(maxDelayMs, baseDelayMs * 2 ** (over - 1));
+      res.setHeader('X-Auth-Throttle-Delay-Ms', String(delay));
+      await delayFn(delay);
+    }
+
+    return next();
+  };
+}
+
+export { defaultKeyGenerator };

--- a/backend/src/middleware/authLockout.test.js
+++ b/backend/src/middleware/authLockout.test.js
@@ -1,0 +1,292 @@
+// @ts-check
+//
+// Unit tests for the brute-force / lockout middleware (#588).
+//
+// These pin the behaviour that actually protects the auth endpoints:
+//
+//   - failed attempts (401) accumulate per client; successes (2xx/3xx) reset
+//   - a progressive, exponentially-growing delay kicks in past the soft
+//     threshold and is capped at maxDelayMs
+//   - a temporary lockout (429 + Retry-After) kicks in past the hard threshold
+//   - lockouts expire on the clock, and repeat episodes back off exponentially
+//   - the failure window is a sliding reset
+//   - keying is per-IP and independent across clients
+//   - the in-memory store is bounded (oldest-key eviction)
+//   - onFailure / onLockout hooks fire for metrics + alerting
+//
+// Tests run under node:test (matching rateLimit.test.js) so `npm test` picks
+// them up with no extra runner. The clock, delay, and store are all injected so
+// the tests are deterministic and never actually sleep.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createAuthLockout, createLockoutMemoryStore } from './authLockout.js';
+
+/** @param {{ ip?: string }} [opts] */
+function makeReqRes({ ip = '1.1.1.1' } = {}) {
+  /** @type {Array<() => void>} */
+  const finishListeners = [];
+  /** @type {Record<string, string>} */
+  const headersOut = {};
+  const req = { headers: {}, query: {}, ip, socket: { remoteAddress: ip } };
+  const res = {
+    statusCode: 200,
+    headersOut,
+    /** @type {unknown} */
+    body: undefined,
+    setHeader(/** @type {string} */ name, /** @type {string} */ value) {
+      headersOut[name] = value;
+    },
+    status(/** @type {number} */ code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(/** @type {unknown} */ payload) {
+      this.body = payload;
+      return this;
+    },
+    on(/** @type {string} */ event, /** @type {() => void} */ cb) {
+      if (event === 'finish') finishListeners.push(cb);
+      return this;
+    },
+    // Test helper: simulate the response completing with a final status.
+    finish(/** @type {number} */ code) {
+      this.statusCode = code;
+      for (const cb of finishListeners) cb();
+    },
+  };
+  return { req, res };
+}
+
+/**
+ * Drive one request through the guard. When the guard lets it through, we
+ * simulate the downstream auth middleware's outcome via res.finish(outcome).
+ *
+ * @param {import('express').RequestHandler} guard
+ * @param {{ ip?: string, outcome?: number }} [opts]
+ */
+async function attempt(guard, { ip = '1.1.1.1', outcome = 401 } = {}) {
+  const { req, res } = makeReqRes({ ip });
+  let nextCalled = false;
+  await guard(/** @type {any} */ (req), /** @type {any} */ (res), () => {
+    nextCalled = true;
+  });
+  if (nextCalled) {
+    res.finish(outcome);
+  }
+  return { req, res, nextCalled };
+}
+
+test('below the soft threshold: no delay, attempts pass through, failures accumulate', async () => {
+  const store = createLockoutMemoryStore();
+  /** @type {number[]} */
+  const delays = [];
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 5,
+    store,
+    delayFn: async (ms) => {
+      delays.push(ms);
+    },
+  });
+
+  const a1 = await attempt(guard);
+  const a2 = await attempt(guard);
+  assert.equal(a1.nextCalled, true);
+  assert.equal(a2.nextCalled, true);
+  assert.deepEqual(delays, [], 'no delay below the soft threshold');
+  assert.equal(store.get('ip:1.1.1.1')?.failures, 2);
+});
+
+test('a successful (2xx) attempt clears the failure record', async () => {
+  const store = createLockoutMemoryStore();
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 5,
+    store,
+    delayFn: async () => {},
+  });
+
+  await attempt(guard, { outcome: 401 });
+  await attempt(guard, { outcome: 401 });
+  assert.equal(store.get('ip:1.1.1.1')?.failures, 2);
+
+  await attempt(guard, { outcome: 200 });
+  assert.equal(store.get('ip:1.1.1.1'), undefined, 'success wipes the record');
+});
+
+test('progressive delay grows exponentially past the soft threshold and caps at maxDelayMs', async () => {
+  const store = createLockoutMemoryStore();
+  /** @type {number[]} */
+  const delays = [];
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 5,
+    baseDelayMs: 100,
+    maxDelayMs: 400,
+    store,
+    delayFn: async (ms) => {
+      delays.push(ms);
+    },
+  });
+
+  // 5 consecutive 401s. The 3rd/4th/5th sit past the soft threshold.
+  for (let i = 0; i < 5; i += 1) {
+    await attempt(guard);
+  }
+  // over = 1,2,3 → 100, 200, 400 (400 = base*2^2; the 400 cap also holds).
+  assert.deepEqual(delays, [100, 200, 400]);
+});
+
+test('locks out with 429 + Retry-After once the hard threshold is reached', async () => {
+  const store = createLockoutMemoryStore();
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 3,
+    baseLockoutMs: 1000,
+    store,
+    delayFn: async () => {},
+  });
+
+  await attempt(guard); // f1
+  await attempt(guard); // f2
+  await attempt(guard); // f3 → triggers lockout
+
+  // Next request is blocked outright, before any auth runs.
+  const blocked = await attempt(guard);
+  assert.equal(blocked.nextCalled, false, 'next() must not run while locked out');
+  assert.equal(blocked.res.statusCode, 429);
+  assert.equal(/** @type {any} */ (blocked.res.body).code, 'AUTH_LOCKED_OUT');
+  assert.ok(Number(blocked.res.headersOut['Retry-After']) > 0);
+  assert.equal(blocked.res.headersOut['X-Auth-Lockout'], 'active');
+});
+
+test('lockout expires on the clock; a repeat lockout backs off exponentially', async () => {
+  let now = 1_000_000;
+  const store = createLockoutMemoryStore();
+  /** @type {Array<{ lockoutMs: number, lockoutCount: number }>} */
+  const lockouts = [];
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 3,
+    baseLockoutMs: 1000,
+    maxLockoutMs: 60_000,
+    failureWindowMs: 10_000,
+    timeProvider: () => now,
+    store,
+    delayFn: async () => {},
+    onLockout: (info) =>
+      lockouts.push({ lockoutMs: info.lockoutMs, lockoutCount: info.lockoutCount }),
+  });
+
+  await attempt(guard); // f1
+  await attempt(guard); // f2
+  await attempt(guard); // f3 → first lockout (1000ms)
+  assert.deepEqual(lockouts[0], { lockoutMs: 1000, lockoutCount: 1 });
+
+  // Still locked just before expiry.
+  now += 999;
+  assert.equal((await attempt(guard)).nextCalled, false);
+
+  // After expiry the request is allowed through again...
+  now += 2;
+  const after = await attempt(guard); // f4 → re-locks (2nd episode)
+  assert.equal(after.nextCalled, true);
+  assert.deepEqual(lockouts[1], { lockoutMs: 2000, lockoutCount: 2 }, 'exponential back-off');
+});
+
+test('the failure window is a sliding reset once a key is no longer locked', async () => {
+  let now = 1_000_000;
+  const store = createLockoutMemoryStore();
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 10,
+    failureWindowMs: 5_000,
+    timeProvider: () => now,
+    store,
+    delayFn: async () => {},
+  });
+
+  await attempt(guard); // f1
+  await attempt(guard); // f2
+  assert.equal(store.get('ip:1.1.1.1')?.failures, 2);
+
+  // Advance past the failure window with no lockout in effect.
+  now += 5_001;
+  await attempt(guard); // should start fresh
+  assert.equal(store.get('ip:1.1.1.1')?.failures, 1, 'window elapsed → counter reset');
+});
+
+test('keying is per-IP: one client locking out does not affect another', async () => {
+  const store = createLockoutMemoryStore();
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 3,
+    store,
+    delayFn: async () => {},
+  });
+
+  await attempt(guard, { ip: '10.0.0.1' });
+  await attempt(guard, { ip: '10.0.0.1' });
+  await attempt(guard, { ip: '10.0.0.1' }); // locks out 10.0.0.1
+
+  const lockedClient = await attempt(guard, { ip: '10.0.0.1' });
+  assert.equal(lockedClient.nextCalled, false);
+
+  const otherClient = await attempt(guard, { ip: '10.0.0.2' });
+  assert.equal(otherClient.nextCalled, true, 'a different IP is unaffected');
+});
+
+test('non-auth outcomes (e.g. 500) do not move the failure counter', async () => {
+  const store = createLockoutMemoryStore();
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 5,
+    store,
+    delayFn: async () => {},
+  });
+
+  await attempt(guard, { outcome: 500 });
+  assert.equal(store.get('ip:1.1.1.1'), undefined, 'a 500 is neither pass nor auth-reject');
+});
+
+test('onFailure and onLockout hooks fire for metrics/alerting', async () => {
+  let failures = 0;
+  let lockouts = 0;
+  const guard = createAuthLockout({
+    softThreshold: 2,
+    hardThreshold: 3,
+    delayFn: async () => {},
+    onFailure: () => {
+      failures += 1;
+    },
+    onLockout: () => {
+      lockouts += 1;
+    },
+  });
+
+  await attempt(guard);
+  await attempt(guard);
+  await attempt(guard); // 3rd failure → lockout
+
+  assert.equal(failures, 3);
+  assert.equal(lockouts, 1);
+});
+
+test('createLockoutMemoryStore bounds its size and evicts the oldest key', () => {
+  const store = createLockoutMemoryStore({ maxEntries: 2 });
+  const rec = () => ({
+    failures: 1,
+    firstFailureAt: 0,
+    lockedUntil: 0,
+    lockoutCount: 0,
+    lastSeen: 0,
+  });
+  store.set('a', rec());
+  store.set('b', rec());
+  store.set('c', rec()); // evicts 'a'
+  assert.equal(store.size, 2);
+  assert.equal(store.get('a'), undefined);
+  assert.ok(store.get('b'));
+  assert.ok(store.get('c'));
+});

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -29,14 +29,15 @@ frontend-friendly message mappings.
 
 ## Backend API Errors
 
-| Status | Error                   | Cause                              | Frontend Message                                       |
-| ------ | ----------------------- | ---------------------------------- | ------------------------------------------------------ |
-| 400    | `Bad Request`           | Invalid request body or parameters | "Invalid input. Please check your data and try again"  |
-| 401    | `Unauthorized`          | Missing or invalid API key         | "API key is required or invalid"                       |
-| 404    | `Not Found`             | Campaign or resource not found     | "The requested campaign was not found"                 |
-| 429    | `Too Many Requests`     | Rate limit exceeded                | "Too many requests. Please wait before trying again"   |
-| 500    | `Internal Server Error` | Server error                       | "An unexpected error occurred. Please try again later" |
-| 503    | `Service Unavailable`   | Soroban RPC unavailable            | "The blockchain service is temporarily unavailable"    |
+| Status | Error                   | Cause                                          | Frontend Message                                       |
+| ------ | ----------------------- | ---------------------------------------------- | ------------------------------------------------------ |
+| 400    | `Bad Request`           | Invalid request body or parameters             | "Invalid input. Please check your data and try again"  |
+| 401    | `Unauthorized`          | Missing or invalid API key                     | "API key is required or invalid"                       |
+| 404    | `Not Found`             | Campaign or resource not found                 | "The requested campaign was not found"                 |
+| 429    | `Too Many Requests`     | Rate limit exceeded                            | "Too many requests. Please wait before trying again"   |
+| 429    | `AUTH_LOCKED_OUT`       | Brute-force lockout after repeated failed auth | "Too many failed attempts. Try again later"            |
+| 500    | `Internal Server Error` | Server error                                   | "An unexpected error occurred. Please try again later" |
+| 503    | `Service Unavailable`   | Soroban RPC unavailable                        | "The blockchain service is temporarily unavailable"    |
 
 ## Frontend Error Mapping
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -98,6 +98,26 @@ If the API returns 429 responses unexpectedly:
 3. For immediate relief, restart the backend container to flush the in-memory limiter (only
    effective when Redis is not in use).
 
+## Auth Brute-Force Lockout
+
+Triggered by the `AuthFailureSpike` / `AuthLockoutTriggered` alerts, or a surge in
+`trivela_auth_failures_total` / `trivela_auth_lockouts_total` on `/metrics`. The backend
+progressively delays and then temporarily locks out (HTTP 429, `code: AUTH_LOCKED_OUT`) clients that
+repeatedly fail authentication on a guarded route.
+
+1. Identify the offending source(s). Lockout/failure events are logged at `warn` with the keyed
+   client, e.g.:
+   ```bash
+   docker compose logs backend --tail 500 | grep -E "Authentication lockout|Failed authentication"
+   ```
+2. If the traffic is malicious, block the source IP(s) at the edge (nginx / load balancer / WAF) so
+   it never reaches the app.
+3. If a legitimate integrator is locked out (e.g. a rotated/expired key), have them fix their
+   credentials; the lockout self-clears after the back-off window, or restart the backend to flush
+   the in-memory lockout state immediately.
+4. Tune thresholds via `AUTH_LOCKOUT_SOFT_THRESHOLD`, `AUTH_LOCKOUT_HARD_THRESHOLD`, and
+   `AUTH_LOCKOUT_BASE_MS` if the defaults are too aggressive/lenient, then restart the backend.
+
 ## Database Migration Failures
 
 If `npm run db:migrate` fails during deployment:


### PR DESCRIPTION
## Summary

Implements the **Brute-force / lockout** work item of the security-hardening epic **#651** (originally tracked as #588): progressive delay + temporary lockout on authentication, with spike alerting.

Trivela's auth (API-key and master-key) previously returned a plain `401` on bad credentials with no penalty for repetition, so an attacker could guess keys as fast as the rate limiter allowed. This adds a dedicated brute-force guard in front of the auth middleware.

## What changed

### New middleware — `backend/src/middleware/authLockout.js`
- `createAuthLockout()` sits **in front of** the auth middleware and observes each guarded request's response status:
  - a `401` (auth rejected) counts as a **failed attempt**, keyed **per client IP** (brute-force/credential-stuffing presents many invalid credentials from one origin, so IP is the right axis);
  - a `2xx/3xx` (auth accepted) **clears** the client's record.
- **Escalation:**
  1. After `softThreshold` consecutive failures → a **progressive, exponentially-growing delay** (`baseDelayMs · 2ⁿ`, capped at `maxDelayMs`) is injected before the request is processed — slows automated guessing without hard-locking a fat-fingered human.
  2. After `hardThreshold` failures → a **temporary lockout**: further attempts are rejected immediately with **`429` + `Retry-After`** and `code: AUTH_LOCKED_OUT`, until it expires. Repeat lockout episodes back off exponentially (capped at `maxLockoutMs`).
- A **sliding failure window** forgets stale failures; the in-memory store is **bounded** (oldest-key eviction) so a distributed attack can't grow it without limit.
- Mirrors the existing rate-limiter's design: **pluggable store** + **injectable clock/delay**, so it's fully deterministic to test.

### Wiring — `backend/src/index.js`
- The guard is prepended to the API-key and master-key auth as `[authGuard, requireX]` arrays (Express flattens these), so existing route registrations pick it up unchanged. **Only auth-bearing routes are guarded**, which keeps a `200` on a public route from ever resetting an attacker's counter.

### Spike alerting
- New Prometheus counters on `/metrics`: `trivela_auth_failures_total`, `trivela_auth_lockouts_total`.
- Structured `warn` logs on each failure and lockout (keyed client, failure count, lockout duration).
- New alert rules in `.github/workflows/alertingrules.yml`: **`AuthFailureSpike`** (failure rate) and **`AuthLockoutTriggered`**, both linking a new RUNBOOK section.

### Config & docs
- Tunable via `AUTH_LOCKOUT_SOFT_THRESHOLD` (5), `AUTH_LOCKOUT_HARD_THRESHOLD` (10), `AUTH_LOCKOUT_BASE_MS` (60000) — validated in `envValidation.js`, documented in `.env.example`.
- `docs/RUNBOOK.md`: "Auth Brute-Force Lockout" response procedure.
- `docs/ERROR_CODES.md`: `AUTH_LOCKED_OUT` row.
- `GET /api/v1` now advertises the lockout policy alongside the rate-limit policy.

## Note on scope
This epic (#651) bundles 9 formerly-separate issues. This PR deliberably scopes to the **brute-force/lockout** item only, to keep it reviewable; the remaining items (SBOM/provenance, image signing, reproducible builds, CSP+SRI, secret rotation, fuzzing, allowlist anomaly detection, disclosure) are best landed as their own PRs. SEP-10 is not yet implemented in the backend, so the guard is applied to the existing API-key/master-key endpoints and is generic enough to cover a future SEP-10 endpoint.

## Testing
- **10 unit tests** (`backend/src/middleware/authLockout.test.js`): threshold behaviour, exponential delay + cap, lockout + `Retry-After`, clock-based expiry, exponential re-lock, sliding-window reset, per-IP isolation, non-auth outcomes ignored, hooks fire, bounded store eviction.
- **5 integration tests** (`backend/src/integration/authLockout.test.js`): real HTTP through the full stack — lockout after threshold, locked client blocked even with a valid key, success-clears-counter, `/metrics` counters, `/api/v1` policy advertisement.
- Full backend suite green: **105/105 passing**; `tsc` typecheck clean; Prettier clean.

```
ℹ tests 105
ℹ pass 105
ℹ fail 0
```

Closes #588.
