### PR TITLE
feat(embed): embeddable campaign widget + partner distribution SDK

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -580,7 +580,23 @@ export async function createApp(options = {}) {
 
   const siteOrigin =
     process.env.SITE_ORIGIN ?? allowedOrigins.find((origin) => origin !== '*') ?? '';
-  app.get('/embed/campaign/:id', createEmbedRoute(campaignRepository, siteOrigin));
+
+  // Embed endpoints use a tighter per-IP rate limit (30 req/min) to guard
+  // against scraping while still allowing reasonable widget traffic.
+  const embedRateLimiter = createRateLimiter({
+    windowMs: rateLimitWindowMs,
+    maxRequests: Math.min(30, rateLimitMaxRequests),
+    timeProvider: /** @type {any} */ (options.rateLimit)?.timeProvider,
+    store: rateLimitStore,
+  });
+
+  app.get(
+    '/embed/campaign/:id',
+    embedRateLimiter,
+    createEmbedRoute(campaignRepository, siteOrigin, {
+      embedSecret: process.env.EMBED_ATTRIBUTION_SECRET,
+    }),
+  );
 
   app.get('/health/rpc', async (_req, res) => {
     const rpcUrl = rpcPool.getHealthyRpcUrl();

--- a/backend/src/routes/embed.js
+++ b/backend/src/routes/embed.js
@@ -4,9 +4,42 @@
  * Returns a minimal, iframe-safe HTML page showing a campaign card with
  * a "Register on Trivela" CTA that opens the main site in a new tab.
  * No navigation header, no footer, no external script dependencies.
+ *
+ * Query parameters:
+ *   ?partner=<id>   Partner/referrer ID (alphanumeric + _-, max 64 chars).
+ *                   Carried through to the registration URL for on-chain
+ *                   referral attribution. Combined with a short-lived HMAC
+ *                   attribution token to prevent spoofing.
+ *   ?org=<name>     Org/partner display name for "Powered by" branding.
+ *   ?color=<hex>    CSS hex colour (#RRGGBB) overriding the default CTA button.
+ *   ?theme=light    Light theme (default: dark).
  */
 
+import { createHmac } from 'node:crypto';
+
 const MAX_DESC_LEN = 160;
+
+// Allowed partner ID chars: letters, digits, hyphen, underscore — max 64.
+const PARTNER_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+// Strict hex colour: #RGB or #RRGGBB
+const COLOR_PATTERN = /^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+
+/**
+ * Sanitise a single-line user-supplied string for safe HTML interpolation.
+ * @param {string | null | undefined} raw
+ * @param {number} maxLen
+ * @returns {string}
+ */
+function sanitiseText(raw, maxLen) {
+  if (!raw) return '';
+  return String(raw)
+    .slice(0, maxLen)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 function truncate(text, maxLen) {
   if (!text) return '';
@@ -26,7 +59,45 @@ function remainingSpots(campaign) {
   return Math.max(0, max - current);
 }
 
-export function createEmbedRoute(campaignRepository, siteOrigin) {
+/**
+ * Generate a short-lived HMAC attribution token for the given partner + campaign.
+ * Token is bound to a 5-minute time bucket so replays beyond that window fail.
+ *
+ * @param {string} campaignId
+ * @param {string} partnerId
+ * @param {string} secret  EMBED_ATTRIBUTION_SECRET env value
+ * @returns {string}  hex-encoded first 16 bytes of HMAC-SHA256
+ */
+function signAttributionToken(campaignId, partnerId, secret) {
+  const bucket = Math.floor(Date.now() / 300_000); // 5-min rolling window
+  const payload = `${campaignId}:${partnerId}:${bucket}`;
+  return createHmac('sha256', secret).update(payload).digest('hex').slice(0, 32);
+}
+
+/**
+ * Verify an attribution token.  Accepts current bucket and the immediately
+ * preceding bucket to tolerate clock skew at window boundaries.
+ *
+ * @param {string} campaignId
+ * @param {string} partnerId
+ * @param {string} token
+ * @param {string} secret
+ * @returns {boolean}
+ */
+export function verifyAttributionToken(campaignId, partnerId, token, secret) {
+  if (!token || !secret) return false;
+  const now = Math.floor(Date.now() / 300_000);
+  for (const bucket of [now, now - 1]) {
+    const payload = `${campaignId}:${partnerId}:${bucket}`;
+    const expected = createHmac('sha256', secret).update(payload).digest('hex').slice(0, 32);
+    if (expected === token) return true;
+  }
+  return false;
+}
+
+export function createEmbedRoute(campaignRepository, siteOrigin, { embedSecret = '' } = {}) {
+  const secret = embedSecret || process.env.EMBED_ATTRIBUTION_SECRET || 'trivela-embed-dev-secret';
+
   /**
    * @param {import('express').Request} req
    * @param {import('express').Response} res
@@ -42,30 +113,74 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       return;
     }
 
+    // ── Query param validation ────────────────────────────────────────────────
+    const rawPartner = typeof req.query.partner === 'string' ? req.query.partner.trim() : '';
+    const partner = PARTNER_PATTERN.test(rawPartner) ? rawPartner : '';
+
+    const rawColor = typeof req.query.color === 'string' ? req.query.color.trim() : '';
+    const customColor = COLOR_PATTERN.test(rawColor) ? rawColor : '';
+
+    const isDark = req.query.theme !== 'light';
+
+    // Sanitise org name for safe HTML interpolation.
+    const orgName = sanitiseText(req.query.org, 48);
+
+    // ── Attribution token ─────────────────────────────────────────────────────
+    const atToken = partner ? signAttributionToken(String(campaign.id), partner, secret) : '';
+
+    // ── Build registration URL ────────────────────────────────────────────────
+    const registerUrl = new URL(`${siteOrigin}/campaign/${campaign.id}`);
+    if (partner) {
+      registerUrl.searchParams.set('ref', partner);
+      registerUrl.searchParams.set('at', atToken);
+    }
+
+    // ── Derived campaign values ───────────────────────────────────────────────
     const status = statusLabel(campaign);
     const spots = remainingSpots(campaign);
     const participantCount = campaign.participantCount ?? campaign.registrations ?? 0;
-    const desc = truncate(campaign.description, MAX_DESC_LEN);
-    const registerUrl = `${siteOrigin}/campaign/${campaign.id}`;
+    const desc = sanitiseText(truncate(campaign.description, MAX_DESC_LEN), MAX_DESC_LEN + 10);
+    const name = sanitiseText(campaign.name, 120);
     const isActive = status === 'Active';
 
     const statusColor = isActive ? '#22c55e' : '#94a3b8';
-    const btnBg = isActive ? '#3b82f6' : '#64748b';
+    const defaultBtn = isActive ? '#3b82f6' : '#64748b';
+    const btnBg = customColor || defaultBtn;
+
+    // ── Theme colours ─────────────────────────────────────────────────────────
+    const bg = isDark ? '#0f172a' : '#f8fafc';
+    const cardBg = isDark ? '#1e293b' : '#ffffff';
+    const cardBorder = isDark ? '#334155' : '#e2e8f0';
+    const textPrimary = isDark ? '#f1f5f9' : '#0f172a';
+    const textMuted = isDark ? '#94a3b8' : '#64748b';
+    const textMeta = isDark ? '#64748b' : '#94a3b8';
+    const poweredColor = isDark ? '#475569' : '#94a3b8';
+    const poweredLink = isDark ? '#64748b' : '#475569';
+    const eyebrowColor = isDark ? '#64748b' : '#94a3b8';
+
+    // Campaign ID for postMessage event payloads (safe string).
+    const safeCampaignId = sanitiseText(String(campaign.id), 64);
+    const safePartner = sanitiseText(partner, 64);
+    const poweredLabel = orgName ? `Powered by ${orgName} via Trivela` : 'Powered by Trivela';
 
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.setHeader('X-Embed-Route', 'true');
+    // Prevent the embed from navigating the top-level frame (belt-and-suspenders
+    // alongside the `sandbox` attribute set by the partner SDK).
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
     res.send(`<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>${campaign.name} — Trivela</title>
+  <title>${name} — Trivela</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: #0f172a;
-      color: #e2e8f0;
+      background: ${bg};
+      color: ${textPrimary};
       min-height: 100vh;
       display: flex;
       align-items: flex-start;
@@ -73,8 +188,8 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       padding: 16px;
     }
     .card {
-      background: #1e293b;
-      border: 1px solid #334155;
+      background: ${cardBg};
+      border: 1px solid ${cardBorder};
       border-radius: 12px;
       padding: 20px 24px;
       width: 100%;
@@ -84,19 +199,19 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       font-size: 0.7rem;
       letter-spacing: 0.08em;
       text-transform: uppercase;
-      color: #64748b;
+      color: ${eyebrowColor};
       margin-bottom: 6px;
     }
     .name {
       font-size: 1.1rem;
       font-weight: 700;
-      color: #f1f5f9;
+      color: ${textPrimary};
       margin-bottom: 8px;
       line-height: 1.3;
     }
     .desc {
       font-size: 0.85rem;
-      color: #94a3b8;
+      color: ${textMuted};
       line-height: 1.5;
       margin-bottom: 16px;
     }
@@ -106,8 +221,8 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       gap: 12px;
       margin-bottom: 18px;
     }
-    .meta-item { font-size: 0.78rem; color: #64748b; }
-    .meta-item strong { color: #cbd5e1; }
+    .meta-item { font-size: 0.78rem; color: ${textMeta}; }
+    .meta-item strong { color: ${textPrimary}; }
     .status-dot {
       display: inline-block;
       width: 7px; height: 7px;
@@ -128,6 +243,7 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       text-decoration: none;
       border-radius: 8px;
       transition: opacity 0.15s;
+      cursor: pointer;
     }
     .btn:hover { opacity: 0.88; }
     .btn:focus-visible { outline: 2px solid #93c5fd; outline-offset: 2px; }
@@ -135,16 +251,16 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       text-align: center;
       margin-top: 12px;
       font-size: 0.68rem;
-      color: #475569;
+      color: ${poweredColor};
     }
-    .powered a { color: #64748b; text-decoration: none; }
+    .powered a { color: ${poweredLink}; text-decoration: none; }
     .powered a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
   <div class="card">
     <p class="eyebrow">Trivela Campaign</p>
-    <h1 class="name">${campaign.name}</h1>
+    <h1 class="name">${name}</h1>
     ${desc ? `<p class="desc">${desc}</p>` : ''}
     <div class="meta">
       <span class="meta-item"><span class="status-dot"></span><strong>${status}</strong></span>
@@ -152,11 +268,44 @@ export function createEmbedRoute(campaignRepository, siteOrigin) {
       ${spots !== null ? `<span class="meta-item">Spots left: <strong>${spots}</strong></span>` : ''}
       ${campaign.rewardPerAction ? `<span class="meta-item">Reward: <strong>${campaign.rewardPerAction} pts</strong></span>` : ''}
     </div>
-    <a href="${registerUrl}" target="_blank" rel="noopener noreferrer" class="btn">
+    <a
+      href="${registerUrl.toString()}"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="btn"
+      data-trivela-register="true"
+    >
       Register on Trivela ↗
     </a>
-    <p class="powered">Powered by <a href="${siteOrigin}" target="_blank" rel="noopener noreferrer">Trivela</a></p>
+    <p class="powered">
+      ${poweredLabel.replace('Trivela', `<a href="${siteOrigin}" target="_blank" rel="noopener noreferrer">Trivela</a>`)}
+    </p>
   </div>
+  <script>
+    (function () {
+      var campaignId = ${JSON.stringify(safeCampaignId)};
+      var partner = ${JSON.stringify(safePartner)};
+      var origin = ${JSON.stringify(siteOrigin || '*')};
+
+      function post(type, payload) {
+        try {
+          var msg = { source: 'trivela-widget', type: type, payload: payload };
+          window.parent.postMessage(msg, origin || '*');
+        } catch (_) {}
+      }
+
+      // Signal that the widget has loaded successfully.
+      post('trivela:ready', { campaignId: campaignId, partner: partner });
+
+      // Fire trivela:register_click when the CTA is activated.
+      var btn = document.querySelector('[data-trivela-register]');
+      if (btn) {
+        btn.addEventListener('click', function () {
+          post('trivela:register_click', { campaignId: campaignId, partner: partner });
+        });
+      }
+    })();
+  </script>
 </body>
 </html>`);
   };

--- a/backend/src/routes/embed.test.js
+++ b/backend/src/routes/embed.test.js
@@ -1,0 +1,362 @@
+/**
+ * Tests for the embed campaign route and partner attribution helpers.
+ * Runs with Node.js built-in test runner:  node --test src/routes/embed.test.js
+ */
+
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+import { createHmac } from 'node:crypto';
+import { createEmbedRoute, verifyAttributionToken } from './embed.js';
+
+// ── Fake campaign repository ──────────────────────────────────────────────────
+
+const CAMPAIGNS = {
+  active1: {
+    id: 'active1',
+    name: 'Active Campaign',
+    description: 'Great campaign for testing',
+    active: true,
+    participantCount: 42,
+    maxParticipants: 100,
+    rewardPerAction: 10,
+    endDate: null,
+  },
+  ended1: {
+    id: 'ended1',
+    name: 'Ended Campaign',
+    description: null,
+    active: false,
+    participantCount: 5,
+    maxParticipants: null,
+    rewardPerAction: 0,
+    endDate: '2020-01-01T00:00:00Z',
+  },
+};
+
+function makeFakeRepo(campaigns = CAMPAIGNS) {
+  return {
+    getById(id) {
+      return campaigns[id] ?? null;
+    },
+  };
+}
+
+// ── Lightweight fake req/res ─────────────────────────────────────────────────
+
+function makeReq(params = {}, query = {}) {
+  return {
+    params,
+    query,
+    method: 'GET',
+    path: `/embed/campaign/${params.id || 'unknown'}`,
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _headers: {},
+    _body: '',
+    status(code) { this._status = code; return this; },
+    setHeader(name, value) { this._headers[name.toLowerCase()] = value; },
+    send(body) { this._body = body; return this; },
+  };
+  return res;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+const SITE_ORIGIN = 'https://trivela.app';
+const TEST_SECRET = 'test-secret-do-not-use-in-prod';
+
+describe('createEmbedRoute', () => {
+  test('returns 404 HTML for unknown campaign', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'nonexistent' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.equal(res._status, 404);
+    assert.ok(res._body.includes('Campaign not found'));
+  });
+
+  test('renders campaign name in HTML', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.equal(res._status, 200);
+    assert.ok(res._body.includes('Active Campaign'), 'campaign name should appear');
+  });
+
+  test('sets X-Embed-Route header', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.equal(res._headers['x-embed-route'], 'true');
+  });
+
+  test('sets X-Content-Type-Options: nosniff header', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.equal(res._headers['x-content-type-options'], 'nosniff');
+  });
+
+  test('includes register URL pointing to siteOrigin', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(
+      res._body.includes(`${SITE_ORIGIN}/campaign/active1`),
+      'register link must point to site origin',
+    );
+  });
+
+  test('threads valid partner ID into register URL and fires postMessage', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { partner: 'my-partner' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('ref=my-partner'), 'ref param should appear in register URL');
+    assert.ok(res._body.includes('"my-partner"'), 'partner should appear in postMessage script');
+  });
+
+  test('includes attribution token when partner is set', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { partner: 'acme' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    // at= param must be present in the HTML body (inside the register href)
+    assert.ok(res._body.includes('at='), 'attribution token should be in register URL');
+  });
+
+  test('rejects invalid partner IDs (spaces, XSS attempts)', () => {
+    // These must NOT result in ?ref=<value> appearing in the register URL.
+    const invalidPartners = [
+      '<script>alert(1)</script>',
+      'partner id',   // space
+      'a'.repeat(65), // too long
+      'partner/path', // slash
+    ];
+
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+
+    for (const bad of invalidPartners) {
+      const req = makeReq({ id: 'active1' }, { partner: bad });
+      const res = makeRes();
+      handler(req, res);
+
+      // The exact bad value should never appear unescaped as a URL parameter.
+      assert.ok(
+        !res._body.includes(`ref=${encodeURIComponent(bad)}`),
+        `bad partner "${bad}" must not appear as ref param`,
+      );
+      // No attribution token should be present for an invalid partner.
+      assert.ok(
+        !res._body.includes('&amp;at=') && !res._body.includes('?at='),
+        `attribution token must not appear for bad partner "${bad}"`,
+      );
+    }
+  });
+
+  test('does not add ref param when partner is absent', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, {});
+    const res = makeRes();
+
+    handler(req, res);
+
+    // Register URL must not contain ?ref= or ?at= when no partner given.
+    const registerUrlMatch = res._body.match(/href="([^"]+campaign\/active1[^"]*)"/);
+    assert.ok(registerUrlMatch, 'register link should be present');
+    const href = registerUrlMatch[1];
+    assert.ok(!href.includes('ref='), 'no ref param when partner is absent');
+    assert.ok(!href.includes('at='), 'no attribution token when partner is absent');
+  });
+
+  test('accepts valid hex color and applies it to button', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { color: '#ff0000' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('#ff0000'), 'custom color should be applied');
+  });
+
+  test('rejects invalid hex colors', () => {
+    const bad = ['red', '#GGGGGG', 'javascript:alert(1)', '#12345', ''];
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+
+    for (const color of bad) {
+      const req = makeReq({ id: 'active1' }, { color });
+      const res = makeRes();
+      handler(req, res);
+
+      if (color) {
+        assert.ok(!res._body.includes(`background: ${color}`), `invalid color "${color}" must not appear as background`);
+      }
+    }
+  });
+
+  test('renders org name in powered-by footer', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { org: 'MyDAO' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('MyDAO'), 'org name should appear in powered-by footer');
+  });
+
+  test('HTML-escapes org name to prevent XSS', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { org: '<script>bad()</script>' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(!res._body.includes('<script>bad()</script>'), 'raw script tag must not appear');
+    assert.ok(res._body.includes('&lt;script&gt;'), 'org name should be HTML-escaped');
+  });
+
+  test('HTML-escapes campaign name to prevent XSS', () => {
+    const evilRepo = makeFakeRepo({
+      evil: {
+        id: 'evil',
+        name: '<img onerror="alert(1)" src=x>',
+        description: 'safe',
+        active: true,
+        participantCount: 0,
+        maxParticipants: null,
+        rewardPerAction: 0,
+        endDate: null,
+      },
+    });
+    const handler = createEmbedRoute(evilRepo, SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'evil' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(!res._body.includes('<img onerror'), 'raw img tag must not appear');
+    assert.ok(res._body.includes('&lt;img'), 'campaign name should be HTML-escaped');
+  });
+
+  test('shows "Ended" status for inactive campaign', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'ended1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('Ended'), 'status should be Ended');
+  });
+
+  test('shows dark theme styles by default', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('#0f172a'), 'dark background should be present');
+  });
+
+  test('shows light theme when theme=light is set', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' }, { theme: 'light' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes('#f8fafc'), 'light background should be present');
+  });
+
+  test('postMessage script uses siteOrigin as target', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(
+      res._body.includes(JSON.stringify(SITE_ORIGIN)),
+      'postMessage target must be siteOrigin',
+    );
+  });
+
+  test('postMessage fires trivela:ready event', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(res._body.includes("'trivela:ready'"), 'trivela:ready event must be fired');
+  });
+
+  test('postMessage fires trivela:register_click on CTA click', () => {
+    const handler = createEmbedRoute(makeFakeRepo(), SITE_ORIGIN, { embedSecret: TEST_SECRET });
+    const req = makeReq({ id: 'active1' });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.ok(
+      res._body.includes("'trivela:register_click'"),
+      'trivela:register_click event must be wired to CTA button',
+    );
+  });
+});
+
+describe('verifyAttributionToken', () => {
+  test('returns true for a fresh token generated with the same secret', () => {
+    const secret = 'my-secret';
+    const campaign = 'c1';
+    const partner = 'p1';
+    const bucket = Math.floor(Date.now() / 300_000);
+    const token = createHmac('sha256', secret)
+      .update(`${campaign}:${partner}:${bucket}`)
+      .digest('hex')
+      .slice(0, 32);
+
+    assert.equal(verifyAttributionToken(campaign, partner, token, secret), true);
+  });
+
+  test('returns false for a wrong secret', () => {
+    const bucket = Math.floor(Date.now() / 300_000);
+    const token = createHmac('sha256', 'right-secret')
+      .update(`c1:p1:${bucket}`)
+      .digest('hex')
+      .slice(0, 32);
+
+    assert.equal(verifyAttributionToken('c1', 'p1', token, 'wrong-secret'), false);
+  });
+
+  test('returns false for a tampered token', () => {
+    assert.equal(verifyAttributionToken('c1', 'p1', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'secret'), false);
+  });
+
+  test('returns false for empty token or secret', () => {
+    assert.equal(verifyAttributionToken('c1', 'p1', '', 'secret'), false);
+    assert.equal(verifyAttributionToken('c1', 'p1', 'sometoken', ''), false);
+  });
+});

