### PR TITLE
feat: Web Push notifications (campaign lifecycle, claim ready) (#619)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -112,3 +112,11 @@ OTEL_SERVICE_NAME=trivela-backend
 # When using blue-green, the deploy script manages two backend environments on different ports
 # (blue: 3001, green: 3002) and atomically switches nginx traffic after health verification.
 DEPLOY_STRATEGY=blue-green
+
+# Web Push notifications (VAPID) — issue #619.
+# Generate a keypair with: npx web-push generate-vapid-keys
+# When unset, web push is disabled (the /push endpoints report not_configured)
+# and the backend still boots normally.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:notifications@trivela.app

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,13 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1057.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
+    "@opentelemetry/instrumentation-express": "^0.45.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/resources": "^1.28.0",
+    "@opentelemetry/sdk-node": "^0.55.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@stellar/stellar-sdk": "^14.0.0",
     "better-sqlite3": "^11.0.0",
     "compression": "^1.8.0",
@@ -31,19 +38,14 @@
     "pg": "^8.13.0",
     "pino": "^9.0.0",
     "supertest": "^7.0.0",
+    "swagger-ui-express": "^5.0.1",
     "validator": "^13.12.0",
-    "zod": "^3.23.0",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-node": "^0.55.0",
-    "@opentelemetry/instrumentation-express": "^0.45.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
-    "@opentelemetry/resources": "^1.28.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
-    "swagger-ui-express": "^5.0.1"
+    "web-push": "^3.6.7",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@readme/openapi-parser": "^2.6.0",
+    "@redocly/cli": "^1.34.5",
     "@types/cors": "^2.8.0",
     "@types/express": "^4.17.0",
     "@types/node": "^20.0.0",
@@ -51,8 +53,7 @@
     "ajv": "^8.17.0",
     "js-yaml": "^4.1.0",
     "nodemon": "^3.1.0",
-    "typescript": "^5.0.0",
-    "@redocly/cli": "^1.34.5",
-    "redoc-cli": "^0.13.21"
+    "redoc-cli": "^0.13.21",
+    "typescript": "^5.0.0"
   }
 }

--- a/backend/src/dal/index.js
+++ b/backend/src/dal/index.js
@@ -14,6 +14,7 @@ import { createSqliteApiKeyRepository } from './sqliteApiKeyRepository.js';
 import { createSqliteFailedJobRepository } from './sqliteFailedJobRepository.js';
 import { createSqliteVariantRepository } from './sqliteVariantRepository.js';
 import { createSqliteCohortRepository } from './sqliteCohortRepository.js';
+import { createSqlitePushSubscriptionRepository } from './sqlitePushSubscriptionRepository.js';
 import { createPool, isPostgresUrl } from './pg/pgClient.js';
 import { createSqliteAllowlistRepository } from './sqliteAllowlistRepository.js';
 
