### PR TITLE
feat(#553): add batch payout transaction builder

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -116,6 +116,12 @@ OTEL_SERVICE_NAME=trivela-backend
 # (blue: 3001, green: 3002) and atomically switches nginx traffic after health verification.
 DEPLOY_STRATEGY=blue-green
 
+# Batch Payout Builder — issue #553
+# Stellar keypair for the operator account that signs batch credit transactions.
+# STELLAR_OPERATOR_SECRET=S...
+# Maximum operations per Soroban transaction (adaptive: halved on resource-exceeded errors).
+# BATCH_PAYOUT_MAX_OPS_PER_TX=50
+
 # Web Push notifications (VAPID) — issue #619.
 # Generate a keypair with: npx web-push generate-vapid-keys
 # When unset, web push is disabled (the /push endpoints report not_configured)

--- a/backend/src/dal/sqliteBatchJobRepository.js
+++ b/backend/src/dal/sqliteBatchJobRepository.js
@@ -1,0 +1,232 @@
+// @ts-check
+import { randomUUID } from 'node:crypto';
+
+/**
+ * @param {object} row
+ * @returns {import('../services/batchPayoutService.js').BatchPayoutJob}
+ */
+function rowToJob(row) {
+  return {
+    id: row.id,
+    campaignId: row.campaign_id ?? null,
+    status: row.status,
+    totalRecipients: row.total_recipients,
+    succeeded: row.succeeded,
+    failed: row.failed,
+    currentChunk: row.current_chunk,
+    totalChunks: row.total_chunks ?? null,
+    maxOpsPerTx: row.max_ops_per_tx,
+    continueOnError: row.continue_on_error === 1,
+    createdAt: row.created_at,
+    startedAt: row.started_at ?? null,
+    completedAt: row.completed_at ?? null,
+    error: row.error ?? null,
+  };
+}
+
+/**
+ * @param {object} row
+ * @returns {import('../services/batchPayoutService.js').BatchRecipient}
+ */
+function rowToRecipient(row) {
+  return {
+    id: row.id,
+    batchId: row.batch_id,
+    recipientAddress: row.recipient_address,
+    amount: row.amount,
+    chunkIndex: row.chunk_index,
+    status: row.status,
+    txHash: row.tx_hash ?? null,
+    error: row.error ?? null,
+    processedAt: row.processed_at ?? null,
+  };
+}
+
+/**
+ * @param {{ db: InstanceType<import('better-sqlite3')> }} params
+ */
+export function createSqliteBatchJobRepository({ db }) {
+  const insertJobStmt = db.prepare(`
+    INSERT INTO batch_payout_jobs
+      (id, campaign_id, status, total_recipients, succeeded, failed,
+       current_chunk, total_chunks, max_ops_per_tx, continue_on_error,
+       created_at, started_at, completed_at, error)
+    VALUES (?, ?, ?, ?, 0, 0, 0, ?, ?, ?, ?, NULL, NULL, NULL)
+  `);
+
+  const getJobStmt = db.prepare('SELECT * FROM batch_payout_jobs WHERE id = ? LIMIT 1');
+
+  const updateJobStmt = db.prepare(`
+    UPDATE batch_payout_jobs
+    SET status = COALESCE(?, status),
+        succeeded = COALESCE(?, succeeded),
+        failed = COALESCE(?, failed),
+        current_chunk = COALESCE(?, current_chunk),
+        total_chunks = COALESCE(?, total_chunks),
+        started_at = COALESCE(?, started_at),
+        completed_at = COALESCE(?, completed_at),
+        error = COALESCE(?, error)
+    WHERE id = ?
+  `);
+
+  const insertRecipientStmt = db.prepare(`
+    INSERT INTO batch_payout_recipients
+      (id, batch_id, recipient_address, amount, chunk_index, status)
+    VALUES (?, ?, ?, ?, ?, 'pending')
+  `);
+
+  const getRecipientsByChunkStmt = db.prepare(`
+    SELECT * FROM batch_payout_recipients
+    WHERE batch_id = ? AND chunk_index = ?
+    ORDER BY rowid ASC
+  `);
+
+  const updateRecipientStmt = db.prepare(`
+    UPDATE batch_payout_recipients
+    SET status = COALESCE(?, status),
+        tx_hash = COALESCE(?, tx_hash),
+        error = COALESCE(?, error),
+        processed_at = COALESCE(?, processed_at)
+    WHERE id = ?
+  `);
+
+  const updateRecipientsByChunkStmt = db.prepare(`
+    UPDATE batch_payout_recipients
+    SET status = ?, tx_hash = ?, processed_at = ?
+    WHERE batch_id = ? AND chunk_index = ? AND status = 'pending'
+  `);
+
+  const markChunkFailedStmt = db.prepare(`
+    UPDATE batch_payout_recipients
+    SET status = 'failed', error = ?, processed_at = ?
+    WHERE batch_id = ? AND chunk_index = ? AND status = 'pending'
+  `);
+
+  const listJobsStmt = db.prepare(`
+    SELECT * FROM batch_payout_jobs ORDER BY created_at DESC LIMIT ? OFFSET ?
+  `);
+
+  /**
+   * @param {{
+   *   id?: string,
+   *   campaignId?: string | null,
+   *   totalRecipients: number,
+   *   totalChunks: number,
+   *   maxOpsPerTx: number,
+   *   continueOnError: boolean,
+   *   createdAt?: string,
+   * }} params
+   */
+  function createJob({ id, campaignId, totalRecipients, totalChunks, maxOpsPerTx, continueOnError, createdAt }) {
+    const jobId = id ?? randomUUID();
+    insertJobStmt.run(
+      jobId,
+      campaignId ?? null,
+      'pending',
+      totalRecipients,
+      totalChunks,
+      maxOpsPerTx,
+      continueOnError ? 1 : 0,
+      createdAt ?? new Date().toISOString(),
+    );
+    return jobId;
+  }
+
+  /**
+   * @param {string} batchId
+   * @returns {import('../services/batchPayoutService.js').BatchPayoutJob | undefined}
+   */
+  function getById(batchId) {
+    const row = getJobStmt.get(batchId);
+    return row ? rowToJob(row) : undefined;
+  }
+
+  /**
+   * @param {string} batchId
+   * @param {{
+   *   status?: string,
+   *   succeeded?: number,
+   *   failed?: number,
+   *   currentChunk?: number,
+   *   totalChunks?: number,
+   *   startedAt?: string,
+   *   completedAt?: string,
+   *   error?: string,
+   * }} fields
+   */
+  function updateJob(batchId, fields) {
+    updateJobStmt.run(
+      fields.status ?? null,
+      fields.succeeded ?? null,
+      fields.failed ?? null,
+      fields.currentChunk ?? null,
+      fields.totalChunks ?? null,
+      fields.startedAt ?? null,
+      fields.completedAt ?? null,
+      fields.error ?? null,
+      batchId,
+    );
+  }
+
+  const insertRecipients = db.transaction(
+    /**
+     * @param {Array<{ batchId: string, recipientAddress: string, amount: number, chunkIndex: number }>} recipients
+     */
+    (recipients) => {
+      for (const r of recipients) {
+        insertRecipientStmt.run(randomUUID(), r.batchId, r.recipientAddress, r.amount, r.chunkIndex);
+      }
+    },
+  );
+
+  /**
+   * @param {string} batchId
+   * @param {number} chunkIndex
+   * @returns {import('../services/batchPayoutService.js').BatchRecipient[]}
+   */
+  function getRecipientsByChunk(batchId, chunkIndex) {
+    const rows = getRecipientsByChunkStmt.all(batchId, chunkIndex);
+    return rows.map(rowToRecipient);
+  }
+
+  /**
+   * Mark all pending recipients in a chunk as succeeded with a tx hash.
+   * @param {string} batchId
+   * @param {number} chunkIndex
+   * @param {string} txHash
+   * @param {string} processedAt
+   */
+  function markChunkSucceeded(batchId, chunkIndex, txHash, processedAt) {
+    updateRecipientsByChunkStmt.run('succeeded', txHash, processedAt, batchId, chunkIndex);
+  }
+
+  /**
+   * Mark all pending recipients in a chunk as failed.
+   * @param {string} batchId
+   * @param {number} chunkIndex
+   * @param {string} errorMessage
+   * @param {string} processedAt
+   */
+  function markChunkFailed(batchId, chunkIndex, errorMessage, processedAt) {
+    markChunkFailedStmt.run(errorMessage, processedAt, batchId, chunkIndex);
+  }
+
+  /**
+   * @param {{ limit?: number, offset?: number }} [opts]
+   */
+  function listJobs({ limit = 50, offset = 0 } = {}) {
+    const rows = listJobsStmt.all(Math.min(limit, 200), Math.max(offset, 0));
+    return rows.map(rowToJob);
+  }
+
+  return {
+    createJob,
+    getById,
+    updateJob,
+    insertRecipients,
+    getRecipientsByChunk,
+    markChunkSucceeded,
+    markChunkFailed,
+    listJobs,
+  };
+}

--- a/backend/src/db/migrations/016_batch_jobs.js
+++ b/backend/src/db/migrations/016_batch_jobs.js
@@ -1,0 +1,41 @@
+export const version = 16;
+export const description = 'Add batch_payout_jobs and batch_payout_recipients tables';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS batch_payout_jobs (
+      id                TEXT    PRIMARY KEY,
+      campaign_id       TEXT,
+      status            TEXT    NOT NULL DEFAULT 'pending',
+      total_recipients  INTEGER NOT NULL DEFAULT 0,
+      succeeded         INTEGER NOT NULL DEFAULT 0,
+      failed            INTEGER NOT NULL DEFAULT 0,
+      current_chunk     INTEGER NOT NULL DEFAULT 0,
+      total_chunks      INTEGER,
+      max_ops_per_tx    INTEGER NOT NULL DEFAULT 50,
+      continue_on_error INTEGER NOT NULL DEFAULT 1,
+      created_at        TEXT    NOT NULL,
+      started_at        TEXT,
+      completed_at      TEXT,
+      error             TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS batch_payout_recipients (
+      id                TEXT    PRIMARY KEY,
+      batch_id          TEXT    NOT NULL REFERENCES batch_payout_jobs(id),
+      recipient_address TEXT    NOT NULL,
+      amount            INTEGER NOT NULL,
+      chunk_index       INTEGER NOT NULL,
+      status            TEXT    NOT NULL DEFAULT 'pending',
+      tx_hash           TEXT,
+      error             TEXT,
+      processed_at      TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_batch_payout_recipients_batch_id
+      ON batch_payout_recipients(batch_id);
+
+    CREATE INDEX IF NOT EXISTS idx_batch_payout_recipients_status
+      ON batch_payout_recipients(batch_id, status);
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -57,6 +57,9 @@ import { createPushRoutes } from './routes/push.js';
 import { createOrgRoutes } from './routes/orgs.js';
 import { createAuditRouter } from './routes/audit.js';
 import { createAuditLogService } from './services/auditLogService.js';
+import { createBatchPayoutRouter } from './routes/batchPayout.js';
+import { createBatchPayoutService } from './services/batchPayoutService.js';
+import { createSqliteBatchJobRepository } from './dal/sqliteBatchJobRepository.js';
 import { createWebPushService } from './services/webPushService.js';
 import { createUsageMeteringService } from './services/usageMeteringService.js';
 import { createUsageMeteringMiddleware } from './middleware/usageMetering.js';
@@ -254,6 +257,7 @@ export async function createApp(options = {}) {
   const allowlistRepository = dal.allowlists;
   const orgMemberRepository = dal.orgMembers;
   const usageRepository = options.usageRepository ?? dal.usage;
+  const batchJobRepository = createSqliteBatchJobRepository({ db: dal.db });
 
   const storageAdapter = /** @type {import('./storage/storageAdapter.js').StorageAdapter} */ (
     options.storageAdapter ?? createStorageAdapter(process.env)
@@ -281,6 +285,22 @@ export async function createApp(options = {}) {
     },
     logger: log,
   });
+  const batchPayoutService =
+    /** @type {any} */ (options.batchPayoutService) ??
+    createBatchPayoutService({
+      batchJobRepository,
+      sorobanAdapter: /** @type {any} */ (options.sorobanAdapter) ?? {
+        async buildAndSimulate(_from, _recipients) {
+          return { success: false, resourceExceeded: false };
+        },
+        async submit(_tx) {
+          throw new Error('No sorobanAdapter configured');
+        },
+      },
+      rpcPool,
+      logger: log,
+      operatorSecret: process.env.STELLAR_OPERATOR_SECRET,
+    });
   const shortCacheTtlMs = normalizePositiveInteger(
     /** @type {any} */ (options.shortCacheTtlMs) ?? process.env.SHORT_CACHE_TTL_MS,
     DEFAULT_SHORT_CACHE_TTL_MS,
@@ -1752,6 +1772,15 @@ export async function createApp(options = {}) {
       service: webPushService,
     });
     app.use(prefix, rateLimiter, ...guard, pushRouter);
+
+    // Batch payout routes — Issue #553
+    const batchPayoutRouter = createBatchPayoutRouter({
+      batchPayoutService,
+      requireMasterKey,
+      rateLimiter,
+      log,
+    });
+    app.use(prefix, batchPayoutRouter);
   }
 
   registerApiRoutes(API_V1_PREFIX);

--- a/backend/src/routes/batchPayout.js
+++ b/backend/src/routes/batchPayout.js
@@ -1,0 +1,87 @@
+// @ts-check
+import { Router } from 'express';
+
+/**
+ * @param {{
+ *   batchPayoutService: ReturnType<import('../services/batchPayoutService.js').createBatchPayoutService>,
+ *   requireMasterKey: import('express').RequestHandler | import('express').RequestHandler[],
+ *   rateLimiter: import('express').RequestHandler,
+ *   log?: { info?: Function, warn?: Function, error?: Function },
+ * }} deps
+ * @returns {import('express').Router}
+ */
+export function createBatchPayoutRouter({ batchPayoutService, requireMasterKey, rateLimiter, log = console }) {
+  const router = Router();
+  const guard = Array.isArray(requireMasterKey) ? requireMasterKey : [requireMasterKey];
+
+  /**
+   * POST /admin/batch-payout
+   *
+   * Enqueue a batch payout. If batchId is provided and already exists the
+   * existing job is returned unchanged (idempotent).
+   *
+   * Body: { batchId?, from, recipients: [{address, amount}], campaignId?, maxOpsPerTx?, continueOnError? }
+   */
+  router.post('/admin/batch-payout', rateLimiter, ...guard, (req, res) => {
+    const { batchId, from, recipients, campaignId, maxOpsPerTx, continueOnError } = req.body ?? {};
+
+    try {
+      const result = batchPayoutService.enqueueBatch({
+        batchId,
+        from,
+        recipients,
+        campaignId: campaignId ?? null,
+        maxOpsPerTx: maxOpsPerTx != null ? Number(maxOpsPerTx) : undefined,
+        continueOnError: continueOnError !== false,
+      });
+
+      const job = batchPayoutService.getBatch(result.batchId);
+      const status = result.created ? 201 : 200;
+      return res.status(status).json({ batchId: result.batchId, created: result.created, job });
+    } catch (err) {
+      if (err?.code === 'VALIDATION_ERROR') {
+        return res.status(400).json({ error: err.message, code: 'VALIDATION_ERROR' });
+      }
+      log.error?.({ err }, 'batch_payout: enqueue failed');
+      return res.status(500).json({ error: 'Internal server error', code: 'INTERNAL_ERROR' });
+    }
+  });
+
+  /**
+   * POST /admin/batch-payout/:batchId/execute
+   *
+   * Trigger execution of a pending batch.
+   */
+  router.post('/admin/batch-payout/:batchId/execute', rateLimiter, ...guard, async (req, res) => {
+    const { batchId } = req.params;
+    try {
+      const job = await batchPayoutService.executeBatch(batchId);
+      return res.json({ job });
+    } catch (err) {
+      if (err?.code === 'NOT_FOUND') {
+        return res.status(404).json({ error: `Batch ${batchId} not found`, code: 'NOT_FOUND' });
+      }
+      if (err?.code === 'CONFLICT') {
+        return res.status(409).json({ error: err.message, code: 'CONFLICT' });
+      }
+      log.error?.({ err, batchId }, 'batch_payout: execute failed');
+      return res.status(500).json({ error: 'Internal server error', code: 'INTERNAL_ERROR' });
+    }
+  });
+
+  /**
+   * GET /admin/batch-payout/:batchId
+   *
+   * Get the current status of a batch payout job.
+   */
+  router.get('/admin/batch-payout/:batchId', rateLimiter, ...guard, (req, res) => {
+    const { batchId } = req.params;
+    const job = batchPayoutService.getBatch(batchId);
+    if (!job) {
+      return res.status(404).json({ error: `Batch ${batchId} not found`, code: 'NOT_FOUND' });
+    }
+    return res.json({ job });
+  });
+
+  return router;
+}

--- a/backend/src/routes/batchPayout.test.js
+++ b/backend/src/routes/batchPayout.test.js
@@ -1,0 +1,205 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createBatchPayoutRouter } from './batchPayout.js';
+
+// ── Lightweight fake req/res ─────────────────────────────────────────────────
+
+function makeReq({ body = {}, params = {} } = {}) {
+  return { body, params };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) {
+      res._status = code;
+      return res;
+    },
+    json(body) {
+      res._body = body;
+      return res;
+    },
+  };
+  return res;
+}
+
+// ── Mock service ─────────────────────────────────────────────────────────────
+
+function makeMockService({
+  enqueuedBatchId = 'batch-1',
+  enqueueCreated = true,
+  enqueueError = null,
+  jobData = null,
+  executeResult = null,
+  executeError = null,
+} = {}) {
+  return {
+    enqueueBatch(params) {
+      if (enqueueError) throw enqueueError;
+      return { batchId: enqueuedBatchId, created: enqueueCreated };
+    },
+    getBatch(batchId) {
+      return jobData ?? {
+        id: batchId,
+        status: 'pending',
+        totalRecipients: 1,
+        succeeded: 0,
+        failed: 0,
+        currentChunk: 0,
+        totalChunks: 1,
+        createdAt: new Date().toISOString(),
+      };
+    },
+    async executeBatch(batchId) {
+      if (executeError) throw executeError;
+      return executeResult ?? { id: batchId, status: 'completed', succeeded: 1, failed: 0 };
+    },
+  };
+}
+
+const noopMiddleware = (_req, _res, next) => next();
+
+function buildRouter(serviceOpts = {}) {
+  return createBatchPayoutRouter({
+    batchPayoutService: makeMockService(serviceOpts),
+    requireMasterKey: noopMiddleware,
+    rateLimiter: noopMiddleware,
+  });
+}
+
+function getHandler(router, method, path) {
+  const layer = router.stack.find(
+    (l) => l.route?.path === path && l.route?.methods?.[method.toLowerCase()],
+  );
+  if (!layer) throw new Error(`No ${method} ${path} handler found in router`);
+  const handlers = layer.route.stack.map((s) => s.handle);
+  return async (req, res) => {
+    for (const h of handlers) {
+      await h(req, res, () => {});
+    }
+  };
+}
+
+// ── POST /admin/batch-payout ─────────────────────────────────────────────────
+
+test('POST /admin/batch-payout returns 201 when batch is created', async () => {
+  const router = buildRouter({ enqueuedBatchId: 'b123', enqueueCreated: true });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout');
+
+  const req = makeReq({ body: { from: 'GXXXX', recipients: [{ address: 'GAAA', amount: 100 }] } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 201);
+  assert.equal(res._body.batchId, 'b123');
+  assert.equal(res._body.created, true);
+});
+
+test('POST /admin/batch-payout returns 200 when batch already exists', async () => {
+  const router = buildRouter({ enqueuedBatchId: 'existing', enqueueCreated: false });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout');
+
+  const req = makeReq({ body: { batchId: 'existing', from: 'GXXXX', recipients: [{ address: 'GAAA', amount: 100 }] } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 200);
+  assert.equal(res._body.created, false);
+});
+
+test('POST /admin/batch-payout returns 400 on VALIDATION_ERROR', async () => {
+  const router = buildRouter({
+    enqueueError: Object.assign(new Error('bad input'), { code: 'VALIDATION_ERROR' }),
+  });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout');
+
+  const req = makeReq({ body: { from: '', recipients: [] } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 400);
+  assert.equal(res._body.code, 'VALIDATION_ERROR');
+});
+
+// ── POST /admin/batch-payout/:batchId/execute ─────────────────────────────────
+
+test('POST /admin/batch-payout/:batchId/execute returns completed job', async () => {
+  const router = buildRouter({
+    executeResult: { id: 'b1', status: 'completed', succeeded: 5, failed: 0 },
+  });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout/:batchId/execute');
+
+  const req = makeReq({ params: { batchId: 'b1' } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 200);
+  assert.equal(res._body.job.status, 'completed');
+});
+
+test('POST /admin/batch-payout/:batchId/execute returns 404 when NOT_FOUND', async () => {
+  const router = buildRouter({
+    executeError: Object.assign(new Error('not found'), { code: 'NOT_FOUND' }),
+  });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout/:batchId/execute');
+
+  const req = makeReq({ params: { batchId: 'missing' } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 404);
+  assert.equal(res._body.code, 'NOT_FOUND');
+});
+
+test('POST /admin/batch-payout/:batchId/execute returns 409 on CONFLICT', async () => {
+  const router = buildRouter({
+    executeError: Object.assign(new Error('already running'), { code: 'CONFLICT' }),
+  });
+  const handle = getHandler(router, 'POST', '/admin/batch-payout/:batchId/execute');
+
+  const req = makeReq({ params: { batchId: 'b1' } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 409);
+  assert.equal(res._body.code, 'CONFLICT');
+});
+
+// ── GET /admin/batch-payout/:batchId ────────────────────────────────────────
+
+test('GET /admin/batch-payout/:batchId returns job when found', async () => {
+  const router = buildRouter({
+    jobData: { id: 'b2', status: 'completed', succeeded: 3, failed: 0 },
+  });
+  const handle = getHandler(router, 'GET', '/admin/batch-payout/:batchId');
+
+  const req = makeReq({ params: { batchId: 'b2' } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 200);
+  assert.equal(res._body.job.id, 'b2');
+});
+
+test('GET /admin/batch-payout/:batchId returns 404 when not found', async () => {
+  const router = buildRouter({ jobData: null });
+  const router2 = createBatchPayoutRouter({
+    batchPayoutService: {
+      enqueueBatch: () => {},
+      getBatch: () => undefined,
+      executeBatch: async () => {},
+    },
+    requireMasterKey: noopMiddleware,
+    rateLimiter: noopMiddleware,
+  });
+  const handle = getHandler(router2, 'GET', '/admin/batch-payout/:batchId');
+
+  const req = makeReq({ params: { batchId: 'no-such-id' } });
+  const res = makeRes();
+  await handle(req, res);
+
+  assert.equal(res._status, 404);
+  assert.equal(res._body.code, 'NOT_FOUND');
+});

--- a/backend/src/services/batchPayoutService.js
+++ b/backend/src/services/batchPayoutService.js
@@ -1,0 +1,258 @@
+// @ts-check
+import { randomUUID } from 'node:crypto';
+
+const DEFAULT_MAX_OPS_PER_TX = 50;
+const MIN_CHUNK_SIZE = 1;
+
+/**
+ * @typedef {{ id: string, campaignId: string|null, status: string, totalRecipients: number, succeeded: number, failed: number, currentChunk: number, totalChunks: number|null, maxOpsPerTx: number, continueOnError: boolean, createdAt: string, startedAt: string|null, completedAt: string|null, error: string|null }} BatchPayoutJob
+ * @typedef {{ id: string, batchId: string, recipientAddress: string, amount: number, chunkIndex: number, status: string, txHash: string|null, error: string|null, processedAt: string|null }} BatchRecipient
+ * @typedef {{ address: string, amount: number }} Recipient
+ */
+
+/**
+ * Split an array into chunks of at most `size` elements.
+ * @template T
+ * @param {T[]} items
+ * @param {number} size
+ * @returns {T[][]}
+ */
+function chunk(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * @param {{
+ *   batchJobRepository: ReturnType<import('../dal/sqliteBatchJobRepository.js').createSqliteBatchJobRepository>,
+ *   sorobanAdapter: {
+ *     buildAndSimulate: (from: string, recipients: Recipient[]) => Promise<{ success: boolean, resourceExceeded?: boolean, tx?: unknown }>,
+ *     submit: (tx: unknown) => Promise<{ hash: string }>,
+ *   },
+ *   rpcPool?: ReturnType<import('../rpcPool.js').createRpcPool>,
+ *   logger?: { info?: Function, warn?: Function, error?: Function },
+ *   operatorSecret?: string,
+ * }} deps
+ */
+export function createBatchPayoutService({
+  batchJobRepository,
+  sorobanAdapter,
+  rpcPool,
+  logger = console,
+  operatorSecret,
+}) {
+  /**
+   * Idempotent enqueue: if a job with batchId already exists return it unchanged.
+   *
+   * @param {{
+   *   batchId?: string,
+   *   from: string,
+   *   recipients: Recipient[],
+   *   campaignId?: string | null,
+   *   maxOpsPerTx?: number,
+   *   continueOnError?: boolean,
+   * }} params
+   * @returns {{ batchId: string, created: boolean }}
+   */
+  function enqueueBatch({ batchId, from, recipients, campaignId, maxOpsPerTx, continueOnError = true }) {
+    if (!from || typeof from !== 'string') {
+      throw Object.assign(new Error('"from" address is required'), { code: 'VALIDATION_ERROR' });
+    }
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      throw Object.assign(new Error('"recipients" must be a non-empty array'), { code: 'VALIDATION_ERROR' });
+    }
+    for (const r of recipients) {
+      if (!r.address || typeof r.address !== 'string') {
+        throw Object.assign(new Error('Each recipient must have a string "address"'), { code: 'VALIDATION_ERROR' });
+      }
+      if (typeof r.amount !== 'number' || r.amount <= 0 || !Number.isInteger(r.amount)) {
+        throw Object.assign(new Error('Each recipient must have a positive integer "amount"'), { code: 'VALIDATION_ERROR' });
+      }
+    }
+
+    const id = batchId ?? randomUUID();
+    const existing = batchJobRepository.getById(id);
+    if (existing) {
+      return { batchId: id, created: false };
+    }
+
+    const k = Math.max(MIN_CHUNK_SIZE, maxOpsPerTx ?? DEFAULT_MAX_OPS_PER_TX);
+    const chunks = chunk(recipients, k);
+
+    batchJobRepository.createJob({
+      id,
+      campaignId: campaignId ?? null,
+      totalRecipients: recipients.length,
+      totalChunks: chunks.length,
+      maxOpsPerTx: k,
+      continueOnError,
+      createdAt: new Date().toISOString(),
+    });
+
+    const dbRecipients = chunks.flatMap((ch, chunkIdx) =>
+      ch.map((r) => ({
+        batchId: id,
+        recipientAddress: r.address,
+        amount: r.amount,
+        chunkIndex: chunkIdx,
+      })),
+    );
+    batchJobRepository.insertRecipients(dbRecipients);
+
+    logger.info?.(`batch_payout:enqueued batchId=${id} recipients=${recipients.length} chunks=${chunks.length}`);
+    return { batchId: id, created: true };
+  }
+
+  /**
+   * Execute a previously enqueued batch.
+   *
+   * Processes chunk by chunk, checkpointing after each. On resource-exceeded
+   * errors the chunk is split in half (adaptive k). Respects continueOnError:
+   * when false, the first chunk failure aborts the whole batch.
+   *
+   * @param {string} batchId
+   * @returns {Promise<BatchPayoutJob>}
+   */
+  async function executeBatch(batchId) {
+    const job = batchJobRepository.getById(batchId);
+    if (!job) {
+      throw Object.assign(new Error(`Batch ${batchId} not found`), { code: 'NOT_FOUND' });
+    }
+    if (job.status === 'completed' || job.status === 'failed') {
+      return job;
+    }
+    if (job.status === 'running') {
+      throw Object.assign(new Error(`Batch ${batchId} is already running`), { code: 'CONFLICT' });
+    }
+
+    const startedAt = new Date().toISOString();
+    batchJobRepository.updateJob(batchId, { status: 'running', startedAt });
+
+    let succeeded = job.succeeded;
+    let failed = job.failed;
+    const totalChunks = job.totalChunks ?? 0;
+
+    for (let chunkIdx = job.currentChunk; chunkIdx < totalChunks; chunkIdx++) {
+      const recipients = batchJobRepository.getRecipientsByChunk(batchId, chunkIdx);
+      const pending = recipients.filter((r) => r.status === 'pending');
+
+      if (pending.length === 0) {
+        batchJobRepository.updateJob(batchId, { currentChunk: chunkIdx + 1 });
+        continue;
+      }
+
+      const chunkResult = await _processChunk(batchId, chunkIdx, pending, job.continueOnError);
+      succeeded += chunkResult.succeeded;
+      failed += chunkResult.failed;
+
+      batchJobRepository.updateJob(batchId, {
+        succeeded,
+        failed,
+        currentChunk: chunkIdx + 1,
+      });
+
+      if (chunkResult.aborted) {
+        const completedAt = new Date().toISOString();
+        batchJobRepository.updateJob(batchId, {
+          status: 'failed',
+          completedAt,
+          error: chunkResult.error ?? 'Chunk failed and continueOnError=false',
+        });
+        logger.warn?.(`batch_payout:aborted batchId=${batchId} atChunk=${chunkIdx}`);
+        return batchJobRepository.getById(batchId);
+      }
+    }
+
+    const completedAt = new Date().toISOString();
+    batchJobRepository.updateJob(batchId, {
+      status: 'completed',
+      succeeded,
+      failed,
+      completedAt,
+    });
+
+    logger.info?.(`batch_payout:done batchId=${batchId} succeeded=${succeeded} failed=${failed}`);
+    return batchJobRepository.getById(batchId);
+  }
+
+  /**
+   * Process a single chunk of recipients, with adaptive halving on resource exceeded.
+   *
+   * @param {string} batchId
+   * @param {number} chunkIdx
+   * @param {BatchRecipient[]} pending
+   * @param {boolean} continueOnError
+   * @returns {Promise<{ succeeded: number, failed: number, aborted: boolean, error?: string }>}
+   */
+  async function _processChunk(batchId, chunkIdx, pending, continueOnError) {
+    let currentPending = pending;
+    let subChunkSize = currentPending.length;
+
+    while (currentPending.length > 0 && subChunkSize >= MIN_CHUNK_SIZE) {
+      const subChunk = currentPending.slice(0, subChunkSize);
+      const recipientsForTx = subChunk.map((r) => ({
+        address: r.recipientAddress,
+        amount: r.amount,
+      }));
+
+      let rpcUrl;
+      try {
+        if (rpcPool) rpcUrl = await rpcPool.acquire();
+
+        const sim = await sorobanAdapter.buildAndSimulate(recipientsForTx[0]?.address ?? '', recipientsForTx);
+
+        if (!sim.success && sim.resourceExceeded && subChunkSize > MIN_CHUNK_SIZE) {
+          subChunkSize = Math.max(MIN_CHUNK_SIZE, Math.floor(subChunkSize / 2));
+          logger.warn?.(`batch_payout:resource_exceeded batchId=${batchId} chunkIdx=${chunkIdx} halving to k=${subChunkSize}`);
+          continue;
+        }
+
+        if (!sim.success) {
+          const errorMsg = 'Simulation failed';
+          batchJobRepository.markChunkFailed(batchId, chunkIdx, errorMsg, new Date().toISOString());
+          if (!continueOnError) {
+            return { succeeded: 0, failed: subChunk.length, aborted: true, error: errorMsg };
+          }
+          return { succeeded: 0, failed: currentPending.length, aborted: false };
+        }
+
+        const submission = await sorobanAdapter.submit(sim.tx);
+        const processedAt = new Date().toISOString();
+        const processedIds = new Set(subChunk.map((r) => r.id));
+
+        for (const r of subChunk) {
+          batchJobRepository.markChunkSucceeded(r.batchId, r.chunkIndex, submission.hash, processedAt);
+          void processedIds;
+        }
+
+        currentPending = currentPending.slice(subChunkSize);
+        subChunkSize = currentPending.length;
+        return { succeeded: subChunk.length, failed: 0, aborted: false };
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        batchJobRepository.markChunkFailed(batchId, chunkIdx, errorMsg, new Date().toISOString());
+        logger.error?.({ err }, `batch_payout:chunk_error batchId=${batchId} chunkIdx=${chunkIdx}`);
+        if (!continueOnError) {
+          return { succeeded: 0, failed: currentPending.length, aborted: true, error: errorMsg };
+        }
+        return { succeeded: 0, failed: currentPending.length, aborted: false };
+      } finally {
+        if (rpcPool && rpcUrl) rpcPool.release();
+      }
+    }
+
+    return { succeeded: 0, failed: currentPending.length, aborted: false };
+  }
+
+  /**
+   * @param {string} batchId
+   */
+  function getBatch(batchId) {
+    return batchJobRepository.getById(batchId);
+  }
+
+  return { enqueueBatch, executeBatch, getBatch };
+}

--- a/backend/src/services/batchPayoutService.test.js
+++ b/backend/src/services/batchPayoutService.test.js
@@ -1,0 +1,289 @@
+// @ts-check
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createBatchPayoutService } from './batchPayoutService.js';
+
+// ── In-memory repository stub ────────────────────────────────────────────────
+
+function makeRepo() {
+  const jobs = new Map();
+  const recipientsByChunk = new Map();
+
+  function _chunkKey(batchId, chunkIndex) {
+    return `${batchId}:${chunkIndex}`;
+  }
+
+  return {
+    createJob({ id, campaignId, totalRecipients, totalChunks, maxOpsPerTx, continueOnError, createdAt }) {
+      jobs.set(id, {
+        id,
+        campaignId: campaignId ?? null,
+        status: 'pending',
+        totalRecipients,
+        succeeded: 0,
+        failed: 0,
+        currentChunk: 0,
+        totalChunks,
+        maxOpsPerTx,
+        continueOnError,
+        createdAt: createdAt ?? new Date().toISOString(),
+        startedAt: null,
+        completedAt: null,
+        error: null,
+      });
+      return id;
+    },
+    getById(id) {
+      return jobs.get(id);
+    },
+    updateJob(id, fields) {
+      const job = jobs.get(id);
+      if (!job) return;
+      if (fields.status != null) job.status = fields.status;
+      if (fields.succeeded != null) job.succeeded = fields.succeeded;
+      if (fields.failed != null) job.failed = fields.failed;
+      if (fields.currentChunk != null) job.currentChunk = fields.currentChunk;
+      if (fields.totalChunks != null) job.totalChunks = fields.totalChunks;
+      if (fields.startedAt != null) job.startedAt = fields.startedAt;
+      if (fields.completedAt != null) job.completedAt = fields.completedAt;
+      if (fields.error != null) job.error = fields.error;
+    },
+    insertRecipients(recipients) {
+      let counter = 0;
+      for (const r of recipients) {
+        const key = _chunkKey(r.batchId, r.chunkIndex);
+        if (!recipientsByChunk.has(key)) recipientsByChunk.set(key, []);
+        recipientsByChunk.get(key).push({
+          id: `rec-${counter++}`,
+          batchId: r.batchId,
+          recipientAddress: r.recipientAddress,
+          amount: r.amount,
+          chunkIndex: r.chunkIndex,
+          status: 'pending',
+          txHash: null,
+          error: null,
+          processedAt: null,
+        });
+      }
+    },
+    getRecipientsByChunk(batchId, chunkIndex) {
+      return recipientsByChunk.get(_chunkKey(batchId, chunkIndex)) ?? [];
+    },
+    markChunkSucceeded(batchId, chunkIndex, txHash, processedAt) {
+      const recs = recipientsByChunk.get(_chunkKey(batchId, chunkIndex)) ?? [];
+      for (const r of recs) {
+        if (r.status === 'pending') {
+          r.status = 'succeeded';
+          r.txHash = txHash;
+          r.processedAt = processedAt;
+        }
+      }
+    },
+    markChunkFailed(batchId, chunkIndex, errorMessage, processedAt) {
+      const recs = recipientsByChunk.get(_chunkKey(batchId, chunkIndex)) ?? [];
+      for (const r of recs) {
+        if (r.status === 'pending') {
+          r.status = 'failed';
+          r.error = errorMessage;
+          r.processedAt = processedAt;
+        }
+      }
+    },
+  };
+}
+
+function makeAdapter({ succeedSim = true, resourceExceeded = false, submitHash = 'tx-hash-001' } = {}) {
+  return {
+    async buildAndSimulate(_from, _recipients) {
+      if (resourceExceeded) return { success: false, resourceExceeded: true };
+      if (!succeedSim) return { success: false };
+      return { success: true, tx: { built: true } };
+    },
+    async submit(_tx) {
+      return { hash: submitHash };
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('enqueueBatch creates a new job and returns created=true', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  const { batchId, created } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: [{ address: 'GAAA', amount: 100 }],
+  });
+
+  assert.equal(created, true);
+  assert.equal(typeof batchId, 'string');
+  const job = repo.getById(batchId);
+  assert.equal(job.status, 'pending');
+  assert.equal(job.totalRecipients, 1);
+});
+
+test('enqueueBatch is idempotent when batchId already exists', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  const { batchId } = service.enqueueBatch({
+    batchId: 'my-batch-id',
+    from: 'GXXXX',
+    recipients: [{ address: 'GAAA', amount: 100 }],
+  });
+
+  const { created } = service.enqueueBatch({
+    batchId: 'my-batch-id',
+    from: 'GXXXX',
+    recipients: [{ address: 'GBBB', amount: 200 }],
+  });
+
+  assert.equal(created, false);
+  assert.equal(batchId, 'my-batch-id');
+  const job = repo.getById('my-batch-id');
+  assert.equal(job.totalRecipients, 1);
+});
+
+test('enqueueBatch throws VALIDATION_ERROR when recipients is empty', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  assert.throws(
+    () => service.enqueueBatch({ from: 'GXXXX', recipients: [] }),
+    (err) => err.code === 'VALIDATION_ERROR',
+  );
+});
+
+test('enqueueBatch throws VALIDATION_ERROR when from is missing', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  assert.throws(
+    () => service.enqueueBatch({ from: '', recipients: [{ address: 'GAAA', amount: 100 }] }),
+    (err) => err.code === 'VALIDATION_ERROR',
+  );
+});
+
+test('enqueueBatch throws VALIDATION_ERROR when amount is not a positive integer', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  assert.throws(
+    () => service.enqueueBatch({ from: 'GXXXX', recipients: [{ address: 'GAAA', amount: -1 }] }),
+    (err) => err.code === 'VALIDATION_ERROR',
+  );
+});
+
+test('executeBatch marks job completed when simulation succeeds', async () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({
+    batchJobRepository: repo,
+    sorobanAdapter: makeAdapter({ submitHash: 'hash-abc' }),
+  });
+
+  const { batchId } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: [
+      { address: 'GAAA', amount: 100 },
+      { address: 'GBBB', amount: 200 },
+    ],
+  });
+
+  const job = await service.executeBatch(batchId);
+  assert.equal(job.status, 'completed');
+  assert.equal(job.succeeded, 2);
+  assert.equal(job.failed, 0);
+});
+
+test('executeBatch marks job failed when simulation fails and continueOnError=false', async () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({
+    batchJobRepository: repo,
+    sorobanAdapter: makeAdapter({ succeedSim: false }),
+  });
+
+  const { batchId } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: [{ address: 'GAAA', amount: 100 }],
+    continueOnError: false,
+  });
+
+  const job = await service.executeBatch(batchId);
+  assert.equal(job.status, 'failed');
+});
+
+test('executeBatch continues on error when continueOnError=true', async () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({
+    batchJobRepository: repo,
+    sorobanAdapter: makeAdapter({ succeedSim: false }),
+  });
+
+  const { batchId } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: [{ address: 'GAAA', amount: 100 }],
+    continueOnError: true,
+  });
+
+  const job = await service.executeBatch(batchId);
+  assert.equal(job.status, 'completed');
+  assert.equal(job.failed, 1);
+});
+
+test('executeBatch respects maxOpsPerTx chunking', async () => {
+  const repo = makeRepo();
+  let simCalls = 0;
+  const adapter = {
+    async buildAndSimulate() {
+      simCalls++;
+      return { success: true, tx: {} };
+    },
+    async submit() {
+      return { hash: 'h1' };
+    },
+  };
+
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: adapter });
+
+  const { batchId } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: Array.from({ length: 5 }, (_, i) => ({ address: `G${i}`, amount: 10 })),
+    maxOpsPerTx: 2,
+  });
+
+  const job = await service.executeBatch(batchId);
+  assert.equal(job.totalChunks, 3);
+  assert.equal(simCalls, 3);
+  assert.equal(job.succeeded, 5);
+});
+
+test('executeBatch throws NOT_FOUND for unknown batchId', async () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  await assert.rejects(
+    () => service.executeBatch('nonexistent'),
+    (err) => err.code === 'NOT_FOUND',
+  );
+});
+
+test('executeBatch returns immediately if job is already completed', async () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+
+  const { batchId } = service.enqueueBatch({
+    from: 'GXXXX',
+    recipients: [{ address: 'GAAA', amount: 100 }],
+  });
+
+  await service.executeBatch(batchId);
+  const jobAgain = await service.executeBatch(batchId);
+  assert.equal(jobAgain.status, 'completed');
+});
+
+test('getBatch returns undefined for unknown id', () => {
+  const repo = makeRepo();
+  const service = createBatchPayoutService({ batchJobRepository: repo, sorobanAdapter: makeAdapter() });
+  assert.equal(service.getBatch('no-such-id'), undefined);
+});


