### PR TITLE
feat: public participant achievement profile page (#605)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
 const About = lazy(() => import('./About'));
 const TransactionHistory = lazy(() => import('./TransactionHistory'));
 const EmbedCampaign = lazy(() => import('./pages/EmbedCampaign'));
+const PublicProfile = lazy(() => import('./pages/PublicProfile'));
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
 import { getRuntimeConfig, initializeRuntimeConfig, setRuntimeStellarNetwork } from './config';
 import {
@@ -305,6 +306,7 @@ export default function App() {
             }
           />
           <Route path="/embed/campaign/:id" element={<EmbedCampaign />} />
+          <Route path="/u/:address" element={<PublicProfile />} />
         </Routes>
       </Suspense>
       <WalletModal

--- a/frontend/src/__tests__/PublicProfile.test.jsx
+++ b/frontend/src/__tests__/PublicProfile.test.jsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import PublicProfile from '../pages/PublicProfile';
+
+vi.mock('../config', () => ({
+  apiUrl: (path) => `http://localhost:3001${path}`,
+  SITE_URL: 'https://trivela.app',
+  DEFAULT_OG_IMAGE: '/og-default.png',
+}));
+
+// Capture PageMeta props for OG-tag assertions without relying on jsdom's
+// head manipulation, which react-helmet-async doesn't flush synchronously.
+const capturedMeta = { current: null };
+vi.mock('../components/PageMeta', () => ({
+  default: (props) => {
+    capturedMeta.current = props;
+    return null;
+  },
+}));
+
+const TEST_ADDRESS = 'GABC1234DEFG5678HIJK9012LMNO3456PQRS7890TUVW1234XYZ56789ABC';
+
+function renderProfile(address = TEST_ADDRESS) {
+  capturedMeta.current = null;
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={[`/u/${address}`]}>
+        <Routes>
+          <Route path="/u/:address" element={<PublicProfile />} />
+          <Route path="/campaign/:id" element={<div>Campaign</div>} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>,
+  );
+}
+
+const mockPublicProfile = {
+  address: TEST_ADDRESS,
+  isPublic: true,
+  handle: 'stellar-pioneer',
+  reputation: 1250,
+  streak: { current: 7, longest: 14 },
+  joinedAt: '2025-03-01T00:00:00.000Z',
+  badges: [
+    { id: 'early-adopter', name: 'Early Adopter', description: 'Joined in the first wave' },
+    { id: 'streak-7', name: '7-Day Streak', description: 'Active 7 days in a row' },
+  ],
+  campaigns: [
+    { id: 1, name: 'Alpha Launch', joinedAt: '2025-03-15T00:00:00.000Z', rewardEarned: 500 },
+    { id: 2, name: 'Beta Rewards', joinedAt: '2025-04-01T00:00:00.000Z', rewardEarned: 300 },
+  ],
+};
+
+describe('PublicProfile', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockPublicProfile),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  it('shows a loading indicator while fetching', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {})),
+    );
+    renderProfile();
+    expect(screen.getByTestId('profile-loading')).toBeInTheDocument();
+  });
+
+  // ── Full public profile ────────────────────────────────────────────────────
+
+  it('renders the profile view after a successful fetch', async () => {
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-view')).toBeInTheDocument());
+  });
+
+  it('renders the participant handle', async () => {
+    renderProfile();
+    await waitFor(() => expect(screen.getByText('stellar-pioneer')).toBeInTheDocument());
+  });
+
+  it('renders reputation and streak stats', async () => {
+    renderProfile();
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-stats')).toBeInTheDocument();
+      expect(screen.getByText('1250')).toBeInTheDocument();
+    });
+  });
+
+  it('renders badge chips for each badge', async () => {
+    renderProfile();
+    await waitFor(() => {
+      const badges = screen.getByTestId('profile-badges');
+      expect(badges).toBeInTheDocument();
+      expect(screen.getByText('Early Adopter')).toBeInTheDocument();
+      expect(screen.getByText('7-Day Streak')).toBeInTheDocument();
+    });
+  });
+
+  it('renders campaign history rows', async () => {
+    renderProfile();
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-campaigns')).toBeInTheDocument();
+      expect(screen.getByText('Alpha Launch')).toBeInTheDocument();
+      expect(screen.getByText('Beta Rewards')).toBeInTheDocument();
+    });
+  });
+
+  // ── OG meta tags ──────────────────────────────────────────────────────────
+
+  it('passes the participant handle and stats to PageMeta for OG sharing', async () => {
+    renderProfile();
+    await waitFor(() => screen.getByTestId('profile-view'));
+    expect(capturedMeta.current?.title).toMatch(/stellar-pioneer/i);
+    expect(capturedMeta.current?.description).toMatch(/reputation/i);
+    expect(capturedMeta.current?.path).toBe(`/u/${TEST_ADDRESS}`);
+    expect(capturedMeta.current?.type).toBe('profile');
+  });
+
+  // ── Privacy opt-out ───────────────────────────────────────────────────────
+
+  it('shows a private profile card when isPublic is false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...mockPublicProfile, isPublic: false }),
+      }),
+    );
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-private')).toBeInTheDocument());
+    expect(screen.getByText(/private/i)).toBeInTheDocument();
+  });
+
+  it('does not render badges or history for a private profile', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ...mockPublicProfile, isPublic: false }),
+      }),
+    );
+    renderProfile();
+    await waitFor(() => screen.getByTestId('profile-private'));
+    expect(screen.queryByTestId('profile-badges')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('profile-campaigns')).not.toBeInTheDocument();
+  });
+
+  // ── 404 / not-found ───────────────────────────────────────────────────────
+
+  it('shows not-found state when the API returns 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: 'Not found' }),
+      }),
+    );
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-not-found')).toBeInTheDocument());
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────────────
+
+  it('shows an empty state when the participant has no campaigns or badges', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            ...mockPublicProfile,
+            badges: [],
+            campaigns: [],
+          }),
+      }),
+    );
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-empty')).toBeInTheDocument());
+  });
+
+  // ── Error state ────────────────────────────────────────────────────────────
+
+  it('shows an error state when the fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    renderProfile();
+    await waitFor(() => expect(screen.getByTestId('profile-error')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/PublicProfile.jsx
+++ b/frontend/src/pages/PublicProfile.jsx
@@ -1,0 +1,298 @@
+/**
+ * Public participant achievement profile — /u/:address (#605)
+ *
+ * Renders badges, streaks, reputation, and campaign history for a
+ * Trivela participant. Server-side OG tags (via PageMeta) make shared
+ * links show a rich preview card.
+ *
+ * Privacy model:
+ *   • isPublic === false  → minimal anonymous card (no badge/history leak)
+ *   • No profile found    → graceful 404 empty state
+ *   • Profile exists but empty campaigns/badges → graceful empty state
+ */
+
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import PageMeta from '../components/PageMeta';
+import { apiUrl, SITE_URL } from '../config';
+
+// ── Badge emoji map — extended as NEW-071 types grow ────────────────────────
+const BADGE_ICONS = {
+  'early-adopter': '🌱',
+  'top-contributor': '🏆',
+  'streak-7': '🔥',
+  'streak-30': '⚡',
+  soulbound: '💎',
+  'campaign-winner': '🥇',
+  verified: '✅',
+};
+
+function badgeIcon(id) {
+  return BADGE_ICONS[id] ?? '🎖️';
+}
+
+function shortenAddress(addr) {
+  if (!addr || addr.length < 10) return addr ?? '';
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function StatCard({ label, value, sub }) {
+  return (
+    <div className="profile-stat-card">
+      <span className="profile-stat-value">{value}</span>
+      <span className="profile-stat-label">{label}</span>
+      {sub && <span className="profile-stat-sub">{sub}</span>}
+    </div>
+  );
+}
+
+function BadgeChip({ badge }) {
+  return (
+    <div className="profile-badge" title={badge.description ?? badge.name}>
+      <span className="profile-badge-icon" aria-hidden="true">
+        {badgeIcon(badge.id)}
+      </span>
+      <span className="profile-badge-name">{badge.name}</span>
+    </div>
+  );
+}
+
+function CampaignRow({ campaign }) {
+  const joined = campaign.joinedAt
+    ? new Date(campaign.joinedAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : '—';
+
+  return (
+    <Link to={`/campaign/${campaign.id}`} className="profile-campaign-row">
+      <span className="profile-campaign-name">{campaign.name}</span>
+      <span className="profile-campaign-meta">
+        {joined}
+        {campaign.rewardEarned != null && (
+          <span className="profile-campaign-reward">+{campaign.rewardEarned} pts</span>
+        )}
+      </span>
+    </Link>
+  );
+}
+
+// ── Private / anonymous view ─────────────────────────────────────────────────
+
+function PrivateProfile({ address }) {
+  return (
+    <div className="profile-private" data-testid="profile-private">
+      <span className="profile-private-icon" aria-hidden="true">
+        🔒
+      </span>
+      <h2>This profile is private</h2>
+      <p>
+        <strong>{shortenAddress(address)}</strong> has not enabled public visibility.
+      </p>
+      <p className="profile-private-hint">
+        If this is your wallet, you can make your profile public from your dashboard.
+      </p>
+    </div>
+  );
+}
+
+// ── Empty / no-activity view ─────────────────────────────────────────────────
+
+function EmptyProfile({ address }) {
+  return (
+    <div className="profile-empty" data-testid="profile-empty">
+      <span className="profile-empty-icon" aria-hidden="true">
+        🌑
+      </span>
+      <h2>No activity yet</h2>
+      <p>
+        <strong>{shortenAddress(address)}</strong> hasn&apos;t joined any campaigns yet.
+      </p>
+      <Link to="/" className="btn btn-primary">
+        Browse campaigns
+      </Link>
+    </div>
+  );
+}
+
+// ── Not-found view ────────────────────────────────────────────────────────────
+
+function NotFound({ address }) {
+  return (
+    <div className="profile-not-found" data-testid="profile-not-found">
+      <span className="profile-not-found-icon" aria-hidden="true">
+        🔍
+      </span>
+      <h2>Profile not found</h2>
+      <p>No participant found for address {shortenAddress(address)}.</p>
+      <Link to="/" className="btn btn-primary">
+        Back to campaigns
+      </Link>
+    </div>
+  );
+}
+
+// ── Main profile view ─────────────────────────────────────────────────────────
+
+function ProfileView({ profile, address }) {
+  const hasActivity = (profile.campaigns?.length ?? 0) > 0 || (profile.badges?.length ?? 0) > 0;
+
+  if (!hasActivity) return <EmptyProfile address={address} />;
+
+  const displayName = profile.handle ?? shortenAddress(address);
+  const joinedYear = profile.joinedAt ? new Date(profile.joinedAt).getFullYear() : null;
+
+  return (
+    <div className="profile-view" data-testid="profile-view">
+      {/* Avatar + identity */}
+      <div className="profile-identity">
+        <div className="profile-avatar" aria-hidden="true">
+          {displayName.slice(0, 2).toUpperCase()}
+        </div>
+        <div className="profile-identity-text">
+          <h1 className="profile-handle">{displayName}</h1>
+          {profile.handle && (
+            <p className="profile-address-sub" title={address}>
+              {shortenAddress(address)}
+            </p>
+          )}
+          {joinedYear && <p className="profile-joined">Member since {joinedYear}</p>}
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="profile-stats" data-testid="profile-stats">
+        <StatCard label="Reputation" value={profile.reputation ?? 0} />
+        <StatCard
+          label="Current streak"
+          value={`${profile.streak?.current ?? 0} 🔥`}
+          sub={`Longest: ${profile.streak?.longest ?? 0}`}
+        />
+        <StatCard label="Campaigns" value={profile.campaigns?.length ?? 0} sub="participated" />
+        <StatCard label="Badges" value={profile.badges?.length ?? 0} />
+      </div>
+
+      {/* Badges */}
+      {profile.badges?.length > 0 && (
+        <section className="profile-section" aria-label="Badges">
+          <h2 className="profile-section-title">Badges &amp; Achievements</h2>
+          <div className="profile-badges-grid" data-testid="profile-badges">
+            {profile.badges.map((b) => (
+              <BadgeChip key={b.id} badge={b} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Campaign history */}
+      {profile.campaigns?.length > 0 && (
+        <section className="profile-section" aria-label="Campaign history">
+          <h2 className="profile-section-title">Campaign History</h2>
+          <div className="profile-campaigns" data-testid="profile-campaigns">
+            {profile.campaigns.map((c) => (
+              <CampaignRow key={c.id} campaign={c} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function PublicProfile() {
+  const { address } = useParams();
+  const [status, setStatus] = useState('loading'); // loading | ok | private | notfound | error
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    if (!address) return;
+
+    let cancelled = false;
+    setStatus('loading');
+    setProfile(null);
+
+    fetch(apiUrl(`/api/v1/participants/${encodeURIComponent(address)}/profile`))
+      .then((res) => {
+        if (res.status === 404) return { _notFound: true };
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        if (data._notFound) {
+          setStatus('notfound');
+        } else if (data.isPublic === false) {
+          setStatus('private');
+          setProfile(data);
+        } else {
+          setStatus('ok');
+          setProfile(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  // ── OG meta ────────────────────────────────────────────────────────────────
+  const isPublicProfile = status === 'ok' && profile;
+  const metaTitle = isPublicProfile
+    ? `${profile.handle ?? shortenAddress(address)} on Trivela`
+    : 'Participant Profile — Trivela';
+  const metaDescription = isPublicProfile
+    ? `${profile.handle ?? shortenAddress(address)} has earned ${profile.reputation ?? 0} reputation, ${profile.badges?.length ?? 0} badge${(profile.badges?.length ?? 0) !== 1 ? 's' : ''}, and joined ${profile.campaigns?.length ?? 0} campaign${(profile.campaigns?.length ?? 0) !== 1 ? 's' : ''} on Trivela.`
+    : 'View participant achievements, badges, and campaign history on Trivela.';
+
+  return (
+    <>
+      <PageMeta
+        title={metaTitle}
+        description={metaDescription}
+        path={`/u/${address}`}
+        type="profile"
+      />
+
+      <div className="profile-page">
+        <header className="profile-page-header">
+          <Link to="/" className="profile-back-link" aria-label="Back to campaigns">
+            ← Trivela
+          </Link>
+        </header>
+
+        <main className="profile-main" aria-live="polite">
+          {status === 'loading' && (
+            <div className="profile-loading" data-testid="profile-loading">
+              <div className="spinner" aria-label="Loading profile…" />
+              <p>Loading profile…</p>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div className="profile-error" data-testid="profile-error">
+              <p>Failed to load profile. Please try again.</p>
+              <button className="btn btn-secondary" onClick={() => window.location.reload()}>
+                Retry
+              </button>
+            </div>
+          )}
+
+          {status === 'notfound' && <NotFound address={address} />}
+
+          {status === 'private' && <PrivateProfile address={address} />}
+
+          {status === 'ok' && profile && <ProfileView profile={profile} address={address} />}
+        </main>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the public shareable achievement profile at `/u/:address` as described in issue #605.

- **New route `/u/:address`** — lazy-loaded via React Router, registered alongside existing routes in `App.jsx`
- **`frontend/src/pages/PublicProfile.jsx`** — single page component with five exhaustive states:
  - **Loading** — spinner while API call is in-flight
  - **Full profile** — displays avatar initials, reputation score, current/longest streak, badge grid, and campaign history rows; each campaign row links to `/campaign/:id`
  - **Privacy opt-out** (`isPublic: false`) — shows a minimal anonymous card with no badge or history leak; prompts the participant to enable public visibility from their dashboard
  - **Empty state** — participant exists but has no campaign activity or badges yet; links back to campaign browser
  - **404 / not-found** — address has no record; graceful fallback with back-navigation
- **OG / Twitter meta tags** — uses the existing `PageMeta` component (react-helmet-async) to populate `og:title`, `og:description`, `og:url`, and `twitter:card` from live profile data so shared links render rich preview cards
- **`frontend/src/__tests__/PublicProfile.test.jsx`** — 12 tests covering all states, OG meta prop assertions, privacy enforcement, empty-state detection, and error handling

## API contract assumed

`GET /api/v1/participants/:address/profile` returns:

```json
{
  "address": "G…",
  "isPublic": true,
  "handle": "optional-display-name",
  "reputation": 1250,
  "streak": { "current": 7, "longest": 14 },
  "joinedAt": "2025-03-01T00:00:00.000Z",
  "badges": [
    { "id": "early-adopter", "name": "Early Adopter", "description": "…" }
  ],
  "campaigns": [
    { "id": 1, "name": "Alpha Launch", "joinedAt": "…", "rewardEarned": 500 }
  ]
}
```

Returns `404` when no participant record exists. Returns `isPublic: false` when the participant has opted out of public visibility.

## Test plan

- [ ] All 88 frontend Vitest tests pass (`npx vitest run`)
- [ ] `npx prettier --check .` passes (no formatting issues)
- [ ] Navigate to `/u/<valid-address>` — profile renders with badges and campaigns
- [ ] Navigate to `/u/<private-address>` — private card shown, no data leaked
- [ ] Navigate to `/u/<unknown-address>` — 404 card shown
- [ ] Share a profile URL — OG preview card shows participant handle and stats
- [ ] Address with no activity shows empty-state with "Browse campaigns" CTA

Closes #605