@@ -81,6 +82,7 @@ export async function createDal({
     referrals: createSqliteReferralRepository({ db }),
     variants: createSqliteVariantRepository({ db }),
     cohorts: createSqliteCohortRepository({ db }),
+    pushSubscriptions: createSqlitePushSubscriptionRepository({ db }),
     apiKeys: assertApiKeyRepository(apiKeyRepository ?? createSqliteApiKeyRepository({ db })),
     failedJobs: failedJobRepository ?? createSqliteFailedJobRepository({ db }),
     allowlists: allowlistRepository ?? createSqliteAllowlistRepository({ db }),

--- a/backend/src/dal/sqlitePushSubscriptionRepository.js
+++ b/backend/src/dal/sqlitePushSubscriptionRepository.js
@@ -1,0 +1,75 @@
+// @ts-check
+
+/**
+ * Maps a DB row to a Web Push subscription object (PushSubscription-shaped).
+ */
+function rowToSubscription(row) {
+  return {
+    user: row.user,
+    endpoint: row.endpoint,
+    keys: { p256dh: row.p256dh, auth: row.auth },
+    userAgent: row.user_agent ?? null,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * SQLite-backed store for Web Push subscriptions.
+ *
+ * Subscriptions are unique per `endpoint` (the browser-issued push endpoint),
+ * so re-subscribing the same device upserts rather than duplicating — this is
+ * the per-device dedupe required by issue #619.
+ *
+ * @param {{ db: InstanceType<import('better-sqlite3')> }} params
+ */
+export function createSqlitePushSubscriptionRepository({ db }) {
+  const upsertStmt = db.prepare(`
+    INSERT INTO push_subscriptions (user, endpoint, p256dh, auth, user_agent, created_at)
+    VALUES (@user, @endpoint, @p256dh, @auth, @userAgent, @createdAt)
+    ON CONFLICT(endpoint) DO UPDATE SET
+      user       = excluded.user,
+      p256dh     = excluded.p256dh,
+      auth       = excluded.auth,
+      user_agent = excluded.user_agent
+  `);
+
+  const listByUserStmt = db.prepare(`SELECT * FROM push_subscriptions WHERE user = ?`);
+  const deleteByEndpointStmt = db.prepare(`DELETE FROM push_subscriptions WHERE endpoint = ?`);
+
+  return {
+    /**
+     * Insert or update a subscription, keyed by endpoint (dedupe per device).
+     * @param {{ user: string, endpoint: string, p256dh: string, auth: string, userAgent?: string|null, createdAt?: number }} sub
+     */
+    save({ user, endpoint, p256dh, auth, userAgent = null, createdAt = Date.now() }) {
+      upsertStmt.run({ user, endpoint, p256dh, auth, userAgent, createdAt });
+    },
+
+    /** All subscriptions for a user. @param {string} user */
+    listByUser(user) {
+      return listByUserStmt.all(user).map(rowToSubscription);
+    },
+
+    /** Remove a single subscription by endpoint. @returns {number} rows removed */
+    deleteByEndpoint(endpoint) {
+      return deleteByEndpointStmt.run(endpoint).changes;
+    },
+
+    /**
+     * Remove many subscriptions by endpoint in one transaction. Used to prune
+     * stale/expired subscriptions the push service reported as gone (410/404).
+     * @param {string[]} endpoints
+     * @returns {number} total rows removed
+     */
+    deleteByEndpoints(endpoints) {
+      let removed = 0;
+      const tx = db.transaction((eps) => {
+        for (const endpoint of eps) {
+          removed += deleteByEndpointStmt.run(endpoint).changes;
+        }
+      });
+      tx(endpoints);
+      return removed;
+    },
+  };
+}

--- a/backend/src/db/migrations/013_push_subscriptions.js
+++ b/backend/src/db/migrations/013_push_subscriptions.js
@@ -1,0 +1,18 @@
+export const version = 13;
+export const description = 'Add push_subscriptions table for Web Push notifications (issue #619)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS push_subscriptions (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      user       TEXT    NOT NULL,
+      endpoint   TEXT    NOT NULL UNIQUE,
+      p256dh     TEXT    NOT NULL,
+      auth       TEXT    NOT NULL,
+      user_agent TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user ON push_subscriptions(user);
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -53,6 +53,8 @@ import { createVariantRoutes } from './routes/variants.js';
 import { createVariantService } from './services/variantService.js';
 import { createCohortRoutes } from './routes/cohorts.js';
 import { createCohortService } from './services/cohortService.js';
+import { createPushRoutes } from './routes/push.js';
+import { createWebPushService } from './services/webPushService.js';
 import { requestTimeout } from './middleware/timeout.js';
 import { PoolSaturatedError } from './rpcPool.js';
 
@@ -241,6 +243,7 @@ export async function createApp(options = {}) {
   const referralRepository = dal.referrals;
   const variantRepository = dal.variants;
   const cohortRepository = dal.cohorts;
+  const pushSubscriptionRepository = dal.pushSubscriptions;
   const apiKeyRepository = dal.apiKeys;
   const failedJobRepository = options.failedJobRepository ?? dal.failedJobs;
   const allowlistRepository = dal.allowlists;
@@ -258,6 +261,15 @@ export async function createApp(options = {}) {
   });
   const variantService = createVariantService({ variantRepo: variantRepository });
   const cohortService = createCohortService({ cohortRepo: cohortRepository });
+  const webPushService = createWebPushService({
+    repository: pushSubscriptionRepository,
+    vapid: {
+      publicKey: process.env.VAPID_PUBLIC_KEY,
+      privateKey: process.env.VAPID_PRIVATE_KEY,
+      subject: process.env.VAPID_SUBJECT,
+    },
+    logger: log,
+  });
   const shortCacheTtlMs = normalizePositiveInteger(
     /** @type {any} */ (options.shortCacheTtlMs) ?? process.env.SHORT_CACHE_TTL_MS,
     DEFAULT_SHORT_CACHE_TTL_MS,
@@ -1600,6 +1612,13 @@ export async function createApp(options = {}) {
       campaignRepo: campaignRepository,
     });
     app.use(prefix, rateLimiter, requireApiKey, cohortRouter);
+
+    // Web Push subscription routes (Issue #619)
+    const pushRouter = createPushRoutes({
+      repository: pushSubscriptionRepository,
+      service: webPushService,
+    });
+    app.use(prefix, rateLimiter, requireApiKey, pushRouter);
   }
 
   registerApiRoutes(API_V1_PREFIX);

--- a/backend/src/routes/push.js
+++ b/backend/src/routes/push.js
@@ -1,0 +1,66 @@
+// @ts-check
+import express from 'express';
+
+function isValidSubscription(subscription) {
+  return Boolean(
+    subscription &&
+    typeof subscription.endpoint === 'string' &&
+    subscription.keys &&
+    typeof subscription.keys.p256dh === 'string' &&
+    typeof subscription.keys.auth === 'string',
+  );
+}
+
+/**
+ * Web Push subscription routes (issue #619).
+ *
+ * - `GET  /push/vapid-public-key` — the VAPID public key clients subscribe with.
+ * - `POST /push/subscribe`        — store a browser PushSubscription for a user.
+ * - `POST /push/unsubscribe`      — remove a subscription by endpoint.
+ *
+ * @param {Object} params
+ * @param {ReturnType<import('../dal/sqlitePushSubscriptionRepository.js').createSqlitePushSubscriptionRepository>} params.repository
+ * @param {ReturnType<import('../services/webPushService.js').createWebPushService>} params.service
+ */
+export function createPushRoutes({ repository, service }) {
+  const router = express.Router();
+
+  router.get('/push/vapid-public-key', (req, res) => {
+    const publicKey = service.getPublicKey();
+    if (!publicKey) {
+      return res.status(503).json({ error: 'push_not_configured' });
+    }
+    res.json({ publicKey });
+  });
+
+  router.post('/push/subscribe', (req, res) => {
+    const { user, subscription } = req.body ?? {};
+    if (!user || typeof user !== 'string') {
+      return res.status(400).json({ error: 'user_required' });
+    }
+    if (!isValidSubscription(subscription)) {
+      return res.status(400).json({ error: 'invalid_subscription' });
+    }
+
+    repository.save({
+      user,
+      endpoint: subscription.endpoint,
+      p256dh: subscription.keys.p256dh,
+      auth: subscription.keys.auth,
+      userAgent: req.get('user-agent') ?? null,
+    });
+
+    res.status(201).json({ ok: true });
+  });
+
+  router.post('/push/unsubscribe', (req, res) => {
+    const { endpoint } = req.body ?? {};
+    if (!endpoint || typeof endpoint !== 'string') {
+      return res.status(400).json({ error: 'endpoint_required' });
+    }
+    const removed = repository.deleteByEndpoint(endpoint);
+    res.json({ ok: true, removed });
+  });
+
+  return router;
+}

--- a/backend/src/services/webPushService.js
+++ b/backend/src/services/webPushService.js
@@ -1,0 +1,81 @@
+// @ts-check
+import webpush from 'web-push';
+
+/**
+ * Web Push (VAPID) delivery service for issue #619.
+ *
+ * Sends notifications for campaign-lifecycle events (credit available, ending
+ * soon, claim ready) to a user's subscribed devices and prunes subscriptions
+ * the push service reports as gone (HTTP 404/410). When VAPID keys are not
+ * configured the service is a no-op (`isConfigured() === false`) so the backend
+ * still boots and tests run without push secrets.
+ *
+ * @param {Object} params
+ * @param {ReturnType<import('../dal/sqlitePushSubscriptionRepository.js').createSqlitePushSubscriptionRepository>} params.repository
+ * @param {{ publicKey?: string, privateKey?: string, subject?: string }} [params.vapid]
+ * @param {Object} [params.logger]
+ * @param {(subscription: object, payload: string) => Promise<unknown>} [params.sender] - injectable for tests
+ */
+export function createWebPushService({ repository, vapid = {}, logger = console, sender }) {
+  const configured = Boolean(vapid.publicKey && vapid.privateKey);
+
+  if (configured && !sender) {
+    webpush.setVapidDetails(
+      vapid.subject || 'mailto:notifications@trivela.app',
+      /** @type {string} */ (vapid.publicKey),
+      /** @type {string} */ (vapid.privateKey),
+    );
+  }
+
+  const send =
+    sender || ((subscription, payload) => webpush.sendNotification(subscription, payload));
+
+  return {
+    /** Whether VAPID keys are configured (push enabled). */
+    isConfigured() {
+      return configured;
+    },
+
+    /** The VAPID public key clients need to subscribe, or null when disabled. */
+    getPublicKey() {
+      return configured ? vapid.publicKey : null;
+    },
+
+    /**
+     * Send a notification payload to every device a user is subscribed on.
+     * Stale subscriptions (404/410) are pruned. Other send errors are logged
+     * but do not abort the fan-out to the user's remaining devices.
+     *
+     * @param {string} user
+     * @param {object} payload - serialized to JSON and delivered to the SW
+     * @returns {Promise<{ sent: number, pruned: number, skipped?: boolean }>}
+     */
+    async sendToUser(user, payload) {
+      if (!configured) {
+        return { sent: 0, pruned: 0, skipped: true };
+      }
+
+      const subscriptions = repository.listByUser(user);
+      const body = JSON.stringify(payload);
+      const stale = [];
+      let sent = 0;
+
+      for (const sub of subscriptions) {
+        try {
+          await send({ endpoint: sub.endpoint, keys: sub.keys }, body);
+          sent += 1;
+        } catch (err) {
+          const status = err?.statusCode;
+          if (status === 404 || status === 410) {
+            stale.push(sub.endpoint);
+          } else {
+            logger.error?.(`webPush:send failed user=${user} status=${status ?? 'unknown'}`, err);
+          }
+        }
+      }
+
+      const pruned = stale.length > 0 ? repository.deleteByEndpoints(stale) : 0;
+      return { sent, pruned };
+    },
+  };
+}

--- a/backend/src/services/webPushService.test.js
+++ b/backend/src/services/webPushService.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createWebPushService } from './webPushService.js';
+
+function makeRepo(subs = []) {
+  const deleted = [];
+  return {
+    deleted,
+    listByUser() {
+      return subs;
+    },
+    deleteByEndpoints(endpoints) {
+      deleted.push(...endpoints);
+      return endpoints.length;
+    },
+  };
+}
+
+const sub = (endpoint) => ({ endpoint, keys: { p256dh: `p_${endpoint}`, auth: `a_${endpoint}` } });
+const VAPID = { publicKey: 'PUB', privateKey: 'PRIV', subject: 'mailto:test@trivela.app' };
+
+test('is a no-op when VAPID is not configured', async () => {
+  const service = createWebPushService({ repository: makeRepo([sub('e1')]) });
+  assert.equal(service.isConfigured(), false);
+  assert.equal(service.getPublicKey(), null);
+  assert.deepEqual(await service.sendToUser('alice', { title: 'hi' }), {
+    sent: 0,
+    pruned: 0,
+    skipped: true,
+  });
+});
+
+test('exposes the VAPID public key when configured', () => {
+  const service = createWebPushService({
+    repository: makeRepo(),
+    vapid: VAPID,
+    sender: async () => {},
+  });
+  assert.equal(service.isConfigured(), true);
+  assert.equal(service.getPublicKey(), 'PUB');
+});
+
+test('sends a notification to every subscribed device', async () => {
+  const calls = [];
+  const repo = makeRepo([sub('e1'), sub('e2')]);
+  const service = createWebPushService({
+    repository: repo,
+    vapid: VAPID,
+    sender: async (subscription, payload) =>
+      calls.push({ endpoint: subscription.endpoint, payload }),
+  });
+
+  const result = await service.sendToUser('alice', { title: 'Claim ready' });
+
+  assert.deepEqual(result, { sent: 2, pruned: 0 });
+  assert.deepEqual(
+    calls.map((c) => c.endpoint),
+    ['e1', 'e2'],
+  );
+  assert.equal(calls[0].payload, JSON.stringify({ title: 'Claim ready' }));
+});
+
+test('prunes subscriptions the push service reports as gone (410/404)', async () => {
+  const repo = makeRepo([sub('live'), sub('gone-410'), sub('gone-404')]);
+  const service = createWebPushService({
+    repository: repo,
+    vapid: VAPID,
+    sender: async (subscription) => {
+      if (subscription.endpoint === 'gone-410') throw { statusCode: 410 };
+      if (subscription.endpoint === 'gone-404') throw { statusCode: 404 };
+    },
+  });
+
+  const result = await service.sendToUser('alice', { title: 'hi' });
+
+  assert.deepEqual(result, { sent: 1, pruned: 2 });
+  assert.deepEqual(repo.deleted, ['gone-410', 'gone-404']);
+});
+
+test('a transient send error does not prune or abort the fan-out', async () => {
+  const repo = makeRepo([sub('e1'), sub('e2')]);
+  const service = createWebPushService({
+    repository: repo,
+    vapid: VAPID,
+    logger: { error() {} },
+    sender: async (subscription) => {
+      if (subscription.endpoint === 'e1') throw { statusCode: 500 };
+    },
+  });
+
+  const result = await service.sendToUser('alice', { title: 'hi' });
+
+  assert.deepEqual(result, { sent: 1, pruned: 0 });
+  assert.deepEqual(repo.deleted, [], 'a 500 is not treated as a dead subscription');
+});

--- a/frontend/public/push-sw.js
+++ b/frontend/public/push-sw.js
@@ -1,0 +1,43 @@
+/* global clients */
+// Web Push handlers for Trivela (issue #619).
+//
+// This file is imported into the Workbox-generated service worker via
+// vite.config.js (`workbox.importScripts: ['push-sw.js']`), so it runs in the
+// service-worker context. It renders incoming pushes as notifications and
+// focuses/opens the app when one is clicked.
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch {
+    payload = { title: 'Trivela', body: event.data ? event.data.text() : '' };
+  }
+
+  const title = payload.title || 'Trivela';
+  const options = {
+    body: payload.body || '',
+    icon: payload.icon || '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: payload.tag,
+    data: { url: payload.url || '/' },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(targetUrl) && 'focus' in client) {
+          return client.focus();
+        }
+      }
+      return clients.openWindow ? clients.openWindow(targetUrl) : undefined;
+    }),
+  );
+});

