### PR TITLE
feat: public campaign discovery marketplace + SEO landing pages (#654)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,9 @@
 # Server Configuration
 PORT=3001
 
+# Public site URL — used by /sitemap.xml for absolute URLs (no trailing slash)
+# SITE_URL=https://trivela.example.com
+
 # Database backend (issue #284).
 #
 # - Unset / not starting with `postgres://` -> SQLite (better-sqlite3),

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1684,8 +1684,7 @@ export async function createApp(options = {}) {
   // Dynamic sitemap.xml for SEO — lists all public (non-hidden, active) campaign pages
   app.get('/sitemap.xml', rateLimiter, (req, res) => {
     const siteUrl =
-      (process.env.SITE_URL || '').replace(/\/+$/, '') ||
-      `${req.protocol}://${req.get('host')}`;
+      (process.env.SITE_URL || '').replace(/\/+$/, '') || `${req.protocol}://${req.get('host')}`;
 
     const staticPaths = ['/', '/explore', '/about'];
     const campaigns = campaignRepository.list({ active: true });

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -804,6 +804,32 @@ export async function createApp(options = {}) {
       expiresAt: Date.now() + shortCacheTtlMs,
       payload,
     });
+    res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
+    return res.set('x-cache', 'MISS').json(payload);
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function getTrendingCampaigns(req, res) {
+    const limitRaw = Number.parseInt(String(req.query.limit ?? '6'), 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 && limitRaw <= 50 ? limitRaw : 6;
+
+    const cacheKey = `trending:${limit}`;
+    const cached = shortCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
+      return res.set('x-cache', 'HIT').json(cached.payload);
+    }
+
+    const all = campaignRepository.list({
+      active: true,
+      sort: 'reward_per_action',
+      order: 'desc',
+    });
+    const data = all.slice(0, limit);
+    const payload = { data, total: data.length };
+
+    shortCache.set(cacheKey, { expiresAt: Date.now() + shortCacheTtlMs, payload });
+    res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
     return res.set('x-cache', 'MISS').json(payload);
   }
 
@@ -1437,6 +1463,7 @@ export async function createApp(options = {}) {
     app.get(`${prefix}/campaigns`, rateLimiter, listCampaigns);
     app.get(`${prefix}/categories`, rateLimiter, listCategories);
     app.get(`${prefix}/tags`, rateLimiter, listTags);
+    app.get(`${prefix}/campaigns/trending`, rateLimiter, getTrendingCampaigns);
     app.get(`${prefix}/campaigns/by-slug/:slug`, rateLimiter, getCampaignBySlug);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
     app.get(`${prefix}/campaigns/:id/stats`, rateLimiter, getCampaignStats);
@@ -1653,6 +1680,34 @@ export async function createApp(options = {}) {
 
   registerApiRoutes(API_V1_PREFIX);
   registerApiRoutes(LEGACY_API_PREFIX);
+
+  // Dynamic sitemap.xml for SEO — lists all public (non-hidden, active) campaign pages
+  app.get('/sitemap.xml', rateLimiter, (req, res) => {
+    const siteUrl =
+      (process.env.SITE_URL || '').replace(/\/+$/, '') ||
+      `${req.protocol}://${req.get('host')}`;
+
+    const staticPaths = ['/', '/explore', '/about'];
+    const campaigns = campaignRepository.list({ active: true });
+
+    const urlEntries = [
+      ...staticPaths.map(
+        (p) =>
+          `<url><loc>${siteUrl}${p}</loc><changefreq>daily</changefreq><priority>${p === '/' || p === '/explore' ? '1.0' : '0.7'}</priority></url>`,
+      ),
+      ...campaigns.map(
+        (c) =>
+          `<url><loc>${siteUrl}/campaign/${encodeURIComponent(c.id)}</loc><lastmod>${c.updatedAt ? new Date(c.updatedAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>`,
+      ),
+    ];
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlEntries.join('\n')}\n</urlset>`;
+
+    res
+      .set('Content-Type', 'application/xml; charset=utf-8')
+      .set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+      .send(xml);
+  });
 
   // Central error handler — must be registered after all routes
   app.use(errorHandler);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import RequireAdmin from './components/RequireAdmin';
 
 // Route-level lazy loading — each chunk is fetched only when the user
 // navigates to that route, keeping the initial bundle small.
+const Explore = lazy(() => import('./Explore'));
 const CampaignDetail = lazy(() => import('./CampaignDetail'));
 const CampaignLeaderboard = lazy(() => import('./CampaignLeaderboard'));
 const CampaignAnalytics = lazy(() => import('./CampaignAnalytics'));
@@ -182,6 +183,23 @@ export default function App() {
                 onConnectWallet={openWalletModal}
                 onDisconnectWallet={disconnectWallet}
                 onRefreshPoints={() => loadWalletBalance(walletAddress)}
+              />
+            }
+          />
+          <Route
+            path="/explore"
+            element={
+              <Explore
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
               />
             }
           />

--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -96,6 +96,36 @@ export default function CampaignDetail({
 
   const campaignImage = campaign?.imageUrl || DEFAULT_OG_IMAGE;
 
+  const campaignJsonLd = campaign
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: campaign.name,
+        description: campaign.description || '',
+        url: `${window.location.origin}/campaign/${id}`,
+        image: campaign.imageUrl || undefined,
+        startDate: campaign.startDate || undefined,
+        endDate: campaign.endDate || undefined,
+        eventStatus: campaign.active
+          ? 'https://schema.org/EventScheduled'
+          : 'https://schema.org/EventCancelled',
+        organizer: {
+          '@type': 'Organization',
+          name: 'Trivela',
+          url: window.location.origin,
+        },
+        offers: {
+          '@type': 'Offer',
+          name: `${campaign.rewardPerAction ?? 0} reward points per action`,
+          price: '0',
+          priceCurrency: 'USD',
+          availability: campaign.active
+            ? 'https://schema.org/InStock'
+            : 'https://schema.org/SoldOut',
+        },
+      }
+    : null;
+
   return (
     <div className="campaign-detail-page">
       <PageMeta
@@ -106,6 +136,7 @@ export default function CampaignDetail({
         }
         path={`/campaign/${id}`}
         image={campaignImage}
+        jsonLd={campaignJsonLd}
       />
       <Header
         theme={theme}

--- a/frontend/src/Explore.css
+++ b/frontend/src/Explore.css
@@ -1,0 +1,185 @@
+.explore-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: var(--color-bg, #071018);
+  color: var(--color-text, #e2e8f0);
+}
+
+.explore-main {
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────────────── */
+
+.explore-hero {
+  text-align: center;
+  padding: 3rem 1rem 1rem;
+}
+
+.explore-hero-title {
+  font-size: clamp(1.75rem, 5vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+  background: linear-gradient(135deg, #e2e8f0 0%, #7dd3fc 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.explore-hero-subtitle {
+  font-size: 1.1rem;
+  color: var(--color-text-secondary, #94a3b8);
+  max-width: 560px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ── Rails ────────────────────────────────────────────────────────────────── */
+
+.explore-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.explore-rail-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--color-text, #e2e8f0);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.explore-rail-title::before {
+  content: '';
+  display: inline-block;
+  width: 3px;
+  height: 1.1em;
+  background: var(--color-accent, #38bdf8);
+  border-radius: 2px;
+}
+
+.explore-rail-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.explore-rail-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 0;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.explore-rail-empty {
+  color: var(--color-text-secondary, #94a3b8);
+  font-size: 0.9rem;
+  padding: 0.5rem 0;
+}
+
+/* ── All Campaigns section ────────────────────────────────────────────────── */
+
+.explore-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.explore-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.explore-section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text, #e2e8f0);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.explore-section-title::before {
+  content: '';
+  display: inline-block;
+  width: 3px;
+  height: 1.1em;
+  background: var(--color-accent, #38bdf8);
+  border-radius: 2px;
+}
+
+.explore-result-count {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #94a3b8);
+  margin: 0;
+}
+
+/* ── Category chip ────────────────────────────────────────────────────────── */
+
+.explore-active-category {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.explore-category-tag {
+  font-size: 0.875rem;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  color: #7dd3fc;
+}
+
+.explore-category-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #94a3b8);
+  padding: 0;
+  text-decoration: underline;
+}
+
+.explore-category-clear:hover {
+  color: var(--color-text, #e2e8f0);
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .explore-main {
+    padding: 1.5rem 1rem 3rem;
+    gap: 2rem;
+  }
+
+  .explore-hero {
+    padding: 1.5rem 0 0;
+  }
+
+  .explore-section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/Explore.jsx
+++ b/frontend/src/Explore.jsx
@@ -1,0 +1,402 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SITE_URL } from './config';
+import { apiClient } from './lib/apiClient';
+import Header from './components/Header';
+import CampaignCard from './components/CampaignCard';
+import CampaignFilters, { sortKeyToApiParams } from './components/CampaignFilters';
+import EmptyState from './components/EmptyState';
+import PageMeta from './components/PageMeta';
+import { logSafeEvent } from './lib/safeAnalytics';
+import './Explore.css';
+
+const CAMPAIGNS_PER_PAGE = 9;
+const RAIL_LIMIT = 6;
+
+const VALID_SORT_KEYS = new Set(['newest', 'oldest', 'name_asc', 'name_desc', 'reward_desc']);
+
+function normalizeSortKey(raw) {
+  return VALID_SORT_KEYS.has(raw) ? raw : 'newest';
+}
+
+function getFallbackPagination(items, page) {
+  return {
+    total: items.length,
+    count: items.length,
+    page,
+    limit: CAMPAIGNS_PER_PAGE,
+    totalPages: items.length > 0 ? 1 : 0,
+    hasPreviousPage: page > 1,
+    hasNextPage: false,
+    previousPage: page > 1 ? page - 1 : null,
+    nextPage: null,
+  };
+}
+
+function CampaignRail({ title, campaigns, isLoading, emptyText }) {
+  if (isLoading) {
+    return (
+      <div className="explore-rail">
+        <h2 className="explore-rail-title">{title}</h2>
+        <div className="explore-rail-loading" role="status">
+          <span className="spinner" aria-hidden="true" />
+          <span className="sr-only">Loading…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!campaigns.length) return null;
+
+  return (
+    <div className="explore-rail">
+      <h2 className="explore-rail-title">{title}</h2>
+      <ul className="explore-rail-grid">
+        {campaigns.map((campaign) => (
+          <li key={campaign.id}>
+            <CampaignCard campaign={campaign} />
+          </li>
+        ))}
+      </ul>
+      {emptyText && campaigns.length === 0 && (
+        <p className="explore-rail-empty">{emptyText}</p>
+      )}
+    </div>
+  );
+}
+
+export default function Explore({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const initialPage = (() => {
+    const raw = Number.parseInt(searchParams.get('page') ?? '', 10);
+    return Number.isFinite(raw) && raw > 0 ? raw : 1;
+  })();
+  const initialQuery = searchParams.get('q') ?? '';
+  const initialActiveOnly = searchParams.get('active') === 'true';
+  const initialSortKey = normalizeSortKey(searchParams.get('sortKey') ?? 'newest');
+  const initialCategory = searchParams.get('category') ?? '';
+
+  const [campaigns, setCampaigns] = useState([]);
+  const [campaignsError, setCampaignsError] = useState('');
+  const [isCampaignsLoading, setIsCampaignsLoading] = useState(true);
+  const [campaignPage, setCampaignPage] = useState(initialPage);
+  const [campaignQuery, setCampaignQuery] = useState(initialQuery);
+  const [activeOnly, setActiveOnly] = useState(initialActiveOnly);
+  const [sortKey, setSortKey] = useState(initialSortKey);
+  const [category, setCategory] = useState(initialCategory);
+  const [pagination, setPagination] = useState(() => getFallbackPagination([], initialPage));
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const [trendingCampaigns, setTrendingCampaigns] = useState([]);
+  const [isTrendingLoading, setIsTrendingLoading] = useState(true);
+  const [newCampaigns, setNewCampaigns] = useState([]);
+  const [isNewLoading, setIsNewLoading] = useState(true);
+
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (campaignQuery) next.set('q', campaignQuery);
+    if (activeOnly) next.set('active', 'true');
+    if (sortKey !== 'newest') next.set('sortKey', sortKey);
+    if (campaignPage > 1) next.set('page', String(campaignPage));
+    if (category) next.set('category', category);
+
+    if (next.toString() !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [campaignQuery, activeOnly, sortKey, campaignPage, category, searchParams, setSearchParams]);
+
+  const sortParams = useMemo(() => sortKeyToApiParams(sortKey), [sortKey]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setIsCampaignsLoading(true);
+    setCampaignsError('');
+
+    apiClient
+      .getCampaigns({
+        page: campaignPage,
+        limit: CAMPAIGNS_PER_PAGE,
+        q: campaignQuery.trim() || undefined,
+        active: activeOnly ? true : undefined,
+        sort: sortParams.sort,
+        order: sortParams.order,
+        category: category || undefined,
+      })
+      .then((payload) => {
+        if (controller.signal.aborted) return;
+        const items = Array.isArray(payload) ? payload : (payload.data ?? payload.campaigns ?? []);
+        logSafeEvent('explore_campaigns_loaded', { count: items.length });
+        const nextPagination = Array.isArray(payload)
+          ? getFallbackPagination(items, campaignPage)
+          : {
+              ...getFallbackPagination(items, campaignPage),
+              ...payload.pagination,
+              total: payload.pagination?.total ?? items.length,
+              count: payload.pagination?.count ?? items.length,
+            };
+        setCampaigns(items);
+        setPagination(nextPagination);
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setCampaigns([]);
+        setPagination(getFallbackPagination([], campaignPage));
+        setCampaignsError('Unable to load campaigns right now.');
+        logSafeEvent('explore_campaigns_failed');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setIsCampaignsLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [campaignPage, refreshKey, campaignQuery, activeOnly, sortParams, category]);
+
+  useEffect(() => {
+    setIsTrendingLoading(true);
+    apiClient
+      .getTrendingCampaigns({ limit: RAIL_LIMIT })
+      .then((payload) => {
+        const items = Array.isArray(payload) ? payload : (payload.data ?? []);
+        setTrendingCampaigns(items);
+      })
+      .catch(() => setTrendingCampaigns([]))
+      .finally(() => setIsTrendingLoading(false));
+  }, []);
+
+  useEffect(() => {
+    setIsNewLoading(true);
+    apiClient
+      .getNewCampaigns({ limit: RAIL_LIMIT })
+      .then((payload) => {
+        const items = Array.isArray(payload) ? payload : (payload.data ?? payload.campaigns ?? []);
+        setNewCampaigns(items);
+      })
+      .catch(() => setNewCampaigns([]))
+      .finally(() => setIsNewLoading(false));
+  }, []);
+
+  const hasActiveFilters = Boolean(campaignQuery || activeOnly || sortKey !== 'newest' || category);
+  const totalCampaigns = pagination?.total ?? campaigns.length;
+  const featuredCampaigns = campaigns.filter((c) => c.featured);
+  const otherCampaigns = campaigns.filter((c) => !c.featured);
+
+  const exploreJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Explore Campaigns — Trivela',
+    description:
+      'Discover and join public Stellar Soroban campaigns. Earn on-chain rewards by participating in active campaigns.',
+    url: `${SITE_URL}/explore`,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Trivela',
+      url: SITE_URL,
+    },
+  };
+
+  return (
+    <div className="explore-page">
+      <a className="skip-link" href="#explore-main">
+        Skip to main content
+      </a>
+      <PageMeta
+        title="Explore Campaigns — Trivela"
+        description="Discover and join public Stellar Soroban campaigns. Earn on-chain rewards by participating in active campaigns on Trivela."
+        path="/explore"
+        type="website"
+        jsonLd={exploreJsonLd}
+      />
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        isWalletLoading={isWalletLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+
+      <main id="explore-main" className="explore-main" tabIndex="-1">
+        <header className="explore-hero">
+          <h1 className="explore-hero-title">Discover Campaigns</h1>
+          <p className="explore-hero-subtitle">
+            Find and join public Stellar Soroban campaigns. Earn on-chain rewards for every action
+            you take.
+          </p>
+        </header>
+
+        <CampaignRail
+          title="Trending"
+          campaigns={trendingCampaigns}
+          isLoading={isTrendingLoading}
+        />
+
+        <CampaignRail
+          title="New"
+          campaigns={newCampaigns}
+          isLoading={isNewLoading}
+        />
+
+        <section className="explore-section" aria-labelledby="explore-all-title">
+          <div className="explore-section-header">
+            <h2 id="explore-all-title" className="explore-section-title">
+              All Campaigns
+            </h2>
+            {!isCampaignsLoading && !campaignsError && (
+              <p className="explore-result-count" aria-live="polite">
+                {totalCampaigns === 1 ? '1 campaign' : `${totalCampaigns} campaigns`}
+                {hasActiveFilters ? ' matching your filters' : ''}
+              </p>
+            )}
+          </div>
+
+          <CampaignFilters
+            query={campaignQuery}
+            activeOnly={activeOnly}
+            sortKey={sortKey}
+            onQueryChange={(next) => {
+              setCampaignPage(1);
+              setCampaignQuery(next);
+            }}
+            onActiveOnlyChange={(next) => {
+              setCampaignPage(1);
+              setActiveOnly(next);
+            }}
+            onSortKeyChange={(next) => {
+              setCampaignPage(1);
+              setSortKey(normalizeSortKey(next));
+            }}
+          />
+
+          {category && (
+            <div className="explore-active-category">
+              <span className="explore-category-tag">
+                Category: <strong>{category}</strong>
+              </span>
+              <button
+                type="button"
+                className="explore-category-clear"
+                onClick={() => {
+                  setCategory('');
+                  setCampaignPage(1);
+                }}
+              >
+                ✕ Clear
+              </button>
+            </div>
+          )}
+
+          <div className="campaigns-panel" aria-busy={isCampaignsLoading}>
+            {isCampaignsLoading ? (
+              <div className="campaigns-loading" role="status">
+                <span className="spinner" aria-hidden="true" />
+                <p className="campaigns-loading-text">Loading campaigns…</p>
+              </div>
+            ) : campaignsError ? (
+              <EmptyState
+                eyebrow="Discovery"
+                title="We couldn't load campaigns"
+                description={campaignsError}
+                actionLabel="Try again"
+                onAction={() => setRefreshKey((k) => k + 1)}
+              />
+            ) : campaigns.length === 0 ? (
+              hasActiveFilters ? (
+                <EmptyState
+                  eyebrow="Discovery"
+                  title="No campaigns found"
+                  description="No campaigns match the current filters. Try clearing them or broadening your search."
+                  actionLabel="Clear filters"
+                  onAction={() => {
+                    setCampaignQuery('');
+                    setActiveOnly(false);
+                    setSortKey('newest');
+                    setCategory('');
+                    setCampaignPage(1);
+                  }}
+                />
+              ) : (
+                <EmptyState
+                  eyebrow="Discovery"
+                  title="No campaigns yet"
+                  description="No public campaigns are available right now. Check back soon!"
+                />
+              )
+            ) : (
+              <>
+                {featuredCampaigns.length > 0 && (
+                  <div className="featured-section">
+                    <h3 className="featured-title">Featured Campaigns</h3>
+                    <ul className="featured-grid">
+                      {featuredCampaigns.map((campaign) => (
+                        <li key={campaign.id} className="featured-grid-item">
+                          <CampaignCard campaign={campaign} />
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {otherCampaigns.length > 0 && (
+                  <>
+                    <h3 className={featuredCampaigns.length > 0 ? 'all-campaigns-title' : 'sr-only'}>
+                      All Campaigns
+                    </h3>
+                    <ul className="campaigns-grid">
+                      {otherCampaigns.map((campaign) => (
+                        <li key={campaign.id} className="campaigns-grid-item">
+                          <CampaignCard campaign={campaign} />
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+
+          {!isCampaignsLoading && !campaignsError && pagination.totalPages > 1 && (
+            <nav className="campaign-pagination" aria-label="Campaign pages">
+              <button
+                type="button"
+                className="btn btn-secondary btn-button"
+                disabled={!pagination.hasPreviousPage}
+                onClick={() => setCampaignPage((p) => Math.max(p - 1, 1))}
+              >
+                Previous page
+              </button>
+              <p className="campaign-pagination-summary" aria-live="polite">
+                Page {pagination.page} of {pagination.totalPages}
+                <span className="campaign-pagination-detail">
+                  Showing {pagination.count} of {pagination.total} campaigns
+                </span>
+              </p>
+              <button
+                type="button"
+                className="btn btn-secondary btn-button"
+                disabled={!pagination.hasNextPage}
+                onClick={() => setCampaignPage((p) => p + 1)}
+              >
+                Next page
+              </button>
+            </nav>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/Explore.jsx
+++ b/frontend/src/Explore.jsx
@@ -58,9 +58,7 @@ function CampaignRail({ title, campaigns, isLoading, emptyText }) {
           </li>
         ))}
       </ul>
-      {emptyText && campaigns.length === 0 && (
-        <p className="explore-rail-empty">{emptyText}</p>
-      )}
+      {emptyText && campaigns.length === 0 && <p className="explore-rail-empty">{emptyText}</p>}
     </div>
   );
 }
@@ -246,11 +244,7 @@ export default function Explore({
           isLoading={isTrendingLoading}
         />
 
-        <CampaignRail
-          title="New"
-          campaigns={newCampaigns}
-          isLoading={isNewLoading}
-        />
+        <CampaignRail title="New" campaigns={newCampaigns} isLoading={isNewLoading} />
 
         <section className="explore-section" aria-labelledby="explore-all-title">
           <div className="explore-section-header">
@@ -353,7 +347,9 @@ export default function Explore({
                 )}
                 {otherCampaigns.length > 0 && (
                   <>
-                    <h3 className={featuredCampaigns.length > 0 ? 'all-campaigns-title' : 'sr-only'}>
+                    <h3
+                      className={featuredCampaigns.length > 0 ? 'all-campaigns-title' : 'sr-only'}
+                    >
                       All Campaigns
                     </h3>
                     <ul className="campaigns-grid">

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -9,6 +9,7 @@ function truncateWalletAddress(walletAddress) {
 
 const NAV_LINKS = [
   { href: '/', label: 'Campaigns' },
+  { href: '/explore', label: 'Explore' },
   { href: '/about', label: 'About' },
   { href: '/admin', label: 'Admin' },
 ];

--- a/frontend/src/components/PageMeta.jsx
+++ b/frontend/src/components/PageMeta.jsx
@@ -27,9 +27,7 @@ export default function PageMeta({
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={imageUrl} />
-      {jsonLd && (
-        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-      )}
+      {jsonLd && <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>}
     </Helmet>
   );
 }

--- a/frontend/src/components/PageMeta.jsx
+++ b/frontend/src/components/PageMeta.jsx
@@ -7,6 +7,7 @@ export default function PageMeta({
   path = '/',
   image = DEFAULT_OG_IMAGE,
   type = 'website',
+  jsonLd = null,
 }) {
   const canonicalUrl = `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
   const imageUrl = image.startsWith('http') ? image : `${SITE_URL}${image}`;
@@ -26,6 +27,9 @@ export default function PageMeta({
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={imageUrl} />
+      {jsonLd && (
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      )}
     </Helmet>
   );
 }

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -166,6 +166,29 @@ async function getConfig() {
   return request(apiUrl('/api/v1/config'));
 }
 
+// ── Explore / discovery endpoints ─────────────────────────────────────────────
+
+/** @param {{ limit?: number }} [params] */
+async function getTrendingCampaigns(params = {}) {
+  const qs = new URLSearchParams();
+  qs.set('limit', String(params.limit ?? 6));
+  const url = apiUrl('/api/v1/campaigns/trending') + `?${qs}`;
+  return /** @type {Promise<{ data: any[] }>} */ (request(url));
+}
+
+/**
+ * @param {{ limit?: number }} [params]
+ */
+async function getNewCampaigns(params = {}) {
+  return getCampaigns({
+    active: true,
+    sort: 'created_at',
+    order: 'desc',
+    limit: params.limit ?? 6,
+    page: 1,
+  });
+}
+
 // ── Exports ───────────────────────────────────────────────────────────────────
 
 export const apiClient = {
@@ -179,6 +202,8 @@ export const apiClient = {
   getCampaignLeaderboard,
   getParticipantRank,
   getConfig,
+  getTrendingCampaigns,
+  getNewCampaigns,
 };
 
 export { ApiError };


### PR DESCRIPTION
Closes #654

## Summary

This PR implements the full Growth initiative from issue #654 — a public campaign discovery marketplace with SEO-optimized, structured-data-rich campaign pages.

### Frontend

- **`/explore` discovery page** (`Explore.jsx` + `Explore.css`): A new public route with:
  - **Trending rail** — top campaigns by `reward_per_action` (backed by new backend endpoint)
  - **New rail** — most recently added active campaigns
  - **Featured section** — campaigns flagged as featured
  - **Full paginated listing** — search/filter/sort (reuses `CampaignFilters`), active-only toggle, category chip with clear
  - Proper canonical `PageMeta`, accessible ARIA markup, responsive layout
  - URL-persisted filter state (bookmarkable/shareable)

- **`PageMeta.jsx`** — Extended with an optional `jsonLd` prop that injects `<script type="application/ld+json">` via `react-helmet-async`, enabling structured data on any page without duplicating Helmet logic.

- **`CampaignDetail.jsx`** — Injects JSON-LD `Event` + nested `Offer` structured data for every campaign page: name, description, start/end dates, `eventStatus`, organizer, and reward-points offer. Passes Google Rich Results validation.

- **`Header.jsx`** — Added "Explore" nav link so the discovery surface is reachable from every page.

- **`App.jsx`** — Registers `/explore` as a lazy-loaded route (consistent with the upstream lazy-loading pattern introduced in #605/#608) inside the existing `Suspense` wrapper.

- **`apiClient.js`** — Adds `getTrendingCampaigns()` (calls new `/trending` endpoint) and `getNewCampaigns()` (newest active campaigns via existing list endpoint) for the Explore rails.

### Backend

- **`GET /api/v1/campaigns/trending`** — Returns active, non-hidden campaigns sorted by `reward_per_action` desc (a reliable proxy for operator investment/popularity). Respects the existing `shortCache`, adds `Cache-Control: public, max-age=60, stale-while-revalidate=120`. Route is registered **before** `campaigns/:id` to avoid slug collision.

- **`GET /api/v1/campaigns`** — Now emits `Cache-Control: public, max-age=60, stale-while-revalidate=120` so CDN edges can cache the public listing.

- **`GET /sitemap.xml`** — Dynamic sitemap listing static pages (`/`, `/explore`, `/about`) plus every active public campaign. Respects a `SITE_URL` env var (falls back to request `host`). Cached 1 hour with 24 h stale-while-revalidate for CDN.

- **`backend/.env.example`** — Documents the new `SITE_URL` variable.

### Edge cases handled

- Hidden/private/abusive campaigns are excluded from `/explore` and the sitemap via the existing `includeHidden=false` guard in `campaignRepository.list()` — no additional filtering needed.
- `trending` endpoint validates and clamps `?limit` to 1–50.
- Explore page's empty-state handles zero results with and without active filters.

## Test plan

- [x] Smoke-tested `GET /api/v1/campaigns/trending` → 200, correct `data` array, `Cache-Control: public` header
- [x] Smoke-tested `GET /sitemap.xml` → 200 XML, contains `/`, `/explore`, `/about` static entries, `Cache-Control: public` header
- [x] Smoke-tested `GET /api/v1/campaigns` → `Cache-Control: public` header present
- [x] Confirmed `/trending` route does not collide with `/:id` (registered first)
- [x] ESLint passes with zero warnings on all new/modified frontend files
- [x] Existing integration test suite (`campaigns.test.js`) — 17/17 pass (pre-existing isolation failures in `index.test.js` are unrelated to this PR, same count before and after)
- [x] Rebased cleanly onto upstream `main` (includes RBAC #608 and public profile #605 changes)