### PR TITLE
feat(frontend): client-side real-time updates via SSE with polling fallback (#626)

### DIFF
--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -5,7 +5,7 @@ import Header from './components/Header';
 import RegisterCampaign from './RegisterCampaign';
 import StatusBadge from './components/StatusBadge';
 import PageMeta from './components/PageMeta';
-import { useCampaignPolling } from './hooks/useCampaignPolling';
+import { useCampaignLiveUpdates } from './hooks/useCampaignLiveUpdates';
 import './CampaignDetail.css';
 
 export default function CampaignDetail({
@@ -26,7 +26,7 @@ export default function CampaignDetail({
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const { campaign, onChainState, isPolling, isPaused, lastUpdated, stateToast, error, refresh } =
-    useCampaignPolling({ campaignId: id, enabled: Boolean(id) });
+    useCampaignLiveUpdates({ campaignId: id, enabled: Boolean(id) });
 
   const [referralCount, setReferralCount] = useState(0);
   const [bonusEarned, setBonusEarned] = useState(0);

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -134,6 +134,32 @@ export function apiUrl(path) {
   return `${API_BASE_URL}${path}`;
 }
 
+/**
+ * Resolve the real-time (SSE) stream URL for a campaign, or '' when real-time
+ * is not configured — in which case consumers fall back to polling.
+ *
+ * Priority:
+ *   1. VITE_REALTIME_URL (an SSE base; the campaignId is appended when present)
+ *   2. VITE_REALTIME_ENABLED=true → derive `${API}/api/v1/campaigns/:id/events`
+ *   3. otherwise '' (real-time disabled → polling only)
+ *
+ * @param {string} [campaignId]
+ * @returns {string}
+ */
+export function getRealtimeUrl(campaignId) {
+  const base = trimTrailingSlash(import.meta.env.VITE_REALTIME_URL || '');
+  if (base) {
+    return campaignId ? `${base}/${encodeURIComponent(campaignId)}` : base;
+  }
+
+  const enabled = String(import.meta.env.VITE_REALTIME_ENABLED || '').toLowerCase() === 'true';
+  if (enabled && campaignId) {
+    return apiUrl(`/api/v1/campaigns/${encodeURIComponent(campaignId)}/events`);
+  }
+
+  return '';
+}
+
 export async function initializeRuntimeConfig(fetchImpl = globalThis.fetch) {
   if (typeof fetchImpl !== 'function') {
     return getRuntimeConfig();

--- a/frontend/src/hooks/realtimeClient.test.js
+++ b/frontend/src/hooks/realtimeClient.test.js
@@ -1,0 +1,157 @@
+// Tests for the real-time subscription client (#626): event dispatch, id
+// de-duplication, exponential-backoff reconnect, and clean teardown.
+//
+// Located under src/hooks/ to match the vitest `include` glob so it runs in CI.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRealtimeSubscription } from '../lib/realtimeClient';
+
+class MockEventSource {
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.closed = false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  // ── test helpers ──
+  open() {
+    this.onopen?.({});
+  }
+
+  message(payload, lastEventId) {
+    const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    this.onmessage?.({ data, lastEventId });
+  }
+
+  error() {
+    this.onerror?.({});
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function subscribe(overrides = {}) {
+  const events = [];
+  const statuses = [];
+  const handle = createRealtimeSubscription({
+    url: 'http://stream.local/campaigns/1',
+    EventSourceImpl: MockEventSource,
+    onEvent: (e) => events.push(e),
+    onStatusChange: (s) => statuses.push(s),
+    baseDelayMs: 100,
+    maxDelayMs: 1000,
+    ...overrides,
+  });
+  return { handle, events, statuses };
+}
+
+describe('createRealtimeSubscription', () => {
+  it('connects, reports open, and dispatches parsed events', () => {
+    const { events, statuses } = subscribe();
+    const es = MockEventSource.instances[0];
+
+    expect(statuses[0]).toBe('connecting');
+    es.open();
+    expect(statuses).toContain('open');
+
+    es.message({ id: 'e1', type: 'campaign.updated', data: { participantCount: 7 } });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      id: 'e1',
+      type: 'campaign.updated',
+      data: { participantCount: 7 },
+    });
+  });
+
+  it('de-duplicates events by id (idempotent against replays)', () => {
+    const { events } = subscribe();
+    const es = MockEventSource.instances[0];
+    es.open();
+
+    es.message({ id: 'dup', data: { participantCount: 1 } });
+    es.message({ id: 'dup', data: { participantCount: 1 } }); // replay
+    es.message({ id: 'next', data: { participantCount: 2 } });
+
+    expect(events.map((e) => e.id)).toEqual(['dup', 'next']);
+  });
+
+  it('ignores non-JSON payloads (keep-alives/comments)', () => {
+    const { events } = subscribe();
+    const es = MockEventSource.instances[0];
+    es.open();
+    es.message(':keep-alive');
+    expect(events).toHaveLength(0);
+  });
+
+  it('reconnects with capped exponential backoff after an error', () => {
+    vi.useFakeTimers();
+    const { statuses } = subscribe();
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    // First drop → reconnect after baseDelay (100ms).
+    MockEventSource.instances[0].error();
+    expect(statuses).toContain('reconnecting');
+    vi.advanceTimersByTime(99);
+    expect(MockEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    // Second drop → delay doubles to 200ms.
+    MockEventSource.instances[1].error();
+    vi.advanceTimersByTime(199);
+    expect(MockEventSource.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it('resets the backoff after a successful reconnect', () => {
+    vi.useFakeTimers();
+    subscribe();
+    MockEventSource.instances[0].error();
+    vi.advanceTimersByTime(100);
+    expect(MockEventSource.instances).toHaveLength(2);
+    MockEventSource.instances[1].open(); // success resets attempts
+
+    MockEventSource.instances[1].error();
+    // Back to the base delay, not the doubled one.
+    vi.advanceTimersByTime(100);
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it('close() tears down the source and stops reconnecting', () => {
+    vi.useFakeTimers();
+    const { handle, statuses } = subscribe();
+    const es = MockEventSource.instances[0];
+
+    handle.close();
+    expect(es.closed).toBe(true);
+    expect(statuses[statuses.length - 1]).toBe('closed');
+
+    // A late error after close must not schedule a reconnect.
+    es.error();
+    vi.advanceTimersByTime(5000);
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it('throws when constructed without a url or EventSource impl', () => {
+    expect(() => createRealtimeSubscription({ EventSourceImpl: MockEventSource })).toThrow(/url/);
+    expect(() => createRealtimeSubscription({ url: 'x', EventSourceImpl: undefined })).toThrow(
+      /EventSource/,
+    );
+  });
+});

--- a/frontend/src/hooks/useCampaignLiveUpdates.js
+++ b/frontend/src/hooks/useCampaignLiveUpdates.js
@@ -1,0 +1,92 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCampaignPolling } from './useCampaignPolling';
+import { useRealtimeSubscription } from './useRealtimeSubscription';
+import { getRealtimeUrl } from '../config';
+
+/**
+ * useCampaignLiveUpdates — augments useCampaignPolling with a real-time SSE
+ * stream (#626). Behaviour:
+ *
+ *   - subscribes to the campaign's SSE stream when one is configured;
+ *   - while the stream is live, interval polling is paused (no wasteful
+ *     requests) and live events drive updates;
+ *   - each event merges any carried campaign fields into the cache (so
+ *     participant counts / claims update live) and then triggers a refresh to
+ *     reconcile against the authoritative API + on-chain state — idempotent, so
+ *     duplicate/out-of-order events are harmless;
+ *   - on disconnect, polling resumes automatically as a fallback; if no stream
+ *     is configured it is pure polling, exactly as before.
+ *
+ * Returns the same shape as useCampaignPolling plus `{ isLive, connectionStatus,
+ * realtimeEnabled, liveUpdatedAt }`, so it is a drop-in replacement.
+ *
+ * @param {{
+ *   campaignId?: string,
+ *   contractId?: string,
+ *   enabled?: boolean,
+ *   realtimeUrl?: string,
+ *   eventSourceImpl?: typeof EventSource,
+ * }} options
+ */
+export function useCampaignLiveUpdates({
+  campaignId,
+  contractId,
+  enabled = true,
+  realtimeUrl,
+  eventSourceImpl,
+} = {}) {
+  const url = realtimeUrl ?? getRealtimeUrl(campaignId);
+  const [liveUpdatedAt, setLiveUpdatedAt] = useState(null);
+
+  // Filled in after useCampaignPolling runs; read lazily inside handleEvent so
+  // the event handler identity stays stable (no connection churn).
+  const refreshRef = useRef(null);
+  const setCampaignRef = useRef(null);
+
+  const handleEvent = useCallback((event) => {
+    setLiveUpdatedAt(new Date());
+
+    const data = event?.data;
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      setCampaignRef.current?.((prev) => (prev ? { ...prev, ...data } : prev));
+    }
+
+    // Reconcile with the source of truth (API + chain). Idempotent.
+    refreshRef.current?.();
+  }, []);
+
+  const { status, isLive } = useRealtimeSubscription({
+    url,
+    enabled: enabled && Boolean(url),
+    onEvent: handleEvent,
+    EventSourceImpl: eventSourceImpl,
+  });
+
+  // Poll only while NOT live: covers the initial baseline load and acts as the
+  // fallback whenever the stream is down.
+  const poll = useCampaignPolling({
+    campaignId,
+    contractId,
+    enabled: enabled && !isLive,
+  });
+
+  refreshRef.current = poll.refresh;
+  setCampaignRef.current = poll.setCampaign;
+
+  const lastUpdated = useMemo(() => {
+    const liveMs = liveUpdatedAt?.getTime?.() ?? 0;
+    const pollMs = poll.lastUpdated?.getTime?.() ?? 0;
+    return pollMs >= liveMs ? poll.lastUpdated : liveUpdatedAt;
+  }, [liveUpdatedAt, poll.lastUpdated]);
+
+  return {
+    ...poll,
+    lastUpdated,
+    isLive,
+    connectionStatus: status,
+    realtimeEnabled: Boolean(url),
+    liveUpdatedAt,
+  };
+}
+
+export default useCampaignLiveUpdates;

--- a/frontend/src/hooks/useCampaignLiveUpdates.test.jsx
+++ b/frontend/src/hooks/useCampaignLiveUpdates.test.jsx
@@ -1,0 +1,110 @@
+// Tests for the composed live-updates hook (#626): pure-polling fallback when
+// no stream is configured, and going live + reconciling on events.
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCampaignLiveUpdates } from './useCampaignLiveUpdates';
+
+vi.mock('../config', () => ({
+  apiUrl: (path) => `http://test.local${path}`,
+  getPollIntervalMs: () => 1000,
+  getRealtimeUrl: () => '',
+}));
+
+vi.mock('../stellar', () => ({
+  fetchCampaignOnChainState: vi.fn(async () => ({
+    isActive: true,
+    isWithinWindow: true,
+    participantCount: 3,
+  })),
+}));
+
+class MockEventSource {
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.closed = false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  open() {
+    this.onopen?.({});
+  }
+
+  message(payload) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('fetch', vi.fn());
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('useCampaignLiveUpdates', () => {
+  it('falls back to pure polling when no stream is configured', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: '1', name: 'Polled', contractId: 'C1' }),
+    });
+
+    const { result } = renderHook(() => useCampaignLiveUpdates({ campaignId: '1' }));
+
+    await waitFor(() => expect(result.current.campaign?.name).toBe('Polled'));
+    expect(result.current.realtimeEnabled).toBe(false);
+    expect(result.current.isLive).toBe(false);
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('goes live on connect and reconciles on each event', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: '1', name: 'Live', contractId: 'C1', participantCount: 1 }),
+    });
+
+    const { result } = renderHook(() =>
+      useCampaignLiveUpdates({
+        campaignId: '1',
+        realtimeUrl: 'http://stream.local/1',
+        eventSourceImpl: MockEventSource,
+      }),
+    );
+
+    // Baseline load happens before the stream is live.
+    await waitFor(() => expect(result.current.campaign?.name).toBe('Live'));
+    expect(result.current.realtimeEnabled).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    // Stream opens → live.
+    act(() => MockEventSource.instances[0].open());
+    await waitFor(() => expect(result.current.isLive).toBe(true));
+    expect(result.current.connectionStatus).toBe('open');
+
+    // A live event triggers a reconcile (refresh) against the source of truth.
+    const callsBefore = fetch.mock.calls.length;
+    await act(async () => {
+      MockEventSource.instances[0].message({ id: 'e1', data: { participantCount: 9 } });
+    });
+    await waitFor(() => expect(fetch.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(result.current.liveUpdatedAt).toBeInstanceOf(Date);
+  });
+});

--- a/frontend/src/hooks/useRealtimeSubscription.js
+++ b/frontend/src/hooks/useRealtimeSubscription.js
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+import { createRealtimeSubscription } from '../lib/realtimeClient';
+
+/**
+ * useRealtimeSubscription — React wrapper around createRealtimeSubscription.
+ *
+ * Opens an SSE subscription to `url` while `enabled`, forwarding parsed events
+ * to `onEvent` and exposing the connection status. The subscription is torn
+ * down (and reopened) when `url`/`enabled` change or on unmount.
+ *
+ * `onEvent` is read through a ref so that passing a fresh callback each render
+ * does NOT churn the connection.
+ *
+ * @param {{
+ *   url?: string,
+ *   enabled?: boolean,
+ *   onEvent?: (event: { id: string|null, type: string, data: unknown }) => void,
+ *   EventSourceImpl?: typeof EventSource,
+ *   baseDelayMs?: number,
+ *   maxDelayMs?: number,
+ * }} options
+ * @returns {{ status: string, isLive: boolean }}
+ */
+export function useRealtimeSubscription({
+  url,
+  enabled = true,
+  onEvent,
+  EventSourceImpl,
+  baseDelayMs,
+  maxDelayMs,
+} = {}) {
+  const [status, setStatus] = useState('idle');
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!enabled || !url) {
+      setStatus('idle');
+      return undefined;
+    }
+
+    const ImplToUse =
+      EventSourceImpl ?? (typeof globalThis !== 'undefined' ? globalThis.EventSource : undefined);
+    if (typeof ImplToUse !== 'function') {
+      // No SSE support (e.g. SSR or old browser) → caller keeps polling.
+      setStatus('unsupported');
+      return undefined;
+    }
+
+    const subscription = createRealtimeSubscription({
+      url,
+      EventSourceImpl: ImplToUse,
+      baseDelayMs,
+      maxDelayMs,
+      onStatusChange: setStatus,
+      onEvent: (event) => onEventRef.current?.(event),
+    });
+
+    return () => subscription.close();
+  }, [url, enabled, EventSourceImpl, baseDelayMs, maxDelayMs]);
+
+  return { status, isLive: status === 'open' };
+}
+
+export default useRealtimeSubscription;

--- a/frontend/src/hooks/useRealtimeSubscription.test.jsx
+++ b/frontend/src/hooks/useRealtimeSubscription.test.jsx
@@ -1,0 +1,96 @@
+// Tests for the useRealtimeSubscription React wrapper (#626).
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useRealtimeSubscription } from './useRealtimeSubscription';
+
+class MockEventSource {
+  static instances = [];
+
+  constructor(url) {
+    this.url = url;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.closed = false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  open() {
+    this.onopen?.({});
+  }
+
+  message(payload) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+});
+
+describe('useRealtimeSubscription', () => {
+  it('stays idle when disabled or given no url', () => {
+    const { result } = renderHook(() =>
+      useRealtimeSubscription({ url: '', enabled: true, EventSourceImpl: MockEventSource }),
+    );
+    expect(result.current.status).toBe('idle');
+    expect(result.current.isLive).toBe(false);
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('connects when enabled and reports live on open', () => {
+    const { result } = renderHook(() =>
+      useRealtimeSubscription({
+        url: 'http://stream.local/1',
+        enabled: true,
+        EventSourceImpl: MockEventSource,
+      }),
+    );
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(result.current.status).toBe('connecting');
+
+    act(() => MockEventSource.instances[0].open());
+    expect(result.current.isLive).toBe(true);
+    expect(result.current.status).toBe('open');
+  });
+
+  it('forwards parsed events to onEvent', () => {
+    const received = [];
+    renderHook(() =>
+      useRealtimeSubscription({
+        url: 'http://stream.local/1',
+        enabled: true,
+        EventSourceImpl: MockEventSource,
+        onEvent: (e) => received.push(e),
+      }),
+    );
+
+    act(() => {
+      MockEventSource.instances[0].open();
+      MockEventSource.instances[0].message({ id: 'a', data: { participantCount: 5 } });
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].data).toEqual({ participantCount: 5 });
+  });
+
+  it('closes the subscription on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useRealtimeSubscription({
+        url: 'http://stream.local/1',
+        enabled: true,
+        EventSourceImpl: MockEventSource,
+      }),
+    );
+    const es = MockEventSource.instances[0];
+    expect(es.closed).toBe(false);
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+});

--- a/frontend/src/lib/realtimeClient.js
+++ b/frontend/src/lib/realtimeClient.js
@@ -1,0 +1,151 @@
+// Real-time subscription client (#626).
+//
+// Wraps an SSE EventSource with the behaviour the UI needs to consume a live
+// campaign/participant stream instead of polling:
+//
+//   - parses JSON messages and forwards them as { id, type, data }
+//   - de-duplicates by event id (idempotent against out-of-order/replayed
+//     events) over a bounded window
+//   - on connection drop, reconnects with capped exponential backoff (we drive
+//     this explicitly rather than relying on EventSource's built-in retry so
+//     callers can fall back to polling while disconnected)
+//   - reports lifecycle via onStatusChange: connecting → open →
+//     reconnecting → (open | failed | closed)
+//
+// Pure and dependency-free: EventSource is injectable so it can be unit-tested
+// with a fake, and reconnection uses the global timers (controllable with fake
+// timers in tests).
+
+const DEFAULT_BASE_DELAY_MS = 1_000;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+const DEFAULT_DEDUP_WINDOW = 500;
+
+/**
+ * @param {{
+ *   url: string,
+ *   onEvent?: (event: { id: string|null, type: string, data: unknown }) => void,
+ *   onStatusChange?: (status: string) => void,
+ *   EventSourceImpl?: typeof EventSource,
+ *   baseDelayMs?: number,
+ *   maxDelayMs?: number,
+ *   maxReconnectAttempts?: number,
+ *   dedupWindow?: number,
+ * }} options
+ * @returns {{ close: () => void, getReconnectAttempts: () => number }}
+ */
+export function createRealtimeSubscription({
+  url,
+  onEvent,
+  onStatusChange,
+  EventSourceImpl = typeof globalThis !== 'undefined' ? globalThis.EventSource : undefined,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  maxReconnectAttempts = Infinity,
+  dedupWindow = DEFAULT_DEDUP_WINDOW,
+} = {}) {
+  if (!url) {
+    throw new Error('createRealtimeSubscription requires a url');
+  }
+  if (typeof EventSourceImpl !== 'function') {
+    throw new Error('EventSource is not available in this environment');
+  }
+
+  let source = null;
+  let closed = false;
+  let attempts = 0;
+  let reconnectTimer = null;
+
+  const seenIds = [];
+  const seenSet = new Set();
+
+  const setStatus = (status) => {
+    onStatusChange?.(status);
+  };
+
+  // Returns true if this id was already seen (i.e. a duplicate to drop).
+  const isDuplicate = (id) => {
+    if (id === undefined || id === null || id === '') return false;
+    if (seenSet.has(id)) return true;
+    seenSet.add(id);
+    seenIds.push(id);
+    if (seenIds.length > dedupWindow) {
+      seenSet.delete(seenIds.shift());
+    }
+    return false;
+  };
+
+  const handleMessage = (evt) => {
+    let parsed;
+    try {
+      parsed = JSON.parse(evt.data);
+    } catch {
+      return; // ignore non-JSON keep-alives / comments
+    }
+    const id = parsed.id ?? evt.lastEventId ?? null;
+    if (isDuplicate(id)) return;
+    onEvent?.({
+      id,
+      type: parsed.type ?? evt.type ?? 'message',
+      data: parsed.data ?? parsed,
+    });
+  };
+
+  const scheduleReconnect = () => {
+    if (closed) return;
+    if (attempts >= maxReconnectAttempts) {
+      setStatus('failed');
+      return;
+    }
+    const delay = Math.min(maxDelayMs, baseDelayMs * 2 ** attempts);
+    attempts += 1;
+    setStatus('reconnecting');
+    reconnectTimer = setTimeout(connect, delay);
+  };
+
+  function connect() {
+    if (closed) return;
+    setStatus(attempts === 0 ? 'connecting' : 'reconnecting');
+    source = new EventSourceImpl(url);
+    source.onopen = () => {
+      attempts = 0;
+      setStatus('open');
+    };
+    source.onmessage = handleMessage;
+    source.onerror = () => {
+      // Take control of reconnection ourselves: close the failed source and
+      // back off, so consumers can poll while we're disconnected.
+      try {
+        source?.close();
+      } catch {
+        /* noop */
+      }
+      source = null;
+      scheduleReconnect();
+    };
+  }
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    try {
+      source?.close();
+    } catch {
+      /* noop */
+    }
+    source = null;
+    setStatus('closed');
+  };
+
+  connect();
+
+  return {
+    close,
+    getReconnectAttempts: () => attempts,
+  };
+}
+
+export default createRealtimeSubscription;


### PR DESCRIPTION
## Summary

Consumes a live **SSE** stream client-side so campaign/participant state updates without manual refresh, with **reconnect/backoff**, **event de-duplication**, **cache reconciliation**, and an automatic **fall back to polling** on disconnect (#626). With no stream configured it behaves exactly like today's polling — so this is safe to merge ahead of the backend stream (WS #456 / Horizon SSE #468).

## What changed

### `src/lib/realtimeClient.js` — pure SSE subscription client
- Parses JSON messages into `{ id, type, data }`.
- **De-duplicates by event id** over a bounded window → idempotent against replays / out-of-order delivery.
- **Capped exponential-backoff reconnect**, driven explicitly (not EventSource's built-in retry) so the UI can poll while disconnected; backoff resets on a successful reconnect.
- Lifecycle via `onStatusChange`: `connecting → open → reconnecting → (open | failed | closed)`. `EventSource` is injectable (unit-tested with a fake).

### `src/hooks/useRealtimeSubscription.js`
React wrapper that opens/closes the subscription for a `url` while `enabled`, exposes `{ status, isLive }`, and reads `onEvent` via a ref so re-renders don't churn the connection.

### `src/hooks/useCampaignLiveUpdates.js` — drop-in augmentation of `useCampaignPolling`
- While the stream is **live**, interval polling is **paused** (no wasteful requests).
- Each event **merges** carried campaign fields into the cache (participant counts / claims update live) then triggers a **refresh to reconcile** with the authoritative API + on-chain state — idempotent, so duplicate/out-of-order events are harmless.
- On **disconnect**, polling **resumes** as fallback. With no stream configured → pure polling. Returns the same shape as `useCampaignPolling` plus `{ isLive, connectionStatus, realtimeEnabled, liveUpdatedAt }`.
- **`useCampaignPolling` is left untouched** (its tests stay green); the new hook composes it.

### `src/config.js` + `CampaignDetail.jsx`
- `getRealtimeUrl(campaignId)`: `VITE_REALTIME_URL`, or derive the SSE path when `VITE_REALTIME_ENABLED=true`, else `''` (disabled → polling).
- `CampaignDetail` switched to `useCampaignLiveUpdates` (identical behaviour until a stream is configured).

## Acceptance criteria
- ✅ Participant counts/claims update live without manual refresh (when a stream is configured).
- ✅ Falls back to polling on disconnect / when no stream is configured.
- ✅ Reconnects with exponential backoff; out-of-order/duplicate events handled idempotently.

## Testing
New suites under `src/hooks/` (the vitest `include`, so they run in CI):
- **`realtimeClient.test.js`** — connect + dispatch, id de-dup, exponential-backoff reconnect, backoff reset on success, `close()` teardown, constructor guards.
- **`useRealtimeSubscription.test.jsx`** — idle when disabled, connect + live on open, event forwarding, close on unmount.
- **`useCampaignLiveUpdates.test.jsx`** — pure-polling fallback, go-live on connect, reconcile on event.

Local: vitest (new suites) ✅, `eslint .` ✅ (0 errors), `prettier --check` ✅, `vite build` ✅.

### Note on E2E
The task list includes an E2E observing a live update. The CI Playwright run has no backend (the lifecycle suite `test.skip`s itself), and there's no SSE endpoint deployed yet, so a live-update E2E needs the docker-compose environment + the backend stream. Live behaviour is therefore covered here at the client/hook level; the E2E can follow once the stream endpoint lands.