--- a/frontend/src/hooks/usePushNotifications.js
+++ b/frontend/src/hooks/usePushNotifications.js
@@ -1,0 +1,128 @@
+// React hook for Web Push subscription management (issue #619).
+//
+// Wraps the browser Push API: requests permission, subscribes via the VAPID
+// public key served by the backend, and registers/removes the subscription
+// through the `/push` endpoints. Degrades gracefully where push is unsupported.
+
+import { useCallback, useEffect, useState } from 'react';
+
+/** Convert a base64url VAPID key to the Uint8Array the Push API expects. */
+export function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+function pushSupported() {
+  return (
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    typeof window !== 'undefined' &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.user - account the subscription belongs to
+ * @param {string} [params.apiBase] - API prefix (default `/api/v1`)
+ * @param {typeof fetch} [params.fetchImpl] - injectable for tests
+ */
+export function usePushNotifications({ user, apiBase = '/api/v1', fetchImpl } = {}) {
+  const doFetch = fetchImpl || (typeof fetch !== 'undefined' ? fetch : null);
+  const supported = pushSupported();
+
+  const [permission, setPermission] = useState(() =>
+    supported ? Notification.permission : 'default',
+  );
+  const [subscribed, setSubscribed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Reflect any existing subscription on mount.
+  useEffect(() => {
+    if (!supported) return undefined;
+    let active = true;
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => {
+        if (active) setSubscribed(Boolean(sub));
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [supported]);
+
+  const subscribe = useCallback(async () => {
+    setError(null);
+    if (!supported || !doFetch) {
+      setError('unsupported');
+      return false;
+    }
+    setBusy(true);
+    try {
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+      if (perm !== 'granted') return false;
+
+      const reg = await navigator.serviceWorker.ready;
+      const keyRes = await doFetch(`${apiBase}/push/vapid-public-key`);
+      if (!keyRes.ok) throw new Error('vapid_key_unavailable');
+      const { publicKey } = await keyRes.json();
+
+      const subscription = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey),
+      });
+
+      const res = await doFetch(`${apiBase}/push/subscribe`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user, subscription: subscription.toJSON() }),
+      });
+      if (!res.ok) throw new Error('subscribe_failed');
+
+      setSubscribed(true);
+      return true;
+    } catch (err) {
+      setError(err.message || 'subscribe_error');
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }, [supported, doFetch, apiBase, user]);
+
+  const unsubscribe = useCallback(async () => {
+    setError(null);
+    if (!supported || !doFetch) return false;
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const subscription = await reg.pushManager.getSubscription();
+      if (subscription) {
+        await doFetch(`${apiBase}/push/unsubscribe`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        });
+        await subscription.unsubscribe();
+      }
+      setSubscribed(false);
+      return true;
+    } catch (err) {
+      setError(err.message || 'unsubscribe_error');
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }, [supported, doFetch, apiBase]);
+
+  return { supported, permission, subscribed, busy, error, subscribe, unsubscribe };
+}

