### PR TITLE
feat(frontend): virtualize campaign leaderboard for large datasets (closes #629)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.0.0",
+    "@tanstack/react-virtual": "^3.14.3",
     "dompurify": "^3.1.0",
     "driver.js": "^1.3.1",
     "react": "^18.3.1",

--- a/frontend/src/CampaignLeaderboard.css
+++ b/frontend/src/CampaignLeaderboard.css
@@ -146,6 +146,14 @@
   backdrop-filter: blur(16px);
 }
 
+/* Scrollable viewport for the virtualized participant rows (issue #629).
+   A bounded height lets the windowing only render the visible rows, so large
+   leaderboards (thousands of participants) stay smooth without DOM bloat. */
+.lb-virtual-viewport {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
 .lb-row {
   display: grid;
   grid-template-columns: 72px 1fr 110px 110px 110px;

--- a/frontend/src/CampaignLeaderboard.jsx
+++ b/frontend/src/CampaignLeaderboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { apiUrl } from './config';
 import Header from './components/Header';
+import VirtualizedList from './components/VirtualizedList';
 import './CampaignLeaderboard.css';
 
 const PAGE_LIMIT = 20;
@@ -172,6 +173,15 @@ export default function CampaignLeaderboard({
     fetchLeaderboard(nextPage, false);
   };
 
+  // Infinite scroll: the virtualized list calls this as the user nears the end.
+  // Guarded so it only advances the cursor once per page.
+  const handleReachEnd = useCallback(() => {
+    if (!hasMore || isLoadingMore || isLoading) return;
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchLeaderboard(nextPage, false);
+  }, [hasMore, isLoadingMore, isLoading, page, fetchLeaderboard]);
+
   const buildShareText = (rank) => {
     const name = campaign?.name ?? 'this campaign';
     const rankStr = rank != null ? `#${rank} of ${total}` : 'the top';
@@ -276,8 +286,13 @@ export default function CampaignLeaderboard({
           </div>
 
           {/* Table header */}
-          <div className="lb-table" role="table" aria-label="Campaign leaderboard">
-            <div className="lb-row lb-row-header" role="row">
+          <div
+            className="lb-table"
+            role="table"
+            aria-label="Campaign leaderboard"
+            aria-rowcount={total + 1}
+          >
+            <div className="lb-row lb-row-header" role="row" aria-rowindex={1}>
               <span className="lb-col-rank" role="columnheader">
                 Rank
               </span>
@@ -319,31 +334,40 @@ export default function CampaignLeaderboard({
                 </p>
               </div>
             ) : (
-              participants.map((p) => (
-                <div
-                  key={p.walletAddress ?? p.rank}
-                  className={`lb-row lb-row-data${isMyRow(p.walletAddress) ? ' lb-row-mine' : ''}`}
-                  role="row"
-                  aria-current={isMyRow(p.walletAddress) ? 'true' : undefined}
-                >
-                  <span className="lb-col-rank" role="cell">
-                    <RankMedal rank={p.rank} />
-                  </span>
-                  <span className="lb-col-address" role="cell" title={p.walletAddress}>
-                    {truncateAddress(p.walletAddress)}
-                    {isMyRow(p.walletAddress) && <span className="lb-you-badge">You</span>}
-                  </span>
-                  <span className="lb-col-points" role="cell">
-                    {(p.points ?? 0).toLocaleString()}
-                  </span>
-                  <span className="lb-col-claimed" role="cell">
-                    {(p.claimedPoints ?? 0).toLocaleString()}
-                  </span>
-                  <span className="lb-col-net" role="cell">
-                    {((p.points ?? 0) - (p.claimedPoints ?? 0)).toLocaleString()}
-                  </span>
-                </div>
-              ))
+              <VirtualizedList
+                items={participants}
+                getKey={(p) => p.walletAddress ?? p.rank}
+                estimateSize={56}
+                className="lb-virtual-viewport"
+                containerProps={{ role: 'rowgroup', 'aria-label': 'Leaderboard participants' }}
+                onReachEnd={handleReachEnd}
+                getItemProps={(p, i) => ({
+                  className: `lb-row lb-row-data${isMyRow(p.walletAddress) ? ' lb-row-mine' : ''}`,
+                  role: 'row',
+                  'aria-rowindex': i + 2,
+                  'aria-current': isMyRow(p.walletAddress) ? 'true' : undefined,
+                })}
+                renderItem={(p) => (
+                  <>
+                    <span className="lb-col-rank" role="cell">
+                      <RankMedal rank={p.rank} />
+                    </span>
+                    <span className="lb-col-address" role="cell" title={p.walletAddress}>
+                      {truncateAddress(p.walletAddress)}
+                      {isMyRow(p.walletAddress) && <span className="lb-you-badge">You</span>}
+                    </span>
+                    <span className="lb-col-points" role="cell">
+                      {(p.points ?? 0).toLocaleString()}
+                    </span>
+                    <span className="lb-col-claimed" role="cell">
+                      {(p.claimedPoints ?? 0).toLocaleString()}
+                    </span>
+                    <span className="lb-col-net" role="cell">
+                      {((p.points ?? 0) - (p.claimedPoints ?? 0)).toLocaleString()}
+                    </span>
+                  </>
+                )}
+              />
             )}
           </div>
 

--- a/frontend/src/components/VirtualizedList.jsx
+++ b/frontend/src/components/VirtualizedList.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+/**
+ * Windowed list (issue #629). Only the rows in or near the viewport are kept in
+ * the DOM, so large datasets (thousands of rows) scroll smoothly without
+ * bloating the DOM. Rows are measured dynamically, which handles variable row
+ * heights.
+ *
+ * When the user scrolls within `endThreshold` rows of the end, `onReachEnd`
+ * fires so the caller can load the next page — infinite scroll over the
+ * existing cursor pagination. Callers should guard `onReachEnd` (e.g. with
+ * `hasMore && !isLoadingMore`) since it may fire more than once.
+ *
+ * The scroll container and each row are role-agnostic: pass ARIA via
+ * `containerProps` and `getItemProps` so the caller keeps its table semantics
+ * (e.g. `role="rowgroup"` here, `role="row"` + `aria-rowindex` per item).
+ *
+ * @param {object} props
+ * @param {Array} props.items
+ * @param {(item: any, index: number) => string|number} props.getKey
+ * @param {(item: any, index: number) => React.ReactNode} props.renderItem
+ * @param {(item: any, index: number) => object} [props.getItemProps]
+ * @param {number} [props.estimateSize] estimated row height in px
+ * @param {number} [props.overscan]
+ * @param {number} [props.endThreshold] rows from the end that trigger onReachEnd
+ * @param {() => void} [props.onReachEnd]
+ * @param {string} [props.className]
+ * @param {object} [props.style]
+ * @param {object} [props.containerProps] spread onto the scroll container (ARIA, etc.)
+ */
+export default function VirtualizedList({
+  items,
+  getKey,
+  renderItem,
+  getItemProps,
+  estimateSize = 56,
+  overscan = 10,
+  endThreshold = 8,
+  onReachEnd,
+  className,
+  style,
+  containerProps = {},
+}) {
+  const scrollRef = useRef(null);
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const lastIndex = virtualItems.length ? virtualItems[virtualItems.length - 1].index : -1;
+
+  // Infinite scroll: fire when the last rendered row nears the end of the data.
+  useEffect(() => {
+    if (!onReachEnd) return;
+    if (items.length > 0 && lastIndex >= items.length - 1 - endThreshold) {
+      onReachEnd();
+    }
+  }, [lastIndex, items.length, endThreshold, onReachEnd]);
+
+  return (
+    <div
+      ref={scrollRef}
+      className={className}
+      style={{ overflowY: 'auto', ...style }}
+      {...containerProps}
+    >
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          position: 'relative',
+          width: '100%',
+        }}
+      >
+        {virtualItems.map((virtualItem) => {
+          const item = items[virtualItem.index];
+          const itemProps = getItemProps ? getItemProps(item, virtualItem.index) : {};
+          return (
+            <div
+              key={getKey(item, virtualItem.index)}
+              data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
+              {...itemProps}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualItem.start}px)`,
+                ...(itemProps.style || {}),
+              }}
+            >
+              {renderItem(item, virtualItem.index)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VirtualizedList.test.jsx
+++ b/frontend/src/components/VirtualizedList.test.jsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+// Tests for the VirtualizedList windowing component (issue #629).
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import VirtualizedList from './VirtualizedList';
+
+afterEach(cleanup);
+
+const makeItems = (n) => Array.from({ length: n }, (_, i) => ({ id: i }));
+
+// jsdom has no layout, so give @tanstack/react-virtual real element sizes and a
+// ResizeObserver to measure against — otherwise it renders nothing and the
+// windowing behaviour can't be observed.
+const origResizeObserver = globalThis.ResizeObserver;
+const origGetRect = Element.prototype.getBoundingClientRect;
+
+const origOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+const origOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    constructor(cb) {
+      this.cb = cb;
+    }
+    observe() {
+      if (this.cb) this.cb([]);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return {
+      width: 600,
+      height: 600,
+      top: 0,
+      left: 0,
+      right: 600,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+  };
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => 600,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 600,
+  });
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = origResizeObserver;
+  Element.prototype.getBoundingClientRect = origGetRect;
+  if (origOffsetHeight)
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', origOffsetHeight);
+  if (origOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', origOffsetWidth);
+});
+
+describe('VirtualizedList', () => {
+  it('windows large datasets: only a small subset of rows is in the DOM', () => {
+    render(
+      <VirtualizedList
+        items={makeItems(10000)}
+        getKey={(it) => it.id}
+        getItemProps={() => ({ 'data-testid': 'row' })}
+        renderItem={(it) => <span>row {it.id}</span>}
+      />,
+    );
+
+    const rendered = screen.queryAllByTestId('row');
+    expect(rendered.length).toBeGreaterThan(0);
+    // A handful of overscanned rows — never the full 10k.
+    expect(rendered.length).toBeLessThan(200);
+  });
+
+  it('renders every row when the dataset fits', () => {
+    render(
+      <VirtualizedList
+        items={makeItems(4)}
+        getKey={(it) => it.id}
+        getItemProps={() => ({ 'data-testid': 'row' })}
+        renderItem={(it) => <span>row {it.id}</span>}
+      />,
+    );
+
+    expect(screen.queryAllByTestId('row')).toHaveLength(4);
+  });
+
+  it('applies item props (role / aria) to each row for accessibility', () => {
+    render(
+      <VirtualizedList
+        items={makeItems(3)}
+        getKey={(it) => it.id}
+        getItemProps={(_, i) => ({ role: 'row', 'aria-rowindex': i + 2, 'data-testid': 'row' })}
+        renderItem={(it) => <span>row {it.id}</span>}
+      />,
+    );
+
+    const rows = screen.queryAllByTestId('row');
+    expect(rows[0].getAttribute('role')).toBe('row');
+    expect(rows[0].getAttribute('aria-rowindex')).toBe('2');
+  });
+
+  it('fires onReachEnd for infinite scroll when the end is in view', () => {
+    const onReachEnd = vi.fn();
+    render(
+      <VirtualizedList
+        items={makeItems(5)}
+        getKey={(it) => it.id}
+        renderItem={(it) => <span>row {it.id}</span>}
+        onReachEnd={onReachEnd}
+      />,
+    );
+
+    expect(onReachEnd).toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^14.0.0",
+        "@tanstack/react-virtual": "^3.14.3",
         "dompurify": "^3.1.0",
         "driver.js": "^1.3.1",
         "react": "^18.3.1",
@@ -6343,6 +6344,33 @@
       },
       "peerDependencies": {
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {


### PR DESCRIPTION
## Summary

Large leaderboards rendered every participant row on initial load, causing DOM bloat and janky scrolling at thousands of rows. This PR adds windowed (virtualized) rendering so only the visible rows are ever in the DOM, while preserving the full ARIA table semantics and the existing search/sort/load-more UX.

### Changes

- **`frontend/src/components/VirtualizedList.jsx`** — New reusable windowed list built on `@tanstack/react-virtual`. Features:
  - Dynamic row measurement (handles variable heights)
  - Configurable `overscan` for smooth scroll edges
  - `onReachEnd` callback for infinite scroll (fires when last rendered row is within `endThreshold` of the end)
  - ARIA-transparent: pass roles/attributes via `containerProps` and `getItemProps`

- **`frontend/src/CampaignLeaderboard.jsx`** — Wired in VirtualizedList for participant rows:
  - `aria-rowcount={total + 1}` on the `role="table"` wrapper (correct count despite windowing)
  - `aria-rowindex={1}` on the header row; `aria-rowindex={i + 2}` per participant row
  - `aria-current` on the connected wallet's row
  - `handleReachEnd` guard: only advances the page cursor once per page

- **`frontend/src/CampaignLeaderboard.css`** — `.lb-virtual-viewport { max-height: 70vh; overflow-y: auto; }` bounds the scrollable region so the virtualizer has a fixed viewport to window against

- **`frontend/src/components/VirtualizedList.test.jsx`** — 4 vitest tests:
  - Windowing: 10 000 rows → only a small DOM subset rendered
  - All rows present when dataset fits the window
  - Per-row ARIA attributes (`role`, `aria-rowindex`) applied correctly
  - `onReachEnd` fires when the end is in view

### Performance

Before: O(n) DOM nodes for n participants (every row rendered)
After: O(viewport / row-height + overscan) DOM nodes regardless of list length — typically ~20-30 rows for a standard viewport

### Test plan

- [x] `vitest run` — 157 tests pass (4 new VirtualizedList tests added)
- [x] `eslint .` — no new errors
- [x] `vite build` — clean production build
- [x] `prettier --check` — all changed files pass
- [x] Existing e2e tests unaffected (VirtualizedList preserves `.lb-row-data` class on each item)

Closes #629