--- a/backend/src/routes/embed.test.js
+++ b/backend/src/routes/embed.test.js
@@ -57,9 +57,17 @@ function makeRes() {
     _status: 200,
     _headers: {},
     _body: '',
-    status(code) { this._status = code; return this; },
-    setHeader(name, value) { this._headers[name.toLowerCase()] = value; },
-    send(body) { this._body = body; return this; },
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    setHeader(name, value) {
+      this._headers[name.toLowerCase()] = value;
+    },
+    send(body) {
+      this._body = body;
+      return this;
+    },
   };
   return res;
 }
@@ -151,7 +159,7 @@ describe('createEmbedRoute', () => {
     // These must NOT result in ?ref=<value> appearing in the register URL.
     const invalidPartners = [
       '<script>alert(1)</script>',
-      'partner id',   // space
+      'partner id', // space
       'a'.repeat(65), // too long
       'partner/path', // slash
     ];
@@ -211,7 +219,10 @@ describe('createEmbedRoute', () => {
       handler(req, res);
 
       if (color) {
-        assert.ok(!res._body.includes(`background: ${color}`), `invalid color "${color}" must not appear as background`);
+        assert.ok(
+          !res._body.includes(`background: ${color}`),
+          `invalid color "${color}" must not appear as background`,
+        );
       }
     }
   });
@@ -352,7 +363,10 @@ describe('verifyAttributionToken', () => {
   });
 
   test('returns false for a tampered token', () => {
-    assert.equal(verifyAttributionToken('c1', 'p1', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'secret'), false);
+    assert.equal(
+      verifyAttributionToken('c1', 'p1', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'secret'),
+      false,
+    );
   });
 
   test('returns false for empty token or secret', () => {

--- a/frontend/public/embed.js
+++ b/frontend/public/embed.js
@@ -27,7 +27,6 @@
  *   - No credentials, API keys, or wallet secrets are ever exposed in the snippet.
  */
 
-/* global window, document */
 (function (global) {
   'use strict';
 
@@ -45,7 +44,7 @@
         var u = new URL(scriptEl.src);
         return u.origin;
       }
-    } catch (_) {}
+    } catch (_) { /* invalid URL — fall through to default */ }
     return 'https://trivela.app';
   })();
 
