### PR TITLE
feat(frontend): optimistic UI for register/claim with rollback (#627)

### DIFF
--- a/frontend/src/ClaimRewards.jsx
+++ b/frontend/src/ClaimRewards.jsx
@@ -1,10 +1,16 @@
 import { useId, useState } from 'react';
-import { submitClaimTransaction, normalizeError, getStellarNetwork } from './stellar';
+import { submitClaimTransaction, getStellarNetwork } from './stellar';
 import TransactionStatus from './components/TransactionStatus';
+import { useOptimisticAction } from './hooks/useOptimisticAction';
 
 /**
  * ClaimRewards — lets the user enter a points amount, sign a Soroban
  * `claim(user, amount)` transaction via Freighter, and see the result.
+ *
+ * The submit is optimistic: the input clears and a pending indicator appears
+ * immediately; on confirmation the parent reconciles the on-chain balance, and
+ * on failure the entered amount is restored and a class-aware error is shown.
+ * A second submit while one is in flight is ignored (double-submit guard).
  *
  * Props
  * ─────
@@ -15,40 +21,35 @@ import TransactionStatus from './components/TransactionStatus';
  */
 export default function ClaimRewards({ walletAddress, onClaimSuccess }) {
   const [amount, setAmount] = useState('');
-  const [isClaiming, setIsClaiming] = useState(false);
   const [txHash, setTxHash] = useState('');
-  const [claimError, setClaimError] = useState('');
   const amountId = useId();
   const headingId = useId();
   const feedbackId = useId();
-  const feedbackDescribedBy = txHash || claimError ? feedbackId : undefined;
   const stellarNetwork = getStellarNetwork();
+  const { run, isPending, isError, error } = useOptimisticAction();
 
   const parsedAmount = Number(amount);
   const isValid = Number.isInteger(parsedAmount) && parsedAmount > 0;
+  const feedbackDescribedBy = txHash || isError ? feedbackId : undefined;
 
   const handleClaim = async (event) => {
     event.preventDefault();
     if (!walletAddress || !isValid) return;
 
-    setIsClaiming(true);
-    setClaimError('');
     setTxHash('');
+    const submittedAmount = amount;
 
-    try {
-      const { hash, newBalance } = await submitClaimTransaction(walletAddress, parsedAmount);
-
-      setTxHash(hash);
-      setAmount('');
-
-      if (onClaimSuccess) {
-        onClaimSuccess(newBalance);
-      }
-    } catch (error) {
-      setClaimError(normalizeError(error));
-    } finally {
-      setIsClaiming(false);
-    }
+    await run(() => submitClaimTransaction(walletAddress, parsedAmount), {
+      // Optimistic: clear the input right away so the action feels instant.
+      optimistic: () => setAmount(''),
+      // Rollback: restore the amount the user entered if the claim fails.
+      rollback: () => setAmount(submittedAmount),
+      // Reconcile: surface the tx + let the parent refresh the chain balance.
+      reconcile: ({ hash, newBalance }) => {
+        setTxHash(hash);
+        onClaimSuccess?.(newBalance);
+      },
+    });
   };
 
   return (
@@ -70,26 +71,32 @@ export default function ClaimRewards({ walletAddress, onClaimSuccess }) {
             placeholder="e.g. 100"
             className="claim-input"
             value={amount}
-            disabled={isClaiming || !walletAddress}
-            aria-invalid={Boolean(claimError)}
+            disabled={isPending || !walletAddress}
+            aria-invalid={isError}
             aria-describedby={feedbackDescribedBy}
             onChange={(e) => setAmount(e.target.value)}
           />
           <button
             type="submit"
             className="btn btn-primary btn-button"
-            disabled={!walletAddress || !isValid || isClaiming}
+            disabled={!walletAddress || !isValid || isPending}
           >
-            {isClaiming ? 'Signing…' : 'Claim'}
+            {isPending ? 'Signing…' : 'Claim'}
           </button>
         </div>
       </form>
 
-      {txHash && <TransactionStatus hash={txHash} network={stellarNetwork} />}
+      {isPending && (
+        <TransactionStatus variant="pending" network={stellarNetwork} status="Claiming…" />
+      )}
+      {!isPending && txHash && (
+        <TransactionStatus hash={txHash} network={stellarNetwork} status="Claim confirmed" />
+      )}
 
-      {claimError && (
+      {isError && error && (
         <p id={feedbackId} className="claim-error" role="alert">
-          {claimError}
+          {error.message}
+          {error.recovery ? ` ${error.recovery}.` : ''}
         </p>
       )}
     </section>

--- a/frontend/src/RegisterCampaign.jsx
+++ b/frontend/src/RegisterCampaign.jsx
@@ -7,10 +7,16 @@ import {
   getStellarNetwork,
 } from './stellar';
 import TransactionStatus from './components/TransactionStatus';
+import { useOptimisticAction } from './hooks/useOptimisticAction';
 
 /**
  * RegisterCampaign — lets the connected wallet register as a campaign
  * participant by calling the campaign contract's `register(participant)`.
+ *
+ * The submit flow is optimistic: the participant status flips to "Registered"
+ * the instant the user clicks, then either confirms on success or rolls back to
+ * the previous status on failure (with a class-aware error). A second click
+ * while a registration is in flight is ignored (double-submit guard).
  *
  * Props
  * ─────
@@ -19,27 +25,27 @@ import TransactionStatus from './components/TransactionStatus';
 export default function RegisterCampaign({ walletAddress, onRegistered }) {
   const [isRegistered, setIsRegistered] = useState(null);
   const [isChecking, setIsChecking] = useState(false);
-  const [isRegistering, setIsRegistering] = useState(false);
   const [txHash, setTxHash] = useState('');
-  const [error, setError] = useState('');
+  const [checkError, setCheckError] = useState('');
   const [notice, setNotice] = useState('');
   const headingId = useId();
   const statusId = useId();
   const campaignContractId = getCampaignContractId();
   const stellarNetwork = getStellarNetwork();
+  const { run, isPending, isError, error } = useOptimisticAction();
 
   /* On mount (and when the wallet changes), check participant status. */
   useEffect(() => {
     if (!walletAddress || !campaignContractId) {
       setIsRegistered(null);
-      setError('');
+      setCheckError('');
       setNotice('');
       return;
     }
 
     let cancelled = false;
     setIsChecking(true);
-    setError('');
+    setCheckError('');
     setNotice('');
 
     checkParticipantStatus(walletAddress)
@@ -47,7 +53,7 @@ export default function RegisterCampaign({ walletAddress, onRegistered }) {
         if (!cancelled) setIsRegistered(registered);
       })
       .catch((err) => {
-        if (!cancelled) setError(normalizeError(err));
+        if (!cancelled) setCheckError(normalizeError(err));
       })
       .finally(() => {
         if (!cancelled) setIsChecking(false);
@@ -61,43 +67,45 @@ export default function RegisterCampaign({ walletAddress, onRegistered }) {
   const handleRegister = async () => {
     if (!walletAddress) return;
 
-    setIsRegistering(true);
-    setError('');
     setNotice('');
     setTxHash('');
+    setCheckError('');
+    const previousStatus = isRegistered;
 
-    try {
-      const { hash, alreadyRegistered } = await submitRegisterTransaction(walletAddress);
-      setTxHash(hash);
-      setIsRegistered(true);
-
-      if (alreadyRegistered) {
-        setNotice('You were already registered in this campaign.');
-      } else {
-        onRegistered?.();
-      }
-    } catch (err) {
-      setError(normalizeError(err));
-    } finally {
-      setIsRegistering(false);
-    }
+    await run(() => submitRegisterTransaction(walletAddress), {
+      // Optimistic: reflect "registered" immediately so the action feels instant.
+      optimistic: () => setIsRegistered(true),
+      // Rollback: restore the prior status if the transaction fails.
+      rollback: () => setIsRegistered(previousStatus),
+      // Reconcile with chain truth once confirmed.
+      reconcile: ({ hash, alreadyRegistered }) => {
+        setTxHash(hash);
+        if (alreadyRegistered) {
+          setNotice('You were already registered in this campaign.');
+        } else {
+          onRegistered?.();
+        }
+      },
+    });
   };
 
   if (!campaignContractId) return null;
 
   const statusLabel = isChecking
     ? 'Checking…'
-    : isRegistered === true
-      ? '✓ Registered'
-      : isRegistered === false
-        ? 'Not registered'
-        : '—';
+    : isPending
+      ? 'Registering…'
+      : isRegistered === true
+        ? '✓ Registered'
+        : isRegistered === false
+          ? 'Not registered'
+          : '—';
 
   return (
     <section
       className="register-section"
       aria-labelledby={headingId}
-      aria-busy={isChecking || isRegistering}
+      aria-busy={isChecking || isPending}
     >
       <h3 id={headingId} className="register-heading">
         Campaign registration
@@ -114,24 +122,35 @@ export default function RegisterCampaign({ walletAddress, onRegistered }) {
         <button
           type="button"
           className="btn btn-primary btn-button"
-          disabled={isRegistering || isChecking || !walletAddress}
+          disabled={isPending || isChecking || !walletAddress}
           aria-describedby={statusId}
           onClick={handleRegister}
         >
-          {isRegistering ? 'Signing…' : 'Register in campaign'}
+          {isPending ? 'Signing…' : 'Register in campaign'}
         </button>
       )}
 
-      {txHash && <TransactionStatus hash={txHash} network={stellarNetwork} />}
+      {isPending && (
+        <TransactionStatus variant="pending" network={stellarNetwork} status="Registering…" />
+      )}
+      {!isPending && txHash && (
+        <TransactionStatus hash={txHash} network={stellarNetwork} status="Registered" />
+      )}
 
       {notice && (
         <p className="register-note" role="status">
           {notice}
         </p>
       )}
-      {error && (
+      {isError && error && (
         <p className="register-error" role="alert">
-          {error}
+          {error.message}
+          {error.recovery ? ` ${error.recovery}.` : ''}
+        </p>
+      )}
+      {checkError && (
+        <p className="register-error" role="alert">
+          {checkError}
         </p>
       )}
     </section>

--- a/frontend/src/components/TransactionStatus.css
+++ b/frontend/src/components/TransactionStatus.css
@@ -131,3 +131,39 @@
 .tx-explorer-link:hover svg {
   transform: translate(1px, -1px);
 }
+
+/* ── Lifecycle variants (optimistic UI) ─────────────────────────────────── */
+
+.tx-status--pending .tx-status-icon {
+  background: var(--warning, #d97706);
+  animation: txPulse 1.2s ease-in-out infinite;
+}
+
+.tx-status--pending .tx-status-label {
+  color: var(--warning, #d97706);
+}
+
+.tx-status--error .tx-status-icon {
+  background: var(--error, #dc2626);
+}
+
+.tx-status--error .tx-status-label {
+  color: var(--error, #dc2626);
+}
+
+.tx-status-message {
+  margin: 0 0 0.85rem;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #4b5563);
+}
+
+@keyframes txPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}

--- a/frontend/src/components/TransactionStatus.jsx
+++ b/frontend/src/components/TransactionStatus.jsx
@@ -1,19 +1,33 @@
 import { useState } from 'react';
 import './TransactionStatus.css';
 
+const VARIANT_ICON = { success: '✓', pending: '⏳', error: '✕' };
+const VARIANT_DEFAULT_LABEL = {
+  success: 'Success',
+  pending: 'Awaiting confirmation…',
+  error: 'Failed',
+};
+
 /**
- * TransactionStatus — A premium component to display on-chain transaction results.
+ * TransactionStatus — displays the state of an on-chain action. Supports an
+ * optimistic lifecycle via `variant`: a `pending` card (shown immediately on
+ * submit, before a hash exists), a `success` card once confirmed, and an
+ * `error` card with a mapped message when the action is rolled back.
  *
- * @param {string} hash - The full transaction hash.
+ * @param {string} [hash] - The full transaction hash (absent while pending).
  * @param {string} network - The Stellar network (e.g., 'testnet', 'mainnet').
- * @param {string} [status='Success'] - The transaction status label.
+ * @param {'success'|'pending'|'error'} [variant='success'] - Lifecycle state.
+ * @param {string} [status] - Override label (defaults per variant).
+ * @param {string} [message] - Extra detail line (e.g. the rolled-back error).
  */
-export default function TransactionStatus({ hash, network, status = 'Success' }) {
+export default function TransactionStatus({ hash, network, variant = 'success', status, message }) {
   const [copied, setCopied] = useState(false);
 
   const shortenedHash = hash ? `${hash.substring(0, 8)}...${hash.substring(hash.length - 8)}` : '';
 
   const explorerUrl = `https://stellar.expert/explorer/${network}/tx/${hash}`;
+  const label = status ?? VARIANT_DEFAULT_LABEL[variant] ?? VARIANT_DEFAULT_LABEL.success;
+  const isError = variant === 'error';
 
   const handleCopy = async () => {
     try {
@@ -25,86 +39,96 @@ export default function TransactionStatus({ hash, network, status = 'Success' })
     }
   };
 
-  if (!hash) return null;
+  // Backward compatible: with no hash the card only renders for non-success
+  // (pending/error) lifecycle states.
+  if (!hash && variant === 'success') return null;
 
   return (
-    <div className="tx-status" role="status" aria-live="polite">
+    <div
+      className={`tx-status tx-status--${variant}`}
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+    >
       <div className="tx-status-header">
         <span className="tx-status-icon" aria-hidden="true">
-          ✓
+          {VARIANT_ICON[variant] ?? VARIANT_ICON.success}
         </span>
-        <span className="tx-status-label">{status}</span>
+        <span className="tx-status-label">{label}</span>
       </div>
 
-      <div className="tx-status-body">
-        <div className="tx-hash-container">
-          <span className="tx-hash-label">Transaction Hash</span>
-          <div className="tx-hash-row">
-            <code className="tx-hash-value" title={hash}>
-              {shortenedHash}
-            </code>
-            <button
-              type="button"
-              className={`tx-copy-btn ${copied ? 'copied' : ''}`}
-              onClick={handleCopy}
-              aria-label={copied ? 'Copied to clipboard' : 'Copy transaction hash'}
-            >
-              {copied ? (
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-              ) : (
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                </svg>
-              )}
-            </button>
+      {message && <p className="tx-status-message">{message}</p>}
+
+      {hash && (
+        <div className="tx-status-body">
+          <div className="tx-hash-container">
+            <span className="tx-hash-label">Transaction Hash</span>
+            <div className="tx-hash-row">
+              <code className="tx-hash-value" title={hash}>
+                {shortenedHash}
+              </code>
+              <button
+                type="button"
+                className={`tx-copy-btn ${copied ? 'copied' : ''}`}
+                onClick={handleCopy}
+                aria-label={copied ? 'Copied to clipboard' : 'Copy transaction hash'}
+              >
+                {copied ? (
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                ) : (
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
-        </div>
 
-        <a
-          href={explorerUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="tx-explorer-link"
-        >
-          View on Stellar Expert
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tx-explorer-link"
           >
-            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-            <polyline points="15 3 21 3 21 9" />
-            <line x1="10" y1="14" x2="21" y2="3" />
-          </svg>
-        </a>
-      </div>
+            View on Stellar Expert
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useOptimisticAction.js
+++ b/frontend/src/hooks/useOptimisticAction.js
@@ -1,0 +1,93 @@
+import { useCallback, useRef, useState } from 'react';
+import { mapError as defaultMapError } from '../lib/errorMapping';
+
+/**
+ * useOptimisticAction — drives an "optimistic UI" lifecycle for an async,
+ * chain-backed action (register, claim, …):
+ *
+ *   submit → apply optimistic state immediately
+ *          → await the real action
+ *          → success: reconcile with chain truth
+ *          → failure: roll back the optimistic state + surface a mapped error
+ *
+ * It also guards against double-submit (a second `run` while one is in flight
+ * is ignored) so a double-click can't fire two transactions.
+ *
+ * State machine: 'idle' → 'pending' → 'success' | 'error'.
+ *
+ * @param {{ mapError?: (error: unknown) => object }} [options]
+ *   `mapError` converts a thrown error into the structured shape from
+ *   lib/errorMapping (overridable for testing). Defaults to the shared mapper.
+ */
+export function useOptimisticAction({ mapError = defaultMapError } = {}) {
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState(null);
+  // Synchronous in-flight latch: state updates are async, so a ref is what
+  // actually prevents a same-tick double-submit.
+  const inFlight = useRef(false);
+
+  /**
+   * @template T
+   * @param {() => Promise<T>} action  The real async action (e.g. submit tx).
+   * @param {{
+   *   optimistic?: () => void,   // apply expected state right away
+   *   rollback?: () => void,     // undo the optimistic state on failure
+   *   reconcile?: (result: T) => void, // align local state with chain truth
+   * }} [handlers]
+   * @returns {Promise<{ ok: boolean, skipped?: boolean, result?: T, error?: object }>}
+   */
+  const run = useCallback(
+    async (action, { optimistic, rollback, reconcile } = {}) => {
+      if (inFlight.current) {
+        return { ok: false, skipped: true };
+      }
+      inFlight.current = true;
+      setStatus('pending');
+      setError(null);
+
+      let appliedOptimistic = false;
+      try {
+        if (optimistic) {
+          optimistic();
+          appliedOptimistic = true;
+        }
+
+        const result = await action();
+
+        reconcile?.(result);
+        setStatus('success');
+        return { ok: true, result };
+      } catch (err) {
+        // Only undo what we actually applied — keeps rollback idempotent and
+        // correct even if the failure happened before the optimistic step.
+        if (appliedOptimistic) {
+          rollback?.();
+        }
+        const mapped = mapError(err);
+        setError(mapped);
+        setStatus('error');
+        return { ok: false, error: mapped };
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [mapError],
+  );
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setError(null);
+  }, []);
+
+  return {
+    status,
+    error,
+    isPending: status === 'pending',
+    isSuccess: status === 'success',
+    isError: status === 'error',
+    run,
+    reset,
+  };
+}
+
+export default useOptimisticAction;

--- a/frontend/src/hooks/useOptimisticAction.test.jsx
+++ b/frontend/src/hooks/useOptimisticAction.test.jsx
@@ -1,0 +1,167 @@
+// Tests for the optimistic-action lifecycle hook and the error classification
+// that powers register/claim's rollback messaging (#627).
+//
+// Located under src/hooks/ to match the vitest `include` glob
+// (src/hooks/**/*.test.{js,jsx}) so it runs in CI.
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useOptimisticAction } from './useOptimisticAction';
+import { classifyError, mapError, ERROR_CLASS } from '../lib/errorMapping';
+
+describe('useOptimisticAction', () => {
+  it('applies the optimistic update, then reconciles on success', async () => {
+    const { result } = renderHook(() => useOptimisticAction());
+    const optimistic = vi.fn();
+    const reconcile = vi.fn();
+    const rollback = vi.fn();
+
+    await act(async () => {
+      const outcome = await result.current.run(async () => 'BALANCE_42', {
+        optimistic,
+        rollback,
+        reconcile,
+      });
+      expect(outcome).toEqual({ ok: true, result: 'BALANCE_42' });
+    });
+
+    expect(optimistic).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith('BALANCE_42');
+    expect(rollback).not.toHaveBeenCalled();
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('rolls back and surfaces a mapped error on failure', async () => {
+    const { result } = renderHook(() => useOptimisticAction());
+    const optimistic = vi.fn();
+    const rollback = vi.fn();
+    const reconcile = vi.fn();
+
+    await act(async () => {
+      const outcome = await result.current.run(
+        async () => {
+          throw new Error('Error(Contract, #103)');
+        },
+        { optimistic, rollback, reconcile },
+      );
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error.class).toBe(ERROR_CLASS.CONTRACT);
+    });
+
+    expect(optimistic).toHaveBeenCalledTimes(1);
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error.code).toBe(103);
+    expect(result.current.error.message).toMatch(/not active/i);
+  });
+
+  it('does not roll back if the failure happens before the optimistic step', async () => {
+    const { result } = renderHook(() => useOptimisticAction());
+    const rollback = vi.fn();
+
+    await act(async () => {
+      await result.current.run(
+        async () => {
+          throw new Error('boom');
+        },
+        {
+          optimistic: () => {
+            throw new Error('optimistic failed');
+          },
+          rollback,
+        },
+      );
+    });
+
+    // The optimistic callback threw, so nothing was applied → nothing to undo.
+    expect(rollback).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('ignores a second submit while one is in flight (double-submit guard)', async () => {
+    const { result } = renderHook(() => useOptimisticAction());
+
+    let resolveFirst;
+    const action = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    let firstPromise;
+    act(() => {
+      firstPromise = result.current.run(action);
+    });
+    expect(result.current.isPending).toBe(true);
+
+    // Second call while pending must be skipped and must not invoke the action.
+    await act(async () => {
+      const second = await result.current.run(action);
+      expect(second).toEqual({ ok: false, skipped: true });
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst('ok');
+      await firstPromise;
+    });
+    expect(result.current.isSuccess).toBe(true);
+
+    // After settling, a fresh submit is allowed again.
+    await act(async () => {
+      await result.current.run(async () => 'again');
+    });
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset returns the hook to its idle state', async () => {
+    const { result } = renderHook(() => useOptimisticAction());
+
+    await act(async () => {
+      await result.current.run(async () => {
+        throw new Error('nope');
+      });
+    });
+    expect(result.current.isError).toBe(true);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe('error classification (distinct messaging)', () => {
+  it('classifies a contract revert by its decoded code', () => {
+    expect(classifyError(new Error('HostError: Error(Contract, #102)'))).toBe(ERROR_CLASS.CONTRACT);
+    const mapped = mapError(new Error('Error(Contract, #102)'));
+    expect(mapped.code).toBe(102);
+    expect(mapped.message).toMatch(/participant limit/i);
+  });
+
+  it('classifies a wallet rejection separately from a system failure', () => {
+    expect(classifyError(new Error('User declined the transaction in Freighter'))).toBe(
+      ERROR_CLASS.WALLET,
+    );
+    expect(mapError(new Error('User rejected request')).message).toMatch(/cancelled/i);
+  });
+
+  it('distinguishes network failures from contract reverts', () => {
+    expect(classifyError(new TypeError('Failed to fetch'))).toBe(ERROR_CLASS.NETWORK);
+    const net = mapError(new Error('network timeout while submitting'));
+    expect(net.class).toBe(ERROR_CLASS.NETWORK);
+    expect(net.retryable).toBe(true);
+    expect(net.message).toMatch(/not submitted/i);
+  });
+
+  it('classifies RPC/Horizon outages as their own class', () => {
+    const rpc = mapError(new Error('Soroban RPC simulate failed: 503 service unavailable'));
+    expect(rpc.class).toBe(ERROR_CLASS.RPC);
+    expect(rpc.retryable).toBe(true);
+    expect(rpc.message).toMatch(/temporarily unavailable/i);
+  });
+});

--- a/frontend/src/lib/errorMapping.js
+++ b/frontend/src/lib/errorMapping.js
@@ -32,6 +32,128 @@ export const ERROR_MESSAGES = {
 };
 
 /**
+ * Coarse error classes used to give register/claim failures distinct messaging
+ * and to decide how the optimistic UI should recover (see useOptimisticAction).
+ *
+ * - `contract`   — the contract reverted with a known/mapped error code.
+ * - `wallet`     — the user rejected/closed the signing prompt.
+ * - `network`    — request never reached the chain (offline, DNS, timeout).
+ * - `rpc`        — Soroban RPC / Horizon reachable but failing (5xx, simulate).
+ * - `validation` — client-side input problem.
+ * - `unknown`    — anything we can't confidently bucket.
+ */
+export const ERROR_CLASS = {
+  CONTRACT: 'contract',
+  WALLET: 'wallet',
+  NETWORK: 'network',
+  RPC: 'rpc',
+  VALIDATION: 'validation',
+  UNKNOWN: 'unknown',
+};
+
+/** Per-class fallback copy used when no specific contract message applies. */
+const CLASS_MESSAGES = {
+  [ERROR_CLASS.WALLET]: 'Signing was cancelled in your wallet. Nothing was submitted.',
+  [ERROR_CLASS.NETWORK]:
+    'Network problem reaching the blockchain — your action was not submitted. Check your connection and try again.',
+  [ERROR_CLASS.RPC]:
+    'The Soroban network is temporarily unavailable. Your action was not applied; please try again in a moment.',
+  [ERROR_CLASS.VALIDATION]: 'Please check your input and try again.',
+  [ERROR_CLASS.UNKNOWN]: 'An unexpected error occurred. Your action was not applied.',
+};
+
+/**
+ * Extract a numeric contract/HTTP error code from any error shape.
+ * @param {Error|number|string|object} error
+ * @returns {number|null}
+ */
+export function extractErrorCode(error) {
+  if (error === null || error === undefined) return null;
+  if (typeof error === 'number') return Number.isFinite(error) ? error : null;
+  if (typeof error === 'string') {
+    const fromString = error.match(/(?:Error\(Contract,\s*#|contract.*?#|code[:\s]+)(\d+)/i);
+    return fromString ? Number(fromString[1]) : null;
+  }
+  if (typeof error.code === 'number') return error.code;
+  if (typeof error.status === 'number') return error.status;
+  const text = error.message || error.toString?.() || '';
+  const match = text.match(/(?:Error\(Contract,\s*#|contract.*?#|code[:\s]+)(\d+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Classify an error so the UI can show class-specific messaging and decide
+ * recovery. Order matters: a contract revert with a real code is the most
+ * specific signal, a rejected wallet prompt next, then transport problems.
+ * @param {Error|number|string|object} error
+ * @returns {string} one of ERROR_CLASS
+ */
+export function classifyError(error) {
+  if (!error) return ERROR_CLASS.UNKNOWN;
+
+  const code = extractErrorCode(error);
+  const text = (
+    typeof error === 'string' ? error : error.message || error.toString?.() || ''
+  ).toLowerCase();
+
+  // A decoded contract revert (e.g. `Error(Contract, #103)`) is unambiguous.
+  if (/error\(contract|contract.*?#\d+/i.test(text)) return ERROR_CLASS.CONTRACT;
+
+  // User-driven wallet rejections must not look like a system failure.
+  if (
+    /user (rejected|declined)|reject|declin|denied|cancel|freighter|wallet|not allowed/.test(text)
+  )
+    return ERROR_CLASS.WALLET;
+
+  // Transport: never reached the chain.
+  if (
+    /failed to fetch|networkerror|offline|timeout|timed out|enotfound|econnrefused|etimedout|dns/.test(
+      text,
+    )
+  )
+    return ERROR_CLASS.NETWORK;
+
+  // RPC/Horizon reachable but erroring.
+  if (/rpc|simulat|soroban|horizon|gateway|bad gateway|service unavailable|50[023]/.test(text))
+    return ERROR_CLASS.RPC;
+
+  if (/invalid|required|must be|too large|not a number/.test(text)) return ERROR_CLASS.VALIDATION;
+
+  // A bare contract code with no transport hints is still a contract error.
+  if (typeof code === 'number' && code >= 1 && code <= 199) return ERROR_CLASS.CONTRACT;
+
+  return ERROR_CLASS.UNKNOWN;
+}
+
+/**
+ * Map any error to a structured, user-facing shape for the optimistic UI.
+ * @param {Error|number|string|object} error
+ * @returns {{ class: string, code: number|null, message: string, recovery: string|null, retryable: boolean }}
+ */
+export function mapError(error) {
+  const errorClass = classifyError(error);
+  const code = extractErrorCode(error);
+
+  // Contract reverts get the precise per-code copy; everything else uses the
+  // class-level message so network/RPC failures read differently from reverts.
+  const message =
+    errorClass === ERROR_CLASS.CONTRACT && code && ERROR_MESSAGES[code]
+      ? getErrorMessage(code)
+      : CLASS_MESSAGES[errorClass] || getErrorMessage(error);
+
+  return {
+    class: errorClass,
+    code: code ?? null,
+    message,
+    recovery: code ? getRecoverySuggestion(code) : null,
+    retryable:
+      errorClass === ERROR_CLASS.NETWORK ||
+      errorClass === ERROR_CLASS.RPC ||
+      (code ? isRetryableError(code) : false),
+  };
+}
+
+/**
  * Get user-friendly error message from error object or code
  * @param {Error|number|string} error - Error object, code, or status
  * @returns {string} User-friendly error message


### PR DESCRIPTION
## Summary

Adds **optimistic UI** to the register and claim flows (#627): the expected state is reflected the instant the user submits, then **reconciled with chain truth on success** or **rolled back on failure** with a clear, class-specific error. Successful actions feel instant; failed actions recover cleanly.

## What changed

### `useOptimisticAction` hook — `src/hooks/useOptimisticAction.js`
A small, reusable lifecycle engine: `idle → pending → success | error`.
- Applies an **optimistic update** immediately, awaits the real action, **reconciles** on success, **rolls back** on failure.
- **Double-submit guard**: a synchronous in-flight latch (ref) ignores a second `run` while one is in flight — a double-click can never fire two transactions.
- Rollback only runs if the optimistic update was actually applied (idempotent, correct even if the failure happens before the optimistic step).

### Error classification — `src/lib/errorMapping.js`
- `classifyError` / `mapError` bucket every failure into a class — `contract | wallet | network | rpc | validation | unknown` — with **distinct messaging**:
  - **network/RPC** outages → "not submitted / temporarily unavailable, try again" (retryable),
  - **contract reverts** → the precise existing per-code copy (e.g. "This campaign has reached its participant limit"),
  - **wallet rejection** → "Signing was cancelled" (not a system error).
- Directly addresses the issue's *"Network/RPC error vs contract revert → distinct messaging"* edge case.

### Components
- **`RegisterCampaign.jsx`**: participant status flips to *Registered* optimistically on submit; rolls back to the prior status on failure; shows a pending card then a confirmed/error state.
- **`ClaimRewards.jsx`**: clears the input + shows a pending indicator immediately; restores the entered amount on failure; reconciles the on-chain balance via `onClaimSuccess`.
- **`TransactionStatus.jsx`**: new `variant` of `pending | success | error` (backward compatible — default `success`), so a pending card can render before a hash exists and rolled-back errors render inline.

## Acceptance criteria
- ✅ Successful actions feel instant (optimistic state on submit).
- ✅ Failed actions roll back to the correct state with a clear, mapped error.
- ✅ Double-submit guarded; pending indicators shown.
- ✅ Distinct messaging for network/RPC vs contract revert.

## Testing
`src/hooks/useOptimisticAction.test.jsx` (under the vitest `include` glob, so it runs in CI):
- optimistic-apply then reconcile on success;
- **rollback on failure** + mapped error class/code/message;
- no rollback when the optimistic step itself throws;
- **double-submit guard** (second submit skipped, action called once);
- `reset`;
- error classification — contract vs wallet vs network vs RPC messaging.

Local: vitest (new suite) ✅, `eslint .` ✅ (0 errors), `prettier --check` ✅, `vite build` ✅.

### Note on E2E
The task list includes an E2E that forces a failure to assert rollback. The existing Playwright lifecycle suite (`tests/e2e/campaign-lifecycle.test.ts`) `test.skip`s itself when no backend is reachable, and the CI Playwright run has no backend — so a register/claim failure E2E needs the documented docker-compose environment. Rollback is therefore asserted here at the hook/integration level; the live E2E can follow in that environment.
