### PR TITLE
feat: tenant-aware quotas & usage metering (#574)

### DIFF
--- a/backend/src/dal/index.js
+++ b/backend/src/dal/index.js
@@ -18,6 +18,7 @@ import { createSqlitePushSubscriptionRepository } from './sqlitePushSubscription
 import { createPool, isPostgresUrl } from './pg/pgClient.js';
 import { createSqliteAllowlistRepository } from './sqliteAllowlistRepository.js';
 import { createSqliteOrgMemberRepository } from './sqliteOrgMemberRepository.js';
+import { createSqliteUsageRepository } from './sqliteUsageRepository.js';
 
 import { runPgMigrations } from './pg/migrate.js';
 import { createPgCampaignRepository } from './pg/pgCampaignRepository.js';
@@ -88,6 +89,7 @@ export async function createDal({
     failedJobs: failedJobRepository ?? createSqliteFailedJobRepository({ db }),
     allowlists: allowlistRepository ?? createSqliteAllowlistRepository({ db }),
     orgMembers: createSqliteOrgMemberRepository({ db }),
+    usage: createSqliteUsageRepository({ db }),
     db,
     pgPool,
   };

--- a/backend/src/dal/sqliteUsageRepository.js
+++ b/backend/src/dal/sqliteUsageRepository.js
@@ -1,0 +1,150 @@
+// @ts-check
+import { randomUUID } from 'node:crypto';
+
+export const VALID_RESOURCES = ['api_calls', 'campaigns', 'participants', 'payouts'];
+
+/**
+ * @param {{ db: InstanceType<import('better-sqlite3')> }} params
+ */
+export function createSqliteUsageRepository({ db }) {
+  // ── Quota CRUD ────────────────────────────────────────────────────────────
+
+  const upsertQuotaStmt = db.prepare(`
+    INSERT INTO org_quotas (id, org_id, resource, soft_limit, hard_limit, window_seconds, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(org_id, resource) DO UPDATE SET
+      soft_limit     = excluded.soft_limit,
+      hard_limit     = excluded.hard_limit,
+      window_seconds = excluded.window_seconds,
+      updated_at     = excluded.updated_at
+  `);
+
+  const selectQuotaStmt = db.prepare(`SELECT * FROM org_quotas WHERE org_id = ? AND resource = ?`);
+  const selectAllQuotasForOrgStmt = db.prepare(
+    `SELECT * FROM org_quotas WHERE org_id = ? ORDER BY resource`,
+  );
+
+  function upsertQuota({
+    orgId,
+    resource,
+    softLimit = null,
+    hardLimit = null,
+    windowSeconds = 3600,
+  }) {
+    const id = randomUUID();
+    const updatedAt = new Date().toISOString();
+    upsertQuotaStmt.run(id, orgId, resource, softLimit, hardLimit, windowSeconds, updatedAt);
+    return getQuota(orgId, resource);
+  }
+
+  function getQuota(orgId, resource) {
+    const row = selectQuotaStmt.get(orgId, resource);
+    if (!row) return null;
+    return rowToQuota(row);
+  }
+
+  function getOrgQuotas(orgId) {
+    return selectAllQuotasForOrgStmt.all(orgId).map(rowToQuota);
+  }
+
+  // ── Usage log ─────────────────────────────────────────────────────────────
+
+  const upsertUsageStmt = db.prepare(`
+    INSERT INTO org_usage_log (id, org_id, resource, window_start, count, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(org_id, resource, window_start) DO UPDATE SET
+      count      = excluded.count,
+      updated_at = excluded.updated_at
+  `);
+
+  const selectUsageStmt = db.prepare(
+    `SELECT * FROM org_usage_log WHERE org_id = ? AND resource = ? AND window_start = ?`,
+  );
+
+  const selectRecentUsageStmt = db.prepare(`
+    SELECT * FROM org_usage_log
+    WHERE org_id = ? AND resource = ?
+    ORDER BY window_start DESC
+    LIMIT 1
+  `);
+
+  const selectAllUsageForOrgStmt = db.prepare(`
+    SELECT * FROM org_usage_log
+    WHERE org_id = ?
+    ORDER BY resource, window_start DESC
+  `);
+
+  const selectAllOrgUsageStmt = db.prepare(`
+    SELECT u.*, q.soft_limit, q.hard_limit, q.window_seconds
+    FROM org_usage_log u
+    LEFT JOIN org_quotas q ON q.org_id = u.org_id AND q.resource = u.resource
+    ORDER BY u.org_id, u.resource, u.window_start DESC
+  `);
+
+  function upsertUsageWindow({ orgId, resource, windowStart, count }) {
+    const id = randomUUID();
+    const updatedAt = new Date().toISOString();
+    upsertUsageStmt.run(id, orgId, resource, windowStart, count, updatedAt);
+  }
+
+  function getUsageWindow(orgId, resource, windowStart) {
+    const row = selectUsageStmt.get(orgId, resource, windowStart);
+    return row ? rowToUsage(row) : null;
+  }
+
+  function getLatestUsage(orgId, resource) {
+    const row = selectRecentUsageStmt.get(orgId, resource);
+    return row ? rowToUsage(row) : null;
+  }
+
+  function getOrgUsageSummary(orgId) {
+    return selectAllUsageForOrgStmt.all(orgId).map(rowToUsage);
+  }
+
+  function adminExportAll() {
+    return selectAllOrgUsageStmt.all().map((row) => ({
+      orgId: row.org_id,
+      resource: row.resource,
+      windowStart: row.window_start,
+      count: row.count,
+      updatedAt: row.updated_at,
+      softLimit: row.soft_limit ?? null,
+      hardLimit: row.hard_limit ?? null,
+      windowSeconds: row.window_seconds ?? null,
+    }));
+  }
+
+  return {
+    upsertQuota,
+    getQuota,
+    getOrgQuotas,
+    upsertUsageWindow,
+    getUsageWindow,
+    getLatestUsage,
+    getOrgUsageSummary,
+    adminExportAll,
+  };
+}
+
+function rowToQuota(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    resource: row.resource,
+    softLimit: row.soft_limit ?? null,
+    hardLimit: row.hard_limit ?? null,
+    windowSeconds: row.window_seconds,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToUsage(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    resource: row.resource,
+    windowStart: row.window_start,
+    count: row.count,
+    updatedAt: row.updated_at,
+  };
+}

--- a/backend/src/db/migrations/015_tenant_quotas.js
+++ b/backend/src/db/migrations/015_tenant_quotas.js
@@ -1,0 +1,39 @@
+// @ts-check
+export const version = 15;
+export const description = 'Add org_quotas and org_usage_log tables for tenant metering (#574)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS org_quotas (
+      id             TEXT PRIMARY KEY,
+      org_id         TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+      resource       TEXT NOT NULL,
+      soft_limit     INTEGER,
+      hard_limit     INTEGER,
+      window_seconds INTEGER NOT NULL DEFAULT 3600,
+      updated_at     TEXT NOT NULL,
+      UNIQUE(org_id, resource)
+    );
+
+    CREATE TABLE IF NOT EXISTS org_usage_log (
+      id           TEXT PRIMARY KEY,
+      org_id       TEXT NOT NULL,
+      resource     TEXT NOT NULL,
+      window_start TEXT NOT NULL,
+      count        INTEGER NOT NULL DEFAULT 0,
+      updated_at   TEXT NOT NULL,
+      UNIQUE(org_id, resource, window_start)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_org_quotas_org_id        ON org_quotas(org_id);
+    CREATE INDEX IF NOT EXISTS idx_org_usage_log_org_id     ON org_usage_log(org_id);
+    CREATE INDEX IF NOT EXISTS idx_org_usage_log_window     ON org_usage_log(org_id, resource, window_start);
+  `);
+}
+
+export function down(db) {
+  db.exec(`
+    DROP TABLE IF EXISTS org_usage_log;
+    DROP TABLE IF EXISTS org_quotas;
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -56,6 +56,8 @@ import { createCohortService } from './services/cohortService.js';
 import { createPushRoutes } from './routes/push.js';
 import { createOrgRoutes } from './routes/orgs.js';
 import { createWebPushService } from './services/webPushService.js';
+import { createUsageMeteringService } from './services/usageMeteringService.js';
+import { createUsageMeteringMiddleware } from './middleware/usageMetering.js';
 import { requestTimeout } from './middleware/timeout.js';
 import { PoolSaturatedError } from './rpcPool.js';
 
@@ -249,6 +251,7 @@ export async function createApp(options = {}) {
   const failedJobRepository = options.failedJobRepository ?? dal.failedJobs;
   const allowlistRepository = dal.allowlists;
   const orgMemberRepository = dal.orgMembers;
+  const usageRepository = options.usageRepository ?? dal.usage;
 
   const storageAdapter = /** @type {import('./storage/storageAdapter.js').StorageAdapter} */ (
     options.storageAdapter ?? createStorageAdapter(process.env)
@@ -382,6 +385,7 @@ export async function createApp(options = {}) {
   const requireAdminMasterKey = requireMasterKey;
 
   let rateLimitStore = null;
+  let usageRedisClient = null;
   const redisUrl = process.env.REDIS_URL || process.env.REDIS_HOST;
   if (redisUrl && !options.disableRedis) {
     try {
@@ -394,6 +398,7 @@ export async function createApp(options = {}) {
         log.error({ err }, 'Redis connection error');
       });
       rateLimitStore = createRedisStore(redisClient);
+      usageRedisClient = redisClient;
       log.info(
         { redisUrl: redisUrl.replace(/:[^:@]+@/, ':***@') },
         'Rate limiter using Redis store',
@@ -405,6 +410,15 @@ export async function createApp(options = {}) {
       );
     }
   }
+
+  const usageMeteringService = createUsageMeteringService({
+    usageRepository,
+    redisClient: usageRedisClient ?? /** @type {any} */ (options.usageRedisClient) ?? null,
+    timeProvider: /** @type {any} */ (options.usageMeteringService)?.timeProvider,
+  });
+  const stopUsageFlush = usageMeteringService.startFlushInterval();
+
+  const usageMeteringMiddleware = createUsageMeteringMiddleware({ usageMeteringService });
 
   const rateLimiter = createRateLimiter({
     windowMs: rateLimitWindowMs,
@@ -717,6 +731,9 @@ export async function createApp(options = {}) {
         updateCampaign: `PUT ${API_V1_PREFIX}/campaigns/:id`,
         deleteCampaign: `DELETE ${API_V1_PREFIX}/campaigns/:id`,
         auditLogs: `GET ${API_V1_PREFIX}/audit-logs`,
+        usage: `GET ${API_V1_PREFIX}/usage`,
+        adminUsage: `GET ${API_V1_PREFIX}/admin/usage`,
+        adminUsageQuotas: `PUT ${API_V1_PREFIX}/admin/usage/quotas`,
         config: `GET ${API_V1_PREFIX}/config`,
         explorer: `GET ${API_V1_PREFIX}/explorer`,
       },
@@ -1457,6 +1474,9 @@ export async function createApp(options = {}) {
 
   /** @param {string} prefix */
   function registerApiRoutes(prefix) {
+    // Shorthand: auth + per-tenant api_calls metering in one step.
+    const guard = [requireApiKey, usageMeteringMiddleware];
+
     app.get(prefix, rateLimiter, apiInfo);
     app.get(`${prefix}/config`, rateLimiter, getPublicConfig);
     app.get(`${prefix}/explorer`, rateLimiter, getExplorerLinks);
@@ -1467,12 +1487,12 @@ export async function createApp(options = {}) {
     app.get(`${prefix}/campaigns/by-slug/:slug`, rateLimiter, getCampaignBySlug);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
     app.get(`${prefix}/campaigns/:id/stats`, rateLimiter, getCampaignStats);
-    app.get(`${prefix}/audit-logs`, rateLimiter, requireApiKey, listAuditLogs);
+    app.get(`${prefix}/audit-logs`, rateLimiter, ...guard, listAuditLogs);
     app.get(`${prefix}/indexer/cursor`, rateLimiter, getIndexerCursorState);
-    app.post(`${prefix}/indexer/cursor`, rateLimiter, requireApiKey, setIndexerCursorState);
-    app.post(`${prefix}/campaigns`, rateLimiter, requireApiKey, createCampaign);
-    app.post(`${prefix}/campaigns/:id/clone`, rateLimiter, requireApiKey, cloneCampaign);
-    app.post(`${prefix}/campaigns/:id/image`, rateLimiter, requireApiKey, (req, res, next) => {
+    app.post(`${prefix}/indexer/cursor`, rateLimiter, ...guard, setIndexerCursorState);
+    app.post(`${prefix}/campaigns`, rateLimiter, ...guard, createCampaign);
+    app.post(`${prefix}/campaigns/:id/clone`, rateLimiter, ...guard, cloneCampaign);
+    app.post(`${prefix}/campaigns/:id/image`, rateLimiter, ...guard, (req, res, next) => {
       imageUpload.single('image')(req, res, (err) => {
         if (err?.code === 'LIMIT_FILE_SIZE') {
           return res.status(400).json({
@@ -1484,8 +1504,8 @@ export async function createApp(options = {}) {
         return uploadCampaignImageHandler(req, res);
       });
     });
-    app.put(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, updateCampaign);
-    app.delete(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, deleteCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, ...guard, updateCampaign);
+    app.delete(`${prefix}/campaigns/:id`, rateLimiter, ...guard, deleteCampaign);
 
     app.post(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, createApiKeyHandler);
     app.get(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, listApiKeysHandler);
@@ -1501,12 +1521,54 @@ export async function createApp(options = {}) {
     app.get(`${prefix}/admin/dashboard`, rateLimiter, requireMasterKey, getAdminDashboard);
     app.get(`${prefix}/admin/campaigns`, rateLimiter, requireMasterKey, listAdminCampaigns);
 
+    // Tenant usage metering (Issue #574)
+    app.get(`${prefix}/usage`, rateLimiter, ...guard, (req, res) => {
+      const orgId = req.auth?.orgId;
+      if (!orgId) {
+        return res.status(403).json({
+          error: 'Usage data is scoped to org-linked API keys.',
+          code: 'NO_ORG_CONTEXT',
+        });
+      }
+      const usage = usageMeteringService.getOrgUsage(orgId);
+      return res.json({ orgId, usage });
+    });
+
+    app.get(`${prefix}/admin/usage`, rateLimiter, requireMasterKey, (_req, res) => {
+      const rows = usageMeteringService.adminExport();
+      return res.json({ usage: rows });
+    });
+
+    app.put(`${prefix}/admin/usage/quotas`, rateLimiter, requireMasterKey, (req, res) => {
+      const {
+        orgId,
+        resource,
+        softLimit = null,
+        hardLimit = null,
+        windowSeconds = 3600,
+      } = req.body ?? {};
+      if (!orgId || !resource) {
+        return res.status(400).json({
+          error: 'orgId and resource are required',
+          code: 'VALIDATION_ERROR',
+        });
+      }
+      const quota = usageRepository.upsertQuota({
+        orgId,
+        resource,
+        softLimit,
+        hardLimit,
+        windowSeconds,
+      });
+      return res.json(quota);
+    });
+
     // Job dead-letter inspection / requeue (Issue #286)
-    app.get(`${prefix}/jobs/failed`, rateLimiter, requireApiKey, listFailedJobsHandler);
-    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, requireApiKey, retryFailedJobHandler);
+    app.get(`${prefix}/jobs/failed`, rateLimiter, ...guard, listFailedJobsHandler);
+    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, ...guard, retryFailedJobHandler);
 
     // Webhook routes (Issue #287)
-    app.post(`${prefix}/webhooks`, rateLimiter, requireApiKey, (req, res) => {
+    app.post(`${prefix}/webhooks`, rateLimiter, ...guard, (req, res) => {
       const { url, events, secret } = req.body;
       if (!url || !Array.isArray(events) || events.length === 0) {
         return res.status(400).json({
@@ -1525,12 +1587,12 @@ export async function createApp(options = {}) {
       return res.status(201).json(webhook);
     });
 
-    app.get(`${prefix}/webhooks`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks`, rateLimiter, ...guard, (req, res) => {
       const webhooks = webhookRepository.list();
       return res.json(paginateItems(webhooks, req.query));
     });
 
-    app.get(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
       const webhook = webhookRepository.getById(req.params.id);
       if (!webhook) {
         return res.status(404).json({ error: 'Webhook not found', code: 'WEBHOOK_NOT_FOUND' });
@@ -1538,7 +1600,7 @@ export async function createApp(options = {}) {
       return res.json(webhook);
     });
 
-    app.put(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.put(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
       const { url, events, active } = req.body;
       const before = webhookRepository.getById(req.params.id);
       if (!before) {
@@ -1558,7 +1620,7 @@ export async function createApp(options = {}) {
       return res.json(webhook);
     });
 
-    app.delete(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.delete(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
       const before = webhookRepository.getById(req.params.id);
       const deleted = webhookRepository.delete(req.params.id);
       if (!deleted) {
@@ -1573,7 +1635,7 @@ export async function createApp(options = {}) {
       return res.status(204).end();
     });
 
-    app.get(`${prefix}/webhooks/:id/deliveries`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks/:id/deliveries`, rateLimiter, ...guard, (req, res) => {
       const webhook = webhookRepository.getById(req.params.id);
       if (!webhook) {
         return res.status(404).json({ error: 'Webhook not found', code: 'WEBHOOK_NOT_FOUND' });
@@ -1661,21 +1723,21 @@ export async function createApp(options = {}) {
       variantService,
       campaignRepo: campaignRepository,
     });
-    app.use(prefix, rateLimiter, requireApiKey, variantRouter);
+    app.use(prefix, rateLimiter, ...guard, variantRouter);
 
     // Cohort and retention analysis routes (Issue #623)
     const cohortRouter = createCohortRoutes({
       cohortService,
       campaignRepo: campaignRepository,
     });
-    app.use(prefix, rateLimiter, requireApiKey, cohortRouter);
+    app.use(prefix, rateLimiter, ...guard, cohortRouter);
 
     // Web Push subscription routes (Issue #619)
     const pushRouter = createPushRoutes({
       repository: pushSubscriptionRepository,
       service: webPushService,
     });
-    app.use(prefix, rateLimiter, requireApiKey, pushRouter);
+    app.use(prefix, rateLimiter, ...guard, pushRouter);
   }
 
   registerApiRoutes(API_V1_PREFIX);
@@ -1752,6 +1814,10 @@ export async function startServer(options = {}) {
 
     // Stop accepting new connections; drain in-flight HTTP requests.
     await new Promise((resolve) => server.close(resolve));
+
+    // Flush usage counters to DB before exiting.
+    stopUsageFlush();
+    await usageMeteringService.flushToDb().catch((err) => log.warn({ err }, 'usage flush warning'));
 
     // Flush OTel exporter.
     await shutdownTracing().catch((err) => log.warn({ err }, 'OTel shutdown warning'));

--- a/backend/src/integration/usageMetering.test.js
+++ b/backend/src/integration/usageMetering.test.js
@@ -1,0 +1,277 @@
+// @ts-check
+//
+// Integration tests for tenant-aware quotas and usage metering (Issue #574).
+//
+// Covers:
+//   GET /api/v1/usage  — requires org-linked key; env-sourced key → 403
+//   GET /api/v1/admin/usage  — requires master key
+//   PUT /api/v1/admin/usage/quotas  — set soft/hard limits
+//   Hard quota enforcement — campaign creation blocked at hard limit
+//   Soft quota warning  — X-Quota-Warning header appears at soft limit
+//   Multi-tenant isolation — org-A's counter doesn't affect org-B
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createApp } from '../index.js';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import { createSqliteApiKeyRepository } from '../dal/sqliteApiKeyRepository.js';
+import { createSqliteOrgMemberRepository } from '../dal/sqliteOrgMemberRepository.js';
+import { createSqliteUsageRepository } from '../dal/sqliteUsageRepository.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function startTestServer(options = {}) {
+  const app = await createApp(options);
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const { port } = /** @type {any} */ (server.address());
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function stopTestServer(server) {
+  await new Promise((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve(undefined))),
+  );
+}
+
+async function makeInMemoryDb() {
+  const db = new Database(':memory:');
+  await runMigrations(db);
+  return db;
+}
+
+/**
+ * Build a db with one org + one API key already created.
+ * Returns { db, rawKey, orgId, apiKeyId }.
+ */
+async function bootstrapOrgAndKey() {
+  const db = await makeInMemoryDb();
+  const apiKeyRepo = createSqliteApiKeyRepository({ db });
+  const orgRepo = createSqliteOrgMemberRepository({ db });
+
+  const { rawKey, key: apiKey } = apiKeyRepo.create({ label: 'test-key' });
+  const org = orgRepo.createOrg({ name: 'Test Org' });
+  orgRepo.addMember({ orgId: org.id, apiKeyId: apiKey.id, role: 'owner' });
+
+  return { db, rawKey, orgId: org.id, apiKeyId: apiKey.id };
+}
+
+// ── GET /api/v1/usage ──────────────────────────────────────────────────────
+
+test('GET /api/v1/usage returns 403 for env-sourced key (no org context)', async () => {
+  const { server, baseUrl } = await startTestServer({
+    apiKeys: ['test-env-key'],
+    disableRedis: true,
+  });
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/usage`, {
+      headers: { 'x-api-key': 'test-env-key' },
+    });
+    assert.equal(res.status, 403);
+    const body = /** @type {any} */ (await res.json());
+    assert.equal(body.code, 'NO_ORG_CONTEXT');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+test('GET /api/v1/usage returns usage for org-linked API key', async () => {
+  const { db, rawKey, orgId } = await bootstrapOrgAndKey();
+  const { server, baseUrl } = await startTestServer({
+    dbPath: ':memory:',
+    disableRedis: true,
+    apiKeyRepository: createSqliteApiKeyRepository({ db }),
+    orgMemberRepository: createSqliteOrgMemberRepository({ db }),
+  });
+  // Hit a write route first to generate some usage.
+  await fetch(`${baseUrl}/api/v1/campaigns`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-api-key': rawKey },
+    body: JSON.stringify({ name: 'C1', description: 'D', rewardPerAction: 1 }),
+  });
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/usage`, {
+      headers: { 'x-api-key': rawKey },
+    });
+    assert.equal(res.status, 200);
+    const body = /** @type {any} */ (await res.json());
+    assert.equal(body.orgId, orgId);
+    assert.ok(Array.isArray(body.usage));
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// ── GET /api/v1/admin/usage ────────────────────────────────────────────────
+
+test('GET /api/v1/admin/usage requires master key and returns usage array', async () => {
+  const { server, baseUrl } = await startTestServer({
+    masterKey: 'master-key-123',
+    disableRedis: true,
+  });
+  try {
+    const unauth = await fetch(`${baseUrl}/api/v1/admin/usage`);
+    assert.equal(unauth.status, 401, 'should require master key');
+
+    const res = await fetch(`${baseUrl}/api/v1/admin/usage`, {
+      headers: { 'x-api-key': 'master-key-123' },
+    });
+    assert.equal(res.status, 200);
+    const body = /** @type {any} */ (await res.json());
+    assert.ok(Array.isArray(body.usage));
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// ── PUT /api/v1/admin/usage/quotas ────────────────────────────────────────
+
+test('PUT /api/v1/admin/usage/quotas sets quota and returns it', async () => {
+  const { db, orgId } = await bootstrapOrgAndKey();
+  const { server, baseUrl } = await startTestServer({
+    masterKey: 'master-key',
+    dbPath: ':memory:',
+    disableRedis: true,
+    apiKeyRepository: createSqliteApiKeyRepository({ db }),
+    orgMemberRepository: createSqliteOrgMemberRepository({ db }),
+    usageRepository: createSqliteUsageRepository({ db }),
+  });
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/admin/usage/quotas`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json', 'x-api-key': 'master-key' },
+      body: JSON.stringify({ orgId, resource: 'api_calls', softLimit: 50, hardLimit: 100 }),
+    });
+    assert.equal(res.status, 200);
+    const quota = /** @type {any} */ (await res.json());
+    assert.equal(quota.orgId, orgId);
+    assert.equal(quota.softLimit, 50);
+    assert.equal(quota.hardLimit, 100);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// ── Hard limit enforcement ─────────────────────────────────────────────────
+
+test('campaign creation is blocked with 429 when hard api_calls quota is exceeded', async () => {
+  const { db, rawKey, orgId } = await bootstrapOrgAndKey();
+  const usageRepo = createSqliteUsageRepository({ db });
+
+  // Set a hard limit of 2 api_calls.
+  db.exec(
+    `INSERT INTO orgs (id, name, created_at) VALUES ('${orgId}', 'x', '2024-01-01') ON CONFLICT DO NOTHING`,
+  );
+  usageRepo.upsertQuota({ orgId, resource: 'api_calls', hardLimit: 2, windowSeconds: 3600 });
+
+  // Pre-fill counter to 2 (at limit).
+  const ws = new Date(Math.floor(Date.now() / 3_600_000) * 3_600_000).toISOString();
+  usageRepo.upsertUsageWindow({ orgId, resource: 'api_calls', windowStart: ws, count: 2 });
+
+  const { server, baseUrl } = await startTestServer({
+    dbPath: ':memory:',
+    disableRedis: true,
+    apiKeyRepository: createSqliteApiKeyRepository({ db }),
+    orgMemberRepository: createSqliteOrgMemberRepository({ db }),
+    usageRepository: usageRepo,
+  });
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/campaigns`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': rawKey },
+      body: JSON.stringify({ name: 'Blocked', description: 'D', rewardPerAction: 1 }),
+    });
+    assert.equal(res.status, 429);
+    const body = /** @type {any} */ (await res.json());
+    assert.equal(body.code, 'QUOTA_EXCEEDED');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// ── Soft limit warning ─────────────────────────────────────────────────────
+
+test('X-Quota-Warning header present when at soft limit', async () => {
+  const { db, rawKey, orgId } = await bootstrapOrgAndKey();
+  const usageRepo = createSqliteUsageRepository({ db });
+
+  db.exec(
+    `INSERT INTO orgs (id, name, created_at) VALUES ('${orgId}', 'x', '2024-01-01') ON CONFLICT DO NOTHING`,
+  );
+  usageRepo.upsertQuota({
+    orgId,
+    resource: 'api_calls',
+    softLimit: 1,
+    hardLimit: 100,
+    windowSeconds: 3600,
+  });
+
+  const { server, baseUrl } = await startTestServer({
+    dbPath: ':memory:',
+    disableRedis: true,
+    apiKeyRepository: createSqliteApiKeyRepository({ db }),
+    orgMemberRepository: createSqliteOrgMemberRepository({ db }),
+    usageRepository: usageRepo,
+  });
+
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/campaigns`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': rawKey },
+      body: JSON.stringify({ name: 'Soft', description: 'D', rewardPerAction: 1 }),
+    });
+    // The first call increments to 1, which equals softLimit=1 → warning.
+    assert.ok(res.headers.get('x-quota-warning'), 'expected X-Quota-Warning header');
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
+// ── Multi-tenant isolation ─────────────────────────────────────────────────
+
+test('usage counters are isolated between orgs', async () => {
+  const dbA = await makeInMemoryDb();
+  const apiKeyRepoA = createSqliteApiKeyRepository({ db: dbA });
+  const orgRepoA = createSqliteOrgMemberRepository({ db: dbA });
+  const { rawKey: keyA, key: akA } = apiKeyRepoA.create({ label: 'a' });
+  const orgA = orgRepoA.createOrg({ name: 'A' });
+  orgRepoA.addMember({ orgId: orgA.id, apiKeyId: akA.id, role: 'owner' });
+
+  const { rawKey: keyB, key: akB } = apiKeyRepoA.create({ label: 'b' });
+  const orgB = orgRepoA.createOrg({ name: 'B' });
+  orgRepoA.addMember({ orgId: orgB.id, apiKeyId: akB.id, role: 'owner' });
+
+  const { server, baseUrl } = await startTestServer({
+    dbPath: ':memory:',
+    disableRedis: true,
+    apiKeyRepository: apiKeyRepoA,
+    orgMemberRepository: orgRepoA,
+  });
+
+  try {
+    // Create a campaign with org-A key (increments org-A counter).
+    await fetch(`${baseUrl}/api/v1/campaigns`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': keyA },
+      body: JSON.stringify({ name: 'A-camp', description: 'D', rewardPerAction: 1 }),
+    });
+
+    // Org-B's usage should be independent.
+    const resB = await fetch(`${baseUrl}/api/v1/usage`, {
+      headers: { 'x-api-key': keyB },
+    });
+    const bodyB = /** @type {any} */ (await resB.json());
+    const apiCallsB = bodyB.usage.find((/** @type {any} */ u) => u.resource === 'api_calls');
+    // org-B's /usage call itself increments its counter by 1, but should not pick up org-A's calls
+    assert.ok(
+      !apiCallsB || apiCallsB.count <= 1,
+      'org-B counter must not be affected by org-A calls',
+    );
+  } finally {
+    await stopTestServer(server);
+  }
+});

--- a/backend/src/middleware/usageMetering.js
+++ b/backend/src/middleware/usageMetering.js
@@ -1,0 +1,65 @@
+// @ts-check
+
+/**
+ * Per-tenant usage metering middleware (#574).
+ *
+ * Behaviour:
+ *   – Increments the `api_calls` counter for the authenticated org on every
+ *     request that carries a valid org-scoped API key.
+ *   – Sets informational quota headers on every response.
+ *   – Adds `X-Quota-Warning` when the soft limit is reached.
+ *   – Enforces the hard limit with 429 before the request is processed.
+ *
+ * Unauthenticated requests and env-sourced keys with no orgId pass through
+ * unmetered.
+ */
+
+/**
+ * @param {{
+ *   usageMeteringService: ReturnType<import('../services/usageMeteringService.js').createUsageMeteringService>,
+ *   resource?: string,
+ * }} options
+ */
+export function createUsageMeteringMiddleware({ usageMeteringService, resource = 'api_calls' }) {
+  return async function usageMeteringMiddleware(req, res, next) {
+    const orgId = req.auth?.orgId;
+    if (!orgId) return next();
+
+    let result;
+    try {
+      result = await usageMeteringService.increment(orgId, resource);
+    } catch {
+      // Metering failure must never block the request.
+      return next();
+    }
+
+    const { count, softLimit, hardLimit, windowSeconds } = result;
+
+    if (hardLimit !== null) {
+      res.setHeader('X-Quota-Limit', String(hardLimit));
+    }
+    res.setHeader('X-Quota-Used', String(count));
+    if (windowSeconds !== null) {
+      res.setHeader('X-Quota-Window', String(windowSeconds));
+    }
+
+    if (hardLimit !== null && count > hardLimit) {
+      return res.status(429).json({
+        error: 'Tenant quota exceeded',
+        code: 'QUOTA_EXCEEDED',
+        resource,
+        limit: hardLimit,
+        used: count,
+      });
+    }
+
+    if (softLimit !== null && count >= softLimit) {
+      res.setHeader(
+        'X-Quota-Warning',
+        `Approaching hard limit: ${count}/${hardLimit ?? 'unlimited'} ${resource} used this window`,
+      );
+    }
+
+    return next();
+  };
+}

--- a/backend/src/middleware/usageMetering.test.js
+++ b/backend/src/middleware/usageMetering.test.js
@@ -1,0 +1,177 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createUsageMeteringMiddleware } from './usageMetering.js';
+
+/**
+ * @param {{ orgId?: string | null; softLimit?: number | null; hardLimit?: number | null; count?: number }} [opts]
+ */
+function makeSetup({ orgId = 'org-1', softLimit = null, hardLimit = null, count = 1 } = {}) {
+  const req = { auth: orgId ? { orgId } : null };
+  const headers = {};
+  const res = {
+    statusCode: 200,
+    headers,
+    setHeader(name, value) {
+      headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+    body: null,
+  };
+
+  const mockService = {
+    async increment(_orgId, _resource) {
+      return {
+        count,
+        softLimit,
+        hardLimit,
+        windowStart: '2024-01-01T00:00:00.000Z',
+        windowSeconds: 3600,
+      };
+    },
+    getOrgUsage() {
+      return [];
+    },
+    adminExport() {
+      return [];
+    },
+    flushToDb() {
+      return Promise.resolve();
+    },
+    startFlushInterval() {
+      return () => {};
+    },
+  };
+
+  return { req, res, mockService };
+}
+
+// ── Pass-through when no orgId ─────────────────────────────────────────────
+
+test('skips metering when req.auth is null', async () => {
+  const { req, res, mockService } = makeSetup({ orgId: null });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, true);
+  assert.equal(res.headers['X-Quota-Used'], undefined);
+});
+
+// ── Header injection ───────────────────────────────────────────────────────
+
+test('sets X-Quota-Used header with the current count', async () => {
+  const { req, res, mockService } = makeSetup({ count: 7 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, true);
+  assert.equal(res.headers['X-Quota-Used'], '7');
+});
+
+test('sets X-Quota-Limit header when hard limit is configured', async () => {
+  const { req, res, mockService } = makeSetup({ hardLimit: 100, count: 5 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  await mw(req, res, () => {});
+  assert.equal(res.headers['X-Quota-Limit'], '100');
+});
+
+test('sets X-Quota-Window header', async () => {
+  const { req, res, mockService } = makeSetup({ count: 1 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  await mw(req, res, () => {});
+  assert.equal(res.headers['X-Quota-Window'], '3600');
+});
+
+// ── Soft limit warning ─────────────────────────────────────────────────────
+
+test('adds X-Quota-Warning when at soft limit', async () => {
+  const { req, res, mockService } = makeSetup({ softLimit: 5, hardLimit: 10, count: 5 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, true);
+  assert.ok(res.headers['X-Quota-Warning'], 'expected X-Quota-Warning header');
+});
+
+test('no warning when below soft limit', async () => {
+  const { req, res, mockService } = makeSetup({ softLimit: 10, hardLimit: 20, count: 3 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  await mw(req, res, () => {});
+  assert.equal(res.headers['X-Quota-Warning'], undefined);
+});
+
+// ── Hard limit enforcement ─────────────────────────────────────────────────
+
+test('returns 429 and blocks next() when hard limit exceeded', async () => {
+  const { req, res, mockService } = makeSetup({ hardLimit: 10, count: 11 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, false, 'next() must not be called after quota exceeded');
+  assert.equal(res.statusCode, 429);
+  assert.equal(res.body.code, 'QUOTA_EXCEEDED');
+  assert.equal(res.body.limit, 10);
+  assert.equal(res.body.used, 11);
+});
+
+test('allows request when exactly at hard limit (not over)', async () => {
+  const { req, res, mockService } = makeSetup({ hardLimit: 10, count: 10 });
+  const mw = createUsageMeteringMiddleware({ usageMeteringService: mockService });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, true, 'next() should be called when count == hardLimit');
+  assert.equal(res.statusCode, 200);
+});
+
+// ── Resilience ─────────────────────────────────────────────────────────────
+
+test('calls next() even when service.increment throws', async () => {
+  const req = { auth: { orgId: 'org-1' } };
+  const headers = {};
+  const res = {
+    statusCode: 200,
+    headers,
+    setHeader(n, v) {
+      headers[n] = v;
+    },
+    status(c) {
+      this.statusCode = c;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+      return this;
+    },
+    body: null,
+  };
+  const failingService = {
+    async increment() {
+      throw new Error('Redis down');
+    },
+  };
+  const mw = createUsageMeteringMiddleware({
+    usageMeteringService: /** @type {any} */ (failingService),
+  });
+  let called = false;
+  await mw(req, res, () => {
+    called = true;
+  });
+  assert.equal(called, true, 'service failure must not block request');
+});

--- a/backend/src/services/usageMeteringService.js
+++ b/backend/src/services/usageMeteringService.js
@@ -1,0 +1,171 @@
+// @ts-check
+
+/**
+ * Tenant-aware usage metering service (#574).
+ *
+ * Counters are stored in Redis (rolling windows) and periodically flushed to
+ * SQLite/PG for billing and reporting. Falls back to DB-only when Redis is
+ * unavailable, preserving correctness at the cost of some latency.
+ *
+ * Redis key schema:
+ *   usage:{orgId}:{resource}:{windowStart}  – rolling window counter
+ *   usage:{orgId}:{resource}:lifetime       – lifetime counter
+ */
+
+const FLUSH_INTERVAL_MS = 60_000;
+
+/**
+ * @param {{
+ *   usageRepository: ReturnType<import('../dal/sqliteUsageRepository.js').createSqliteUsageRepository>,
+ *   redisClient?: import('ioredis').Redis | null,
+ *   timeProvider?: () => number,
+ * }} params
+ */
+export function createUsageMeteringService({
+  usageRepository,
+  redisClient = null,
+  timeProvider = Date.now,
+}) {
+  /**
+   * Compute the start of the current rolling window (in ISO string) for a
+   * given windowSeconds length.
+   */
+  function windowStart(windowSeconds, nowMs = timeProvider()) {
+    const windowMs = windowSeconds * 1000;
+    const startMs = Math.floor(nowMs / windowMs) * windowMs;
+    return new Date(startMs).toISOString();
+  }
+
+  /**
+   * Increment the usage counter for an org + resource.
+   * Returns { count, windowStart, softLimit, hardLimit } after increment.
+   *
+   * If Redis is available the increment is atomic; otherwise we fall back to
+   * a DB read-modify-write (safe for single-process deploys).
+   */
+  async function increment(orgId, resource) {
+    const quota = usageRepository.getQuota(orgId, resource);
+    const windowSecs = quota?.windowSeconds ?? 3600;
+    const ws = windowStart(windowSecs);
+    const windowMs = windowSecs * 1000;
+
+    let count;
+
+    if (redisClient) {
+      const redisKey = `usage:${orgId}:${resource}:${ws}`;
+      const lifetimeKey = `usage:${orgId}:${resource}:lifetime`;
+
+      const results = await redisClient
+        .multi()
+        .incr(redisKey)
+        .pttl(redisKey)
+        .incr(lifetimeKey)
+        .exec();
+
+      if (!results || results[0]?.[0]) {
+        throw new Error('Redis usage increment failed');
+      }
+
+      count = /** @type {number} */ (results[0][1]);
+      const ttl = /** @type {number} */ (results[1][1]);
+
+      if (ttl === -1 || ttl === -2) {
+        await redisClient.pexpire(redisKey, windowMs);
+      }
+    } else {
+      const existing = usageRepository.getUsageWindow(orgId, resource, ws);
+      count = (existing?.count ?? 0) + 1;
+      usageRepository.upsertUsageWindow({ orgId, resource, windowStart: ws, count });
+    }
+
+    return {
+      count,
+      windowStart: ws,
+      softLimit: quota?.softLimit ?? null,
+      hardLimit: quota?.hardLimit ?? null,
+      windowSeconds: windowSecs,
+    };
+  }
+
+  /**
+   * Flush all live Redis counters to the DB for reporting/billing.
+   * Called on a background interval and on graceful shutdown.
+   */
+  async function flushToDb() {
+    if (!redisClient) return;
+
+    const keys = await redisClient.keys('usage:*:*:*');
+    for (const key of keys) {
+      // Ignore lifetime keys — they're not window-based.
+      if (key.endsWith(':lifetime')) continue;
+
+      const parts = key.split(':');
+      if (parts.length < 4) continue;
+      // key format: usage:{orgId}:{resource}:{windowStart}
+      // orgId may contain hyphens (UUID) — parts[1] is orgId, parts[2] is resource, rest is windowStart
+      const orgId = parts[1];
+      const resource = parts[2];
+      const ws = parts.slice(3).join(':');
+
+      const count = await redisClient.get(key);
+      if (count === null) continue;
+
+      usageRepository.upsertUsageWindow({
+        orgId,
+        resource,
+        windowStart: ws,
+        count: parseInt(count, 10),
+      });
+    }
+  }
+
+  /**
+   * Return current-window usage + quota for every tracked resource for an org.
+   */
+  function getOrgUsage(orgId) {
+    const quotas = usageRepository.getOrgQuotas(orgId);
+    const quotaMap = Object.fromEntries(quotas.map((q) => [q.resource, q]));
+
+    const usageRows = usageRepository.getOrgUsageSummary(orgId);
+    // Keep only the most recent window per resource.
+    const latestByResource = new Map();
+    for (const row of usageRows) {
+      if (!latestByResource.has(row.resource)) {
+        latestByResource.set(row.resource, row);
+      }
+    }
+
+    return Array.from(latestByResource.entries()).map(([resource, row]) => {
+      const quota = quotaMap[resource] ?? null;
+      return {
+        resource,
+        windowStart: row.windowStart,
+        count: row.count,
+        softLimit: quota?.softLimit ?? null,
+        hardLimit: quota?.hardLimit ?? null,
+        windowSeconds: quota?.windowSeconds ?? null,
+      };
+    });
+  }
+
+  /**
+   * Admin export: all orgs, all resources, most recent window.
+   */
+  function adminExport() {
+    return usageRepository.adminExportAll();
+  }
+
+  /**
+   * Start periodic flush. Returns a cleanup function.
+   */
+  function startFlushInterval() {
+    if (!redisClient) return () => {};
+    const id = setInterval(() => {
+      flushToDb().catch(() => {});
+    }, FLUSH_INTERVAL_MS);
+    id.unref?.();
+    return () => clearInterval(id);
+  }
+
+  return { increment, flushToDb, getOrgUsage, adminExport, startFlushInterval };
+}

--- a/backend/src/services/usageMeteringService.test.js
+++ b/backend/src/services/usageMeteringService.test.js
@@ -1,0 +1,197 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import { createSqliteUsageRepository } from '../dal/sqliteUsageRepository.js';
+import { createUsageMeteringService } from './usageMeteringService.js';
+
+async function makeDb() {
+  const db = new Database(':memory:');
+  await runMigrations(db);
+  return db;
+}
+
+async function makeService({ redisClient = null, timeProvider = Date.now } = {}) {
+  const db = await makeDb();
+  const usageRepository = createSqliteUsageRepository({ db });
+  const service = createUsageMeteringService({ usageRepository, redisClient, timeProvider });
+  return { service, usageRepository, db };
+}
+
+// ── increment (no Redis) ────────────────────────────────────────────────────
+
+test('increment returns count=1 for first call (no Redis)', async () => {
+  const { service } = await makeService();
+  const result = await service.increment('org-1', 'api_calls');
+  assert.equal(result.count, 1);
+  assert.equal(result.softLimit, null);
+  assert.equal(result.hardLimit, null);
+  assert.ok(typeof result.windowStart === 'string');
+});
+
+test('increment accumulates across calls within same window', async () => {
+  const now = Date.now();
+  const { service } = await makeService({ timeProvider: () => now });
+  await service.increment('org-1', 'api_calls');
+  await service.increment('org-1', 'api_calls');
+  const result = await service.increment('org-1', 'api_calls');
+  assert.equal(result.count, 3);
+});
+
+test('increment tracks different resources independently', async () => {
+  const { service } = await makeService();
+  await service.increment('org-1', 'api_calls');
+  const result = await service.increment('org-1', 'campaigns');
+  assert.equal(result.count, 1);
+});
+
+test('increment tracks different orgs independently', async () => {
+  const { service } = await makeService();
+  await service.increment('org-1', 'api_calls');
+  const result = await service.increment('org-2', 'api_calls');
+  assert.equal(result.count, 1);
+});
+
+// ── quota enforcement return values ────────────────────────────────────────
+
+test('increment returns quota limits when quota exists', async () => {
+  const { service, usageRepository, db } = await makeService();
+
+  // Create an org and set a quota.
+  db.exec(`INSERT INTO orgs (id, name, created_at) VALUES ('org-q', 'Q', '2024-01-01T00:00:00Z')`);
+  usageRepository.upsertQuota({
+    orgId: 'org-q',
+    resource: 'api_calls',
+    softLimit: 5,
+    hardLimit: 10,
+    windowSeconds: 3600,
+  });
+
+  const result = await service.increment('org-q', 'api_calls');
+  assert.equal(result.softLimit, 5);
+  assert.equal(result.hardLimit, 10);
+  assert.equal(result.windowSeconds, 3600);
+});
+
+// ── window bucketing ───────────────────────────────────────────────────────
+
+test('windows roll over when the period expires', async () => {
+  const T0 = Date.now();
+  const { service } = await makeService({ timeProvider: () => T0 });
+  await service.increment('org-1', 'api_calls');
+
+  // Advance past the 1-hour window.
+  const T1 = T0 + 3601 * 1000;
+  const { service: service2 } = await makeService({ timeProvider: () => T1 });
+  const result = await service2.increment('org-1', 'api_calls');
+  assert.equal(result.count, 1, 'counter should reset in a new window');
+});
+
+// ── getOrgUsage ────────────────────────────────────────────────────────────
+
+test('getOrgUsage returns empty array when no usage recorded', async () => {
+  const { service } = await makeService();
+  assert.deepEqual(service.getOrgUsage('unknown-org'), []);
+});
+
+test('getOrgUsage returns latest window per resource', async () => {
+  const { service } = await makeService();
+  await service.increment('org-1', 'api_calls');
+  await service.increment('org-1', 'api_calls');
+  await service.increment('org-1', 'campaigns');
+
+  const usage = service.getOrgUsage('org-1');
+  const apiCalls = usage.find((u) => u.resource === 'api_calls');
+  const campaigns = usage.find((u) => u.resource === 'campaigns');
+
+  assert.ok(apiCalls);
+  assert.equal(apiCalls.count, 2);
+  assert.ok(campaigns);
+  assert.equal(campaigns.count, 1);
+});
+
+// ── adminExport ────────────────────────────────────────────────────────────
+
+test('adminExport returns rows from all orgs', async () => {
+  const { service } = await makeService();
+  await service.increment('org-a', 'api_calls');
+  await service.increment('org-b', 'api_calls');
+
+  const rows = service.adminExport();
+  const orgIds = rows.map((r) => r.orgId);
+  assert.ok(orgIds.includes('org-a'));
+  assert.ok(orgIds.includes('org-b'));
+});
+
+// ── flushToDb (no Redis) ───────────────────────────────────────────────────
+
+test('flushToDb is a no-op when Redis is not configured', async () => {
+  const { service } = await makeService();
+  await assert.doesNotReject(() => service.flushToDb());
+});
+
+// ── Redis mock path ────────────────────────────────────────────────────────
+
+test('increment uses Redis when client is provided', async () => {
+  const store = new Map();
+  const ttls = new Map();
+
+  const mockRedis = {
+    multi() {
+      const ops = [];
+      const chain = {
+        incr(key) {
+          ops.push({ op: 'incr', key });
+          return chain;
+        },
+        pttl(key) {
+          ops.push({ op: 'pttl', key });
+          return chain;
+        },
+        incr2(key) {
+          ops.push({ op: 'incr', key });
+          return chain;
+        },
+        async exec() {
+          const results = [];
+          for (const { op, key } of ops) {
+            if (op === 'incr') {
+              const val = (store.get(key) ?? 0) + 1;
+              store.set(key, val);
+              results.push([null, val]);
+            } else if (op === 'pttl') {
+              results.push([null, ttls.get(key) ?? -2]);
+            }
+          }
+          return results;
+        },
+      };
+      return chain;
+    },
+    async pexpire(key, ms) {
+      ttls.set(key, ms);
+    },
+    async keys(pattern) {
+      const prefix = pattern.replace('*', '');
+      return [...store.keys()].filter((k) => k.startsWith(prefix) && !k.endsWith(':lifetime'));
+    },
+    async get(key) {
+      return String(store.get(key) ?? '0');
+    },
+  };
+
+  const db = await makeDb();
+  db.exec(`INSERT INTO orgs (id, name, created_at) VALUES ('org-r', 'R', '2024-01-01T00:00:00Z')`);
+  const usageRepository = createSqliteUsageRepository({ db });
+  const service = createUsageMeteringService({
+    usageRepository,
+    redisClient: /** @type {any} */ (mockRedis),
+  });
+
+  const r1 = await service.increment('org-r', 'api_calls');
+  assert.equal(r1.count, 1);
+
+  const r2 = await service.increment('org-r', 'api_calls');
+  assert.equal(r2.count, 2);
+});


### PR DESCRIPTION
Implements per-org API usage tracking with configurable soft/hard quota enforcement, a Redis rolling-window counter with SQLite flush fallback, and three new admin endpoints for quota management and usage export.

New files:
- backend/src/db/migrations/015_tenant_quotas.js — org_quotas and org_usage_log tables; org_usage_log intentionally has no FK on org_id for Redis-flush resilience.
- backend/src/dal/sqliteUsageRepository.js — upsertQuota, getQuota, upsertUsageWindow, getUsageWindow, getLatestUsage, getOrgUsageSummary, adminExportAll.
- backend/src/services/usageMeteringService.js — createUsageMeteringService with Redis multi() pipeline, DB fallback, flushToDb, getOrgUsage, adminExport, startFlushInterval.
- backend/src/middleware/usageMetering.js — createUsageMeteringMiddleware; sets X-Quota-Used / X-Quota-Limit / X-Quota-Window headers, adds X-Quota-Warning at soft limit, returns 429 QUOTA_EXCEEDED past hard limit; never blocks on service failure.
- backend/src/services/usageMeteringService.test.js — 11 unit tests.
- backend/src/middleware/usageMetering.test.js — 9 unit tests.
- backend/src/integration/usageMetering.test.js — 6 integration tests.

Modified files:
- backend/src/dal/index.js — expose dal.usage via createSqliteUsageRepository.
- backend/src/index.js — wire usageMeteringService + middleware; add GET /api/v1/usage, GET /api/v1/admin/usage, PUT /api/v1/admin/usage/quotas; spread guard = [requireApiKey, usageMeteringMiddleware] into all authenticated routes; flush on shutdown.

Closes #574