@@ -136,7 +135,7 @@
   TrivelaWidget.prototype._emit = function (event, data) {
     var handlers = this._listeners[event] || [];
     for (var i = 0; i < handlers.length; i++) {
-      try { handlers[i](data); } catch (_) {}
+      try { handlers[i](data); } catch (_) { /* isolate subscriber errors */ }
     }
   };
 

--- a/frontend/public/embed.js
+++ b/frontend/public/embed.js
@@ -44,7 +44,9 @@
         var u = new URL(scriptEl.src);
         return u.origin;
       }
-    } catch (_) { /* invalid URL — fall through to default */ }
+    } catch (_) {
+      /* invalid URL — fall through to default */
+    }
     return 'https://trivela.app';
   })();
 
@@ -127,7 +129,9 @@
     }
     var handlers = this._listeners[event];
     if (!handlers) return this;
-    this._listeners[event] = handlers.filter(function (h) { return h !== handler; });
+    this._listeners[event] = handlers.filter(function (h) {
+      return h !== handler;
+    });
     return this;
   };
 
@@ -135,7 +139,11 @@
   TrivelaWidget.prototype._emit = function (event, data) {
     var handlers = this._listeners[event] || [];
     for (var i = 0; i < handlers.length; i++) {
-      try { handlers[i](data); } catch (_) { /* isolate subscriber errors */ }
+      try {
+        handlers[i](data);
+      } catch (_) {
+        /* isolate subscriber errors */
+      }
     }
   };
 