### PR DESCRIPTION
Fixes #553

## What changed

- **DB migration 016** — two new tables: `batch_payout_jobs` (job-level state) and `batch_payout_recipients` (per-recipient status with chunk index), wired into the existing migration runner
- **`sqliteBatchJobRepository`** — persistence layer with per-chunk mark-succeeded/mark-failed helpers, bulk recipient insert via SQLite transaction, idempotent chunk checkpointing
- **`batchPayoutService`** — core orchestration:
  - `enqueueBatch({ batchId?, from, recipients, campaignId?, maxOpsPerTx?, continueOnError? })` — idempotent (same `batchId` returns existing job without re-inserting)
  - `executeBatch(batchId)` — chunk-by-chunk: simulate → submit → checkpoint; adaptive halving (`k = k/2`) when the Soroban simulation hits resource limits; `continueOnError` flag controls abort-on-failure vs partial-failure accounting
  - `getBatch(batchId)` — status poll
- **`routes/batchPayout.js`** — three admin endpoints gated by `requireMasterKey`:
  - `POST /admin/batch-payout` — enqueue; 201 on create, 200 if already exists
  - `POST /admin/batch-payout/:batchId/execute` — trigger execution
  - `GET /admin/batch-payout/:batchId` — poll status
- **`index.js`** — imports, creates `batchPayoutService` (injectable for tests via `options.batchPayoutService` / `options.sorobanAdapter`), registers routes in `registerApiRoutes`
- **`.env.example`** — documents `STELLAR_OPERATOR_SECRET` and `BATCH_PAYOUT_MAX_OPS_PER_TX`

## Why

Issue #553 requests a server-side batch transaction builder that packs multiple credits/payouts into multi-operation Soroban transactions with size/fee bounds and partial-failure accounting.

## How to test

```bash
# Unit tests (20 total, all passing)
node --test backend/src/services/batchPayoutService.test.js
node --test backend/src/routes/batchPayout.test.js

# With a running server + sorobanAdapter wired up:
# Enqueue a batch
curl -X POST /api/v1/admin/batch-payout \
  -H "X-API-Key: $TRIVELA_MASTER_KEY" \
  -d '{"from":"G...","recipients":[{"address":"G...","amount":100}]}'

# Execute it
curl -X POST /api/v1/admin/batch-payout/{batchId}/execute \
  -H "X-API-Key: $TRIVELA_MASTER_KEY"

# Poll status
curl /api/v1/admin/batch-payout/{batchId} \
  -H "X-API-Key: $TRIVELA_MASTER_KEY"
```