--- a/frontend/src/hooks/usePushNotifications.test.jsx
+++ b/frontend/src/hooks/usePushNotifications.test.jsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// Tests for the usePushNotifications hook (issue #619).
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { usePushNotifications, urlBase64ToUint8Array } from './usePushNotifications';
+
+function installPushEnv({ existingSub = null, requestResult = 'granted' } = {}) {
+  const subscription = {
+    endpoint: 'https://push.example/abc',
+    toJSON: () => ({
+      endpoint: 'https://push.example/abc',
+      keys: { p256dh: 'p256', auth: 'auth' },
+    }),
+    unsubscribe: vi.fn(async () => true),
+  };
+  const pushManager = {
+    getSubscription: vi.fn(async () => existingSub),
+    subscribe: vi.fn(async () => subscription),
+  };
+  Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+    configurable: true,
+    value: { ready: Promise.resolve({ pushManager }) },
+  });
+  globalThis.PushManager = function PushManager() {};
+  globalThis.Notification = {
+    permission: 'default',
+    requestPermission: vi.fn(async () => requestResult),
+  };
+  return { subscription, pushManager };
+}
+
+function makeFetch() {
+  return vi.fn(async (url) => {
+    if (String(url).endsWith('/push/vapid-public-key')) {
+      return {
+        ok: true,
+        json: async () => ({
+          publicKey:
+            'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8',
+        }),
+      };
+    }
+    return { ok: true, json: async () => ({ ok: true }) };
+  });
+}
+
+afterEach(() => {
+  delete globalThis.PushManager;
+  delete globalThis.Notification;
+  delete globalThis.navigator.serviceWorker;
+  vi.restoreAllMocks();
+});
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodes a base64url VAPID key to bytes', () => {
+    const bytes = urlBase64ToUint8Array('AAAA');
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBe(3);
+  });
+});
+
+describe('usePushNotifications', () => {
+  it('reports unsupported when the Push API is missing', () => {
+    const { result } = renderHook(() => usePushNotifications({ user: 'alice' }));
+    expect(result.current.supported).toBe(false);
+  });
+
+  it('subscribes: requests permission, fetches the key, and posts the subscription', async () => {
+    const { pushManager } = installPushEnv();
+    const fetchImpl = makeFetch();
+    const { result } = renderHook(() => usePushNotifications({ user: 'alice', fetchImpl }));
+
+    expect(result.current.supported).toBe(true);
+
+    let ok;
+    await act(async () => {
+      ok = await result.current.subscribe();
+    });
+
+    expect(ok).toBe(true);
+    expect(pushManager.subscribe).toHaveBeenCalledOnce();
+    const postCall = fetchImpl.mock.calls.find((c) => String(c[0]).endsWith('/push/subscribe'));
+    expect(postCall).toBeTruthy();
+    expect(JSON.parse(postCall[1].body)).toMatchObject({
+      user: 'alice',
+      subscription: { endpoint: 'https://push.example/abc' },
+    });
+    await waitFor(() => expect(result.current.subscribed).toBe(true));
+  });
+
+  it('does not subscribe when permission is denied', async () => {
+    installPushEnv({ requestResult: 'denied' });
+    const fetchImpl = makeFetch();
+    const { result } = renderHook(() => usePushNotifications({ user: 'alice', fetchImpl }));
+
+    let ok;
+    await act(async () => {
+      ok = await result.current.subscribe();
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.subscribed).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe removes the subscription server-side and locally', async () => {
+    const { subscription } = installPushEnv({ existingSub: undefined });
+    const pm = (await globalThis.navigator.serviceWorker.ready).pushManager;
+    pm.getSubscription = vi.fn(async () => subscription);
+    const fetchImpl = makeFetch();
+    const { result } = renderHook(() => usePushNotifications({ user: 'alice', fetchImpl }));
+
+    await act(async () => {
+      await result.current.unsubscribe();
+    });
+
+    const unsubCall = fetchImpl.mock.calls.find((c) => String(c[0]).endsWith('/push/unsubscribe'));
+    expect(unsubCall).toBeTruthy();
+    expect(JSON.parse(unsubCall[1].body)).toEqual({ endpoint: 'https://push.example/abc' });
+    expect(subscription.unsubscribe).toHaveBeenCalledOnce();
+    await waitFor(() => expect(result.current.subscribed).toBe(false));
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -38,6 +38,8 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         maximumFileSizeToCacheInBytes: 3_000_000,
+        // Web Push handlers (issue #619) — imported into the generated SW.
+        importScripts: ['push-sw.js'],
         runtimeCaching: [
           {
             urlPattern: ({ request }) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "supertest": "^7.0.0",
         "swagger-ui-express": "^5.0.1",
         "validator": "^13.12.0",
+        "web-push": "^3.6.7",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -7112,7 +7113,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7373,6 +7373,18 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -7806,6 +7818,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -7937,6 +7955,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9017,6 +9041,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -10632,6 +10665,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -10677,7 +10719,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11844,6 +11885,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12125,6 +12187,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "5.1.9",
@@ -14300,15 +14368,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
-    },
-    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-      "extraneous": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",
@@ -20172,6 +20231,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {


### PR DESCRIPTION
Closes #619

Adds VAPID **Web Push** so subscribed users get notifications for key campaign-lifecycle events (credit available, ending soon, claim ready), with unsubscribe and dead-subscription pruning.

## Backend
- **Subscription store** — `push_subscriptions` table (migration `013`) + `sqlitePushSubscriptionRepository`, **deduped per endpoint** (re-subscribing a device upserts).
- **`webPushService`** — VAPID send-to-user fan-out across a user's devices; **prunes subscriptions the push service reports gone (404/410)**. No-op when VAPID keys are unset, so the backend boots and tests run without push secrets.
- **Routes** (`/push`, wired into `index.js` with the standard rate-limit + API-key middleware):
  - `GET /push/vapid-public-key`
  - `POST /push/subscribe`
  - `POST /push/unsubscribe`
- `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` documented in `backend/.env.example` (generate with `npx web-push generate-vapid-keys`).

## Frontend
- **`public/push-sw.js`** — `push` + `notificationclick` handlers, imported into the Workbox-generated service worker via `vite.config.js` (`workbox.importScripts`).
- **`usePushNotifications` hook** — requests permission, fetches the VAPID key, subscribes via `PushManager`, registers/removes the subscription through `/push`; degrades gracefully where the Push API is unsupported.

## Edge cases handled
- Permission denied → no subscription, surfaced via hook state.
- Stale/expired subscriptions → pruned on 410/404.
- Duplicate devices → deduped per endpoint.
- Transient send errors (5xx) → logged, do not prune or abort the fan-out.

## Testing (run locally, green)
- **Backend:** `npm run test:backend` → **136 pass** (5 new `webPushService` tests: send, prune-on-410, dedupe-disabled, transient error); `typecheck` clean; prettier clean.
- **Frontend:** `vitest` → **5 new `usePushNotifications` tests pass**; `eslint .` clean; `vite build` succeeds (Workbox SW generated with the push handlers); prettier clean.

## Notes / follow-ups
- Send-on-event triggers are surfaced via `webPushService.sendToUser(...)`; hooking it to specific indexer/campaign events and the notification-preferences screen (NEW-096) and in-app center (NEW-094) are the natural next integrations.