@@ -186,10 +194,7 @@
     // Sandbox: minimal permissions required for the widget to function.
     // allow-same-origin is needed for postMessage to carry the Trivela origin.
     // allow-popups is needed so the "Register" link opens in a new tab.
-    iframe.setAttribute(
-      'sandbox',
-      'allow-scripts allow-same-origin allow-popups allow-forms'
-    );
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-popups allow-forms');
     iframe.style.cssText = [
       'display:block',
       'width:100%',

--- a/frontend/public/embed.js
+++ b/frontend/public/embed.js
@@ -1,0 +1,293 @@
+/**
+ * Trivela Partner SDK — embed.js
+ *
+ * One-line embed snippet for third-party sites and partner apps.
+ *
+ * Usage:
+ *   <script src="https://trivela.app/embed.js"
+ *           data-campaign="<campaign-id>"
+ *           data-partner="<partner-id>"
+ *           data-theme="dark"
+ *           data-size="md"
+ *           data-org="MyDAO"
+ *           data-color="#3b82f6">
+ *   </script>
+ *
+ * Programmatic usage (after the script loads):
+ *   const widget = new TrivelaWidget({ campaign: 'id', partner: 'pid' });
+ *   widget.on('trivela:ready',          (e) => console.log('loaded', e))
+ *         .on('trivela:register_click', (e) => console.log('register clicked', e))
+ *         .mount(document.getElementById('my-container'));
+ *
+ * Security:
+ *   - The iframe is sandboxed: allow-scripts allow-same-origin allow-popups allow-forms
+ *   - postMessage events are validated: only messages from the Trivela origin are
+ *     forwarded to widget listeners.
+ *   - Partner IDs are validated (alphanumeric + _-) before being placed in the URL.
+ *   - No credentials, API keys, or wallet secrets are ever exposed in the snippet.
+ */
+
+/* global window, document */
+(function (global) {
+  'use strict';
+
+  // Derive the Trivela origin from where this script was loaded.
+  // Falls back to the script src attribute for reliability across CDN setups.
+  var scriptEl = (function () {
+    if (document.currentScript) return document.currentScript;
+    var scripts = document.querySelectorAll('script[src*="embed.js"]');
+    return scripts[scripts.length - 1] || null;
+  })();
+
+  var TRIVELA_ORIGIN = (function () {
+    try {
+      if (scriptEl && scriptEl.src) {
+        var u = new URL(scriptEl.src);
+        return u.origin;
+      }
+    } catch (_) {}
+    return 'https://trivela.app';
+  })();
+
+  var PARTNER_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+  var COLOR_PATTERN = /^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+
+  // Default iframe dimensions per size preset.
+  var SIZE_HEIGHTS = { sm: '260px', md: '320px', lg: '380px' };
+
+  /**
+   * Validate and sanitise a partner ID.
+   * @param {string|null|undefined} raw
+   * @returns {string}
+   */
+  function sanitisePartner(raw) {
+    if (!raw) return '';
+    var s = String(raw).trim();
+    return PARTNER_PATTERN.test(s) ? s : '';
+  }
+
+  /**
+   * Validate a CSS hex colour.
+   * @param {string|null|undefined} raw
+   * @returns {string}
+   */
+  function sanitiseColor(raw) {
+    if (!raw) return '';
+    var s = String(raw).trim();
+    return COLOR_PATTERN.test(s) ? s : '';
+  }
+
+  /**
+   * TrivelaWidget constructor.
+   *
+   * @param {Object} config
+   * @param {string}  config.campaign     Campaign ID (required)
+   * @param {string}  [config.partner]    Partner/referrer ID
+   * @param {string}  [config.theme]      'dark' | 'light'
+   * @param {string}  [config.size]       'sm' | 'md' | 'lg'
+   * @param {string}  [config.org]        Partner org display name
+   * @param {string}  [config.color]      Button hex colour override
+   * @param {string}  [config.origin]     Override Trivela origin (testing only)
+   */
+  function TrivelaWidget(config) {
+    this._config = config || {};
+    this._listeners = Object.create(null);
+    this._iframe = null;
+    this._mounted = false;
+    this._messageHandler = null;
+  }
+
+  /**
+   * Subscribe to a widget event.
+   *
+   * Supported events:
+   *   'trivela:ready'           — widget iframe has loaded the campaign
+   *   'trivela:register_click'  — user clicked "Register on Trivela"
+   *
+   * @param {string}   event
+   * @param {Function} handler
+   * @returns {TrivelaWidget} for chaining
+   */
+  TrivelaWidget.prototype.on = function (event, handler) {
+    if (typeof handler !== 'function') return this;
+    if (!this._listeners[event]) this._listeners[event] = [];
+    this._listeners[event].push(handler);
+    return this;
+  };
+
+  /**
+   * Remove a previously registered handler (or all handlers for the event).
+   * @param {string}    event
+   * @param {Function}  [handler]  Omit to remove all handlers for this event.
+   * @returns {TrivelaWidget}
+   */
+  TrivelaWidget.prototype.off = function (event, handler) {
+    if (!handler) {
+      delete this._listeners[event];
+      return this;
+    }
+    var handlers = this._listeners[event];
+    if (!handlers) return this;
+    this._listeners[event] = handlers.filter(function (h) { return h !== handler; });
+    return this;
+  };
+
+  /** @private */
+  TrivelaWidget.prototype._emit = function (event, data) {
+    var handlers = this._listeners[event] || [];
+    for (var i = 0; i < handlers.length; i++) {
+      try { handlers[i](data); } catch (_) {}
+    }
+  };
+
+  /**
+   * Build the iframe src URL.
+   * @private
+   * @returns {string}
+   */
+  TrivelaWidget.prototype._buildSrc = function () {
+    var cfg = this._config;
+    var origin = cfg.origin || TRIVELA_ORIGIN;
+    var params = new URLSearchParams();
+
+    var partner = sanitisePartner(cfg.partner);
+    if (partner) params.set('partner', partner);
+
+    var color = sanitiseColor(cfg.color);
+    if (color) params.set('color', color);
+
+    if (cfg.theme === 'light') params.set('theme', 'light');
+    if (cfg.size && SIZE_HEIGHTS[cfg.size]) params.set('size', cfg.size);
+    if (cfg.org) params.set('org', String(cfg.org).slice(0, 48));
+
+    var qs = params.toString();
+    return origin + '/embed/campaign/' + encodeURIComponent(cfg.campaign) + (qs ? '?' + qs : '');
+  };
+
+  /**
+   * Mount the widget into the given DOM element.
+   *
+   * @param {Element} container  Host element; the iframe is appended to it.
+   * @returns {TrivelaWidget}
+   */
+  TrivelaWidget.prototype.mount = function (container) {
+    if (this._mounted || !container) return this;
+    this._mounted = true;
+
+    var cfg = this._config;
+    var origin = cfg.origin || TRIVELA_ORIGIN;
+    var size = cfg.size || 'md';
+    var height = SIZE_HEIGHTS[size] || SIZE_HEIGHTS.md;
+
+    var iframe = document.createElement('iframe');
+    iframe.src = this._buildSrc();
+    iframe.title = 'Trivela Campaign Widget';
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('allow', 'payment');
+    // Sandbox: minimal permissions required for the widget to function.
+    // allow-same-origin is needed for postMessage to carry the Trivela origin.
+    // allow-popups is needed so the "Register" link opens in a new tab.
+    iframe.setAttribute(
+      'sandbox',
+      'allow-scripts allow-same-origin allow-popups allow-forms'
+    );
+    iframe.style.cssText = [
+      'display:block',
+      'width:100%',
+      'height:' + height,
+      'border:none',
+      'border-radius:12px',
+      'overflow:hidden',
+    ].join(';');
+
+    container.appendChild(iframe);
+    this._iframe = iframe;
+
+    var self = this;
+
+    this._messageHandler = function (evt) {
+      // Only accept messages from the Trivela embed origin.
+      if (evt.origin !== origin) return;
+      var data = evt.data;
+      if (!data || typeof data !== 'object') return;
+      if (data.source !== 'trivela-widget') return;
+      if (typeof data.type !== 'string') return;
+      self._emit(data.type, data.payload);
+    };
+
+    global.addEventListener('message', this._messageHandler);
+    return this;
+  };
+
+  /**
+   * Unmount and clean up the widget.
+   */
+  TrivelaWidget.prototype.destroy = function () {
+    if (this._messageHandler) {
+      global.removeEventListener('message', this._messageHandler);
+      this._messageHandler = null;
+    }
+    if (this._iframe && this._iframe.parentNode) {
+      this._iframe.parentNode.removeChild(this._iframe);
+      this._iframe = null;
+    }
+    this._mounted = false;
+    this._listeners = Object.create(null);
+  };
+
+  // ── Auto-init ───────────────────────────────────────────────────────────────
+
+  /**
+   * Scan the page for <script data-campaign="..."> tags and auto-mount widgets.
+   * Partners that prefer to control placement can skip this by adding
+   * data-trivela-manual on the script tag.
+   */
+  function autoInit() {
+    var scripts = document.querySelectorAll('script[data-campaign]');
+
+    for (var i = 0; i < scripts.length; i++) {
+      var script = scripts[i];
+      if (script.getAttribute('data-trivela-manual') !== null) continue;
+
+      var campaign = script.getAttribute('data-campaign');
+      if (!campaign) continue;
+
+      var widget = new TrivelaWidget({
+        campaign: campaign,
+        partner: script.getAttribute('data-partner') || '',
+        theme: script.getAttribute('data-theme') || '',
+        size: script.getAttribute('data-size') || 'md',
+        org: script.getAttribute('data-org') || '',
+        color: script.getAttribute('data-color') || '',
+      });
+
+      // Insert a container div immediately after the script tag.
+      var container = document.createElement('div');
+      container.setAttribute('data-trivela-widget', campaign);
+      if (script.parentNode) {
+        script.parentNode.insertBefore(container, script.nextSibling);
+      }
+
+      widget.mount(container);
+
+      // Expose for programmatic post-mount access.
+      if (!global.TrivelaWidgets) global.TrivelaWidgets = Object.create(null);
+      global.TrivelaWidgets[campaign] = widget;
+    }
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /** Expose TrivelaWidget globally for programmatic use. */
+  global.TrivelaWidget = TrivelaWidget;
+
+  /** Index of auto-mounted widgets, keyed by campaign ID. */
+  if (!global.TrivelaWidgets) global.TrivelaWidgets = Object.create(null);
+
+  // Run auto-init after DOM is ready.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoInit);
+  } else {
+    autoInit();
+  }
+})(typeof window !== 'undefined' ? window : this);

--- a/frontend/src/__tests__/EmbedCampaign.test.jsx
+++ b/frontend/src/__tests__/EmbedCampaign.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import EmbedCampaign from '../pages/EmbedCampaign';
 
@@ -36,11 +36,15 @@ describe('EmbedCampaign', () => {
         json: () => Promise.resolve({ campaign: mockCampaign }),
       }),
     );
+    // Stub postMessage so tests don't throw cross-origin errors.
+    vi.stubGlobal('parent', { postMessage: vi.fn() });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  // ── Existing baseline tests ────────────────────────────────────────────────
 
   it('shows loading state initially', () => {
     vi.stubGlobal(
@@ -88,7 +92,7 @@ describe('EmbedCampaign', () => {
     );
     renderEmbed();
     await waitFor(() => {
-      const desc = screen.getByText(/A+\u2026/);
+      const desc = screen.getByText(/A+…/);
       expect(desc.textContent.length).toBeLessThanOrEqual(121);
     });
   });
@@ -103,5 +107,114 @@ describe('EmbedCampaign', () => {
   it('applies light theme when requested', async () => {
     renderEmbed('abc123', '?theme=light');
     await waitFor(() => expect(screen.getByText('Test Campaign')).toBeInTheDocument());
+  });
+
+  // ── Partner attribution tests ──────────────────────────────────────────────
+
+  it('includes ?ref=partner in register URL when valid partner is given', async () => {
+    renderEmbed('abc123', '?partner=acme-dao');
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      expect(link.href).toContain('ref=acme-dao');
+    });
+  });
+
+  it('does NOT include ref param when partner is absent', async () => {
+    renderEmbed('abc123', '');
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      expect(link.href).not.toContain('ref=');
+    });
+  });
+
+  it('ignores an invalid partner ID (special chars)', async () => {
+    renderEmbed('abc123', '?partner=<script>bad()</script>');
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      expect(link.href).not.toContain('ref=');
+      expect(link.href).not.toContain('script');
+    });
+  });
+
+  it('ignores a partner ID that exceeds 64 characters', async () => {
+    const longId = 'a'.repeat(65);
+    renderEmbed('abc123', `?partner=${longId}`);
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      expect(link.href).not.toContain('ref=');
+    });
+  });
+
+  // ── postMessage tests ──────────────────────────────────────────────────────
+
+  it('fires trivela:ready postMessage after campaign loads', async () => {
+    const mockPostMessage = vi.fn();
+    vi.stubGlobal('parent', { postMessage: mockPostMessage });
+
+    renderEmbed('abc123', '?partner=foo');
+    await waitFor(() => {
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'trivela-widget',
+          type: 'trivela:ready',
+          payload: expect.objectContaining({ campaignId: 'abc123', partner: 'foo' }),
+        }),
+        expect.any(String),
+      );
+    });
+  });
+
+  it('fires trivela:register_click postMessage when register link is clicked', async () => {
+    const mockPostMessage = vi.fn();
+    vi.stubGlobal('parent', { postMessage: mockPostMessage });
+
+    renderEmbed('abc123', '?partner=bar');
+    await waitFor(() => screen.getByTestId('register-link'));
+
+    fireEvent.click(screen.getByTestId('register-link'));
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'trivela-widget',
+        type: 'trivela:register_click',
+        payload: expect.objectContaining({ campaignId: 'abc123', partner: 'bar' }),
+      }),
+      expect.any(String),
+    );
+  });
+
+  // ── Org branding tests ─────────────────────────────────────────────────────
+
+  it('shows default "Powered by Trivela" when no org is given', async () => {
+    renderEmbed('abc123');
+    await waitFor(() => {
+      expect(screen.getByText(/powered by trivela/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Powered by OrgName via Trivela" when org param is given', async () => {
+    renderEmbed('abc123', '?org=MyDAO');
+    await waitFor(() => {
+      expect(screen.getByText(/powered by mydao via trivela/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Colour branding tests ─────────────────────────────────────────────────
+
+  it('applies custom button colour from ?color param', async () => {
+    renderEmbed('abc123', '?color=%23ff0000');
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      expect(link.style.background).toBe('rgb(255, 0, 0)');
+    });
+  });
+
+  it('ignores invalid colour values', async () => {
+    renderEmbed('abc123', '?color=javascript%3Aalert(1)');
+    await waitFor(() => {
+      const link = screen.getByTestId('register-link');
+      // Should fall back to default indigo colour
+      expect(link.style.background).not.toContain('javascript');
+    });
   });
 });

--- a/frontend/src/__tests__/OnboardingTour.test.jsx
+++ b/frontend/src/__tests__/OnboardingTour.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
+import { driver } from 'driver.js';
 import OnboardingTour from '../components/OnboardingTour';
 
 const mockDrive = vi.fn();
@@ -45,7 +46,6 @@ describe('OnboardingTour', () => {
   });
 
   it('sets localStorage on tour completion', () => {
-    const { driver } = require('driver.js');
     let onDestroyedCallback;
     driver.mockImplementation((config) => {
       onDestroyedCallback = config.onDestroyed;

--- a/frontend/src/pages/EmbedCampaign.jsx
+++ b/frontend/src/pages/EmbedCampaign.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { apiUrl } from '../config';
 
@@ -10,18 +10,48 @@ const SIZE_MAP = {
   lg: { width: 520, height: 340 },
 };
 
+// Strict validation matching the backend's PARTNER_PATTERN.
+const PARTNER_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const COLOR_PATTERN = /^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+
 function truncate(text, maxLen) {
   if (!text || text.length <= maxLen) return text || '';
-  return text.slice(0, maxLen - 1) + '\u2026';
+  return text.slice(0, maxLen - 1) + '…';
+}
+
+/**
+ * Post a trivela-widget postMessage event to the parent frame.
+ * The target origin is `window.location.origin` by default; in sandboxed
+ * iframes the parent sets `allow-same-origin`, so `'*'` is the safe fallback.
+ */
+function postToParent(type, payload) {
+  try {
+    const msg = { source: 'trivela-widget', type, payload };
+    window.parent.postMessage(msg, window.location.origin || '*');
+  } catch (_) {
+    // Non-sandboxed cross-origin parents will block this — that's expected.
+  }
 }
 
 export default function EmbedCampaign() {
   const { id } = useParams();
   const [searchParams] = useSearchParams();
+  const readyFired = useRef(false);
 
   const theme = searchParams.get('theme') === 'light' ? 'light' : 'dark';
   const sizeKey = SIZE_MAP[searchParams.get('size')] ? searchParams.get('size') : 'md';
   const { width, height } = SIZE_MAP[sizeKey];
+
+  // Partner attribution: validate before accepting.
+  const rawPartner = searchParams.get('partner') ?? '';
+  const partner = PARTNER_PATTERN.test(rawPartner) ? rawPartner : '';
+
+  // Optional org branding.
+  const orgName = (searchParams.get('org') ?? '').slice(0, 48);
+
+  // Optional primary colour override (e.g. for org branding).
+  const rawColor = searchParams.get('color') ?? '';
+  const customColor = COLOR_PATTERN.test(rawColor) ? rawColor : '';
 
   const [campaign, setCampaign] = useState(null);
   const [error, setError] = useState(null);
@@ -43,7 +73,18 @@ export default function EmbedCampaign() {
     return () => clearInterval(timer);
   }, [fetchCampaign]);
 
+  // Fire trivela:ready once the campaign data has loaded.
+  useEffect(() => {
+    if (campaign && !readyFired.current) {
+      readyFired.current = true;
+      postToParent('trivela:ready', { campaignId: id, partner });
+    }
+  }, [campaign, id, partner]);
+
   const isDark = theme === 'dark';
+  const defaultBtnColor = '#6366f1';
+  const btnColor = customColor || defaultBtnColor;
+
   const styles = {
     container: {
       width,
@@ -90,7 +131,7 @@ export default function EmbedCampaign() {
     btn: {
       display: 'inline-block',
       padding: '8px 16px',
-      background: '#6366f1',
+      background: btnColor,
       color: '#ffffff',
       borderRadius: '8px',
       fontSize: '13px',
@@ -98,6 +139,12 @@ export default function EmbedCampaign() {
       textDecoration: 'none',
       textAlign: 'center',
       marginTop: 'auto',
+    },
+    powered: {
+      textAlign: 'center',
+      fontSize: '10px',
+      color: isDark ? '#475569' : '#94a3b8',
+      marginTop: '4px',
     },
   };
 
@@ -121,7 +168,18 @@ export default function EmbedCampaign() {
   const participantCount = campaign.participantCount ?? campaign.participant_count ?? 0;
   const capacity = campaign.capacity ?? campaign.maxParticipants ?? null;
   const remaining = capacity != null ? capacity - participantCount : null;
-  const campaignUrl = `${window.location.origin}/campaign/${id}`;
+
+  // Build the register URL with partner attribution when available.
+  const baseUrl = `${window.location.origin}/campaign/${id}`;
+  const registerUrl = partner
+    ? `${baseUrl}?ref=${encodeURIComponent(partner)}`
+    : baseUrl;
+
+  const handleRegisterClick = () => {
+    postToParent('trivela:register_click', { campaignId: id, partner });
+  };
+
+  const poweredLabel = orgName ? `Powered by ${orgName} via Trivela` : 'Powered by Trivela';
 
   return (
     <div style={styles.container}>
@@ -140,9 +198,17 @@ export default function EmbedCampaign() {
         {capacity != null && <span>of {capacity.toLocaleString()}</span>}
         {campaign.rewardPerAction != null && <span>{campaign.rewardPerAction} pts/action</span>}
       </div>
-      <a href={campaignUrl} target="_blank" rel="noopener noreferrer" style={styles.btn}>
+      <a
+        href={registerUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={styles.btn}
+        onClick={handleRegisterClick}
+        data-testid="register-link"
+      >
         Register on Trivela
       </a>
+      <p style={styles.powered}>{poweredLabel}</p>
     </div>
   );
 }

--- a/frontend/src/pages/EmbedCampaign.jsx
+++ b/frontend/src/pages/EmbedCampaign.jsx
@@ -171,9 +171,7 @@ export default function EmbedCampaign() {
 
   // Build the register URL with partner attribution when available.
   const baseUrl = `${window.location.origin}/campaign/${id}`;
-  const registerUrl = partner
-    ? `${baseUrl}?ref=${encodeURIComponent(partner)}`
-    : baseUrl;
+  const registerUrl = partner ? `${baseUrl}?ref=${encodeURIComponent(partner)}` : baseUrl;
 
   const handleRegisterClick = () => {
     postToParent('trivela:register_click', { campaignId: id, partner });

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom';
+
+// Provide a complete in-memory localStorage implementation.
+// vitest's jsdom environment may omit .clear() when --localstorage-file is active,
+// which breaks tests that reset state in beforeEach/afterEach.
+const makeStorage = () => {
+  let store = {};
+  return {
+    getItem: (key) => Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
+    setItem: (key, value) => { store[key] = String(value); },
+    removeItem: (key) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (n) => Object.keys(store)[n] ?? null,
+  };
+};
+
+Object.defineProperty(window, 'localStorage', { value: makeStorage(), writable: true, configurable: true });
+Object.defineProperty(window, 'sessionStorage', { value: makeStorage(), writable: true, configurable: true });

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -6,14 +6,30 @@ import '@testing-library/jest-dom';
 const makeStorage = () => {
   let store = {};
   return {
-    getItem: (key) => Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
-    setItem: (key, value) => { store[key] = String(value); },
-    removeItem: (key) => { delete store[key]; },
-    clear: () => { store = {}; },
-    get length() { return Object.keys(store).length; },
+    getItem: (key) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
     key: (n) => Object.keys(store)[n] ?? null,
   };
 };
 
-Object.defineProperty(window, 'localStorage', { value: makeStorage(), writable: true, configurable: true });
-Object.defineProperty(window, 'sessionStorage', { value: makeStorage(), writable: true, configurable: true });
+Object.defineProperty(window, 'localStorage', {
+  value: makeStorage(),
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(window, 'sessionStorage', {
+  value: makeStorage(),
+  writable: true,
+  configurable: true,
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -4,7 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   test: {
+    globals: true,
     environment: 'jsdom',
-    include: ['src/hooks/**/*.test.{js,jsx}'],
+    setupFiles: ['./src/setupTests.js'],
+    include: ['src/hooks/**/*.test.{js,jsx}', 'src/__tests__/**/*.test.{js,jsx,ts,tsx}'],
   },
 });


### PR DESCRIPTION
## Summary

Implements the full embeddable campaign widget system described in issue #655, enabling partner sites to embed live Trivela campaign widgets via a single `<script>` tag.

### What was built

#### Backend — `backend/src/routes/embed.js`
- New `GET /embed/campaign/:id` route that renders a self-contained, themed HTML page designed to be loaded inside an iframe.
- **HMAC-SHA256 attribution tokens** (`signAttributionToken` / `verifyAttributionToken`) using 5-minute rolling time buckets. The token is included as `?at=<token>` in the register URL. `verifyAttributionToken` accepts the current and preceding bucket to tolerate clock skew between servers.
- **Partner attribution**: valid `?partner=` IDs (matching `PARTNER_PATTERN=/^[A-Za-z0-9_-]{1,64}$/`) are threaded into the register URL as `?ref=<partner>&at=<hmac-token>`, preventing partner-credit spoofing without requiring the partner to do any signing themselves.
- **Input sanitisation**: `PARTNER_PATTERN` and `COLOR_PATTERN=/^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/` validation; `sanitiseText()` HTML-escapes campaign name and org name before inserting into the page.
- **Theming**: light/dark via `?theme=light|dark`; optional `?org=` for white-label powered-by footer; optional `?color=` for button colour override.
- **postMessage events** to the parent frame: `trivela:ready` on widget load, `trivela:register_click` on CTA click. Events carry `{ source: 'trivela-widget', type, payload: { campaignId, partner } }`.
- Sets `X-Embed-Route: true` and `X-Content-Type-Options: nosniff` response headers. CSP `frame-ancestors: *` is already applied by the existing `securityHeaders.js` middleware via the `X-Embed-Route` header check.

#### Backend wiring — `backend/src/index.js`
- Registers the embed route with a **dedicated rate limiter** capped at `Math.min(30, rateLimitMaxRequests)` requests/minute so embed traffic can't exhaust the global limit, and the global limit can't spike embed iframes into 429s.

#### Frontend — `frontend/src/pages/EmbedCampaign.jsx`
- Validates `?partner=` and `?color=` against the same patterns as the backend.
- Builds the register link with `?ref=<partner>` when a valid partner is present.
- Fires `trivela:ready` after campaign data loads (guarded by a `useRef` so it only fires once even on polling re-renders).
- Fires `trivela:register_click` when the CTA anchor is clicked.
- Shows `Powered by <org> via Trivela` footer when `?org=` is set.
- Custom button colour from `?color=` (validated hex only, falls back to default indigo).

#### Partner SDK — `frontend/public/embed.js`
- Vanilla JS IIFE; zero dependencies; works in any browser that supports ES5.
- **Auto-init**: scans for `<script data-campaign="...">` tags on DOMContentLoaded and mounts an iframe widget next to each one. Partners can opt out with `data-trivela-manual`.
- **`TrivelaWidget` class** with `.on(event, handler)` / `.off()` / `.mount(container)` / `.destroy()` for programmatic usage.
- Derives the Trivela origin from the script's own `src` URL so the SDK works on any CDN without configuration.
- postMessage listener validates `evt.origin` against the Trivela origin and `data.source === 'trivela-widget'` before forwarding to widget subscribers.
- Sandboxed iframe: `sandbox="allow-scripts allow-same-origin allow-popups allow-forms"`.
- Exposes `window.TrivelaWidget` and `window.TrivelaWidgets` (keyed by campaign ID).

#### Tests
- **`backend/src/routes/embed.test.js`** (24 tests, Node.js `node:test` runner): 404 response, HTML rendering, custom headers, partner ref/token threading, XSS rejection (4 invalid partner types), empty-partner guard, hex colour validation, org name HTML-escaping, campaign name HTML-escaping, `Ended` status, dark/light theme styles, postMessage target origin, `trivela:ready` event, `trivela:register_click` event, plus 4 `verifyAttributionToken` unit tests.
- **`frontend/src/__tests__/EmbedCampaign.test.jsx`** (18 tests, Vitest): extended with partner URL threading, invalid partner rejection (XSS, >64 chars), `trivela:ready` postMessage, `trivela:register_click` postMessage, org branding, custom colour, invalid colour rejection.
- **`frontend/vitest.config.js`**: extended `include` glob to also cover `src/__tests__/` so all component tests run in CI.
- **`frontend/src/setupTests.js`**: new setup file wiring `@testing-library/jest-dom` matchers and a full `localStorage` polyfill (fixes pre-existing `localStorage.clear is not a function` failure in `useTour.test.js`).
- **`frontend/src/__tests__/OnboardingTour.test.jsx`**: fixed `require('driver.js')` → top-level ESM `import { driver }` so `driver.mockImplementation()` works correctly in Vitest's ESM mode.

## Security notes

- No partner ID or org string is ever reflected into the page unescaped.
- HMAC tokens use a secret from `process.env.EMBED_ATTRIBUTION_SECRET`; absent the secret the token is still generated (empty HMAC) so the route degrades gracefully rather than erroring.
- The iframe sandbox prevents the embedded page from accessing the host page's DOM or cookies.
- `frame-ancestors: *` is scoped only to embed routes via the `X-Embed-Route` header check in `securityHeaders.js` — all other routes keep `frame-ancestors: 'none'`.

## Test plan

- [x] `node --test backend/src/routes/embed.test.js` → 24/24 pass
- [x] `cd frontend && npm run test:unit` → 55/55 pass (all pre-existing failures fixed)
- [x] Embed route returns correct HTML at `GET /embed/campaign/:id`
- [x] Partner attribution token appears in register URL when valid `?partner=` is given
- [x] Invalid partner IDs (XSS, spaces, >64 chars, slashes) are rejected
- [x] `embed.js` auto-mounts an iframe next to `<script data-campaign="...">` tags
- [x] postMessage events fire from the iframe and are received by SDK listeners