### PR TITLE
feat(backend): batch payout transaction builder with adaptive chunking

### DIFF
--- a/backend/src/routes/batchPayout.js
+++ b/backend/src/routes/batchPayout.js
@@ -1,0 +1,90 @@
+// @ts-check
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import { BatchPayoutError } from '../services/batchPayoutService.js';
+
+/**
+ * Admin API for batch payout operations.
+ *
+ * Routes:
+ *   POST   /api/v1/batch-payouts              – register + launch a batch
+ *   GET    /api/v1/batch-payouts              – list all batches
+ *   GET    /api/v1/batch-payouts/:batchId     – get batch status + per-recipient detail
+ *
+ * @param {{
+ *   batchPayoutService: ReturnType<import('../services/batchPayoutService.js').createBatchPayoutService>,
+ *   requireApiKey: import('express').RequestHandler | import('express').RequestHandler[],
+ *   log: Pick<Console, 'info' | 'warn' | 'error'>,
+ * }} deps
+ * @returns {import('express').Router}
+ */
+export function createBatchPayoutRouter({ batchPayoutService, requireApiKey, log }) {
+  const router = Router();
+  const auth = Array.isArray(requireApiKey) ? requireApiKey : [requireApiKey];
+
+  // ── POST /api/v1/batch-payouts ─────────────────────────────────────────────
+  // Register a new batch and kick off async execution.
+  // Idempotent: if batchId is supplied and already exists, returns the existing
+  // record without re-launching. Omit batchId to auto-generate one.
+
+  router.post('/batch-payouts', ...auth, (req, res) => {
+    const { campaignId, recipients, batchId, failMode } = req.body ?? {};
+
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      return res.status(400).json({ error: 'recipients must be a non-empty array', code: 'VALIDATION_ERROR' });
+    }
+    if (recipients.length > 10_000) {
+      return res.status(400).json({ error: 'Maximum 10 000 recipients per batch', code: 'BATCH_TOO_LARGE' });
+    }
+
+    const id = typeof batchId === 'string' && batchId ? batchId : randomUUID();
+
+    let batch;
+    try {
+      batch = batchPayoutService.registerBatch({ batchId: id, recipients, campaignId: campaignId ?? '' });
+    } catch (err) {
+      if (err instanceof BatchPayoutError) {
+        return res.status(400).json({ error: err.message, code: err.code });
+      }
+      log.error(err, 'batch_payout:register_error');
+      return res.status(500).json({ error: 'Internal server error', code: 'INTERNAL_ERROR' });
+    }
+
+    // Fire-and-forget — progress is visible via GET /batch-payouts/:batchId
+    batchPayoutService.executeBatch(id).catch((err) => {
+      if (err instanceof BatchPayoutError && err.code === 'ALREADY_RUNNING') return;
+      log.error({ err, batchId: id }, 'batch_payout:execution_error');
+    });
+
+    return res.status(202).json({
+      batchId: id,
+      status: batch.status,
+      totalRecipients: batch.totalRecipients,
+    });
+  });
+
+  // ── GET /api/v1/batch-payouts ──────────────────────────────────────────────
+
+  router.get('/batch-payouts', ...auth, (_req, res) => {
+    const batches = batchPayoutService.listBatches().map(summaryView);
+    return res.json({ batches, count: batches.length });
+  });
+
+  // ── GET /api/v1/batch-payouts/:batchId ────────────────────────────────────
+
+  router.get('/batch-payouts/:batchId', ...auth, (req, res) => {
+    const batch = batchPayoutService.getBatch(req.params.batchId);
+    if (!batch) {
+      return res.status(404).json({ error: 'Batch not found', code: 'NOT_FOUND' });
+    }
+    return res.json({ batch });
+  });
+
+  return router;
+}
+
+/** Strip the recipient list for the summary view to keep list responses small. */
+function summaryView(batch) {
+  const { recipients: _r, ...rest } = batch;
+  return rest;
+}

--- a/backend/src/services/batchPayoutService.js
+++ b/backend/src/services/batchPayoutService.js
@@ -1,0 +1,343 @@
+// @ts-check
+// Batch payout transaction builder — packs up to k credit ops per Soroban tx,
+// adapts k on resource-limit failures, checkpoints per chunk, and enforces
+// idempotency so retried batches cannot double-pay.
+
+const MIN_OPS_PER_CHUNK = 1;
+
+export const RECIPIENT_STATUS = /** @type {const} */ ({
+  PENDING: 'pending',
+  SUCCESS: 'success',
+  FAILED: 'failed',
+});
+
+export const BATCH_STATUS = /** @type {const} */ ({
+  PENDING: 'pending',
+  RUNNING: 'running',
+  COMPLETED: 'completed',
+  PARTIAL: 'partial',
+  FAILED: 'failed',
+});
+
+export class BatchPayoutError extends Error {
+  /** @param {string} message @param {string} code */
+  constructor(message, code) {
+    super(message);
+    this.name = 'BatchPayoutError';
+    this.code = code;
+  }
+}
+
+/**
+ * @typedef {{ address: string; amount: string }} PayoutOp
+ * @typedef {{ address: string; amount: string; status: string; txHash: string | null; errorMessage: string | null }} RecipientRecord
+ * @typedef {{
+ *   id: string;
+ *   campaignId: string;
+ *   status: string;
+ *   recipients: RecipientRecord[];
+ *   totalRecipients: number;
+ *   successCount: number;
+ *   failCount: number;
+ *   chunksCompleted: number;
+ *   createdAt: string;
+ *   updatedAt: string;
+ *   completedAt: string | null;
+ * }} BatchRecord
+ */
+
+/**
+ * Creates an in-memory batch store.
+ * Swap for a persistent implementation (SQLite/Postgres) in production.
+ */
+export function createInMemoryBatchStore() {
+  /** @type {Map<string, BatchRecord>} */
+  const batches = new Map();
+
+  return {
+    /** @param {BatchRecord} record */
+    saveBatch(record) {
+      batches.set(record.id, JSON.parse(JSON.stringify(record)));
+    },
+    /** @param {string} batchId @returns {BatchRecord | undefined} */
+    getBatch(batchId) {
+      const r = batches.get(batchId);
+      return r ? JSON.parse(JSON.stringify(r)) : undefined;
+    },
+    /** @param {string} batchId @param {Partial<BatchRecord>} updates */
+    updateBatch(batchId, updates) {
+      const existing = batches.get(batchId);
+      if (!existing) throw new BatchPayoutError(`Batch ${batchId} not found`, 'NOT_FOUND');
+      batches.set(batchId, {
+        ...existing,
+        ...updates,
+        updatedAt: new Date().toISOString(),
+      });
+    },
+    /** @returns {BatchRecord[]} */
+    listBatches() {
+      return Array.from(batches.values())
+        .map((r) => JSON.parse(JSON.stringify(r)))
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    },
+  };
+}
+
+/**
+ * Creates the batch payout service.
+ *
+ * @param {{
+ *   simulateChunk: (ops: PayoutOp[]) => Promise<{ success: boolean; resourceLimitExceeded: boolean; errorMessage?: string }>,
+ *   submitChunk: (ops: PayoutOp[]) => Promise<{ success: boolean; txHash?: string; recipientErrors?: Record<string, string>; errorMessage?: string }>,
+ *   store: ReturnType<typeof createInMemoryBatchStore>,
+ *   maxOpsPerChunk?: number,
+ *   failMode?: 'continue' | 'abort',
+ *   log?: Pick<Console, 'info' | 'warn' | 'error'>,
+ * }} deps
+ */
+export function createBatchPayoutService({
+  simulateChunk,
+  submitChunk,
+  store,
+  maxOpsPerChunk = 50,
+  failMode = 'continue',
+  log = console,
+}) {
+  /**
+   * Register a new batch. Returns immediately; call executeBatch(id) to run.
+   * Idempotent: re-submitting a batchId that already exists returns the
+   * existing record without modifying it — prevents duplicate submissions.
+   *
+   * @param {{ batchId: string; recipients: Array<{address: string; amount: string}>; campaignId: string }} params
+   * @returns {BatchRecord}
+   */
+  function registerBatch({ batchId, recipients, campaignId }) {
+    if (!batchId || typeof batchId !== 'string') {
+      throw new BatchPayoutError('batchId is required', 'INVALID_INPUT');
+    }
+    if (!Array.isArray(recipients) || recipients.length === 0) {
+      throw new BatchPayoutError('recipients must be a non-empty array', 'INVALID_INPUT');
+    }
+    for (const r of recipients) {
+      if (!r.address || typeof r.address !== 'string') {
+        throw new BatchPayoutError('each recipient must have a string address', 'INVALID_INPUT');
+      }
+      if (!r.amount || typeof r.amount !== 'string') {
+        throw new BatchPayoutError('each recipient must have a string amount', 'INVALID_INPUT');
+      }
+    }
+
+    const existing = store.getBatch(batchId);
+    if (existing) return existing; // idempotency
+
+    /** @type {BatchRecord} */
+    const record = {
+      id: batchId,
+      campaignId: campaignId ?? '',
+      status: BATCH_STATUS.PENDING,
+      recipients: recipients.map((r) => ({
+        address: r.address,
+        amount: r.amount,
+        status: RECIPIENT_STATUS.PENDING,
+        txHash: null,
+        errorMessage: null,
+      })),
+      totalRecipients: recipients.length,
+      successCount: 0,
+      failCount: 0,
+      chunksCompleted: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedAt: null,
+    };
+
+    store.saveBatch(record);
+    return store.getBatch(batchId);
+  }
+
+  /**
+   * Execute a registered batch. Safe to call after a partial failure —
+   * resumes from the first still-pending recipient (checkpoint recovery).
+   *
+   * @param {string} batchId
+   * @returns {Promise<BatchRecord>}
+   */
+  async function executeBatch(batchId) {
+    const batch = store.getBatch(batchId);
+    if (!batch) throw new BatchPayoutError(`Batch ${batchId} not found`, 'NOT_FOUND');
+
+    if (batch.status === BATCH_STATUS.COMPLETED) {
+      log.info(`batch:skip_completed id=${batchId}`);
+      return batch;
+    }
+    if (batch.status === BATCH_STATUS.RUNNING) {
+      throw new BatchPayoutError(`Batch ${batchId} is already running`, 'ALREADY_RUNNING');
+    }
+
+    store.updateBatch(batchId, { status: BATCH_STATUS.RUNNING });
+
+    // Resume: only process recipients that are still pending.
+    // Recipients already marked success/failed from a previous partial run are skipped.
+    const queue = batch.recipients
+      .filter((r) => r.status === RECIPIENT_STATUS.PENDING)
+      .map((r) => ({ ...r })); // mutable copies
+
+    let successCount = batch.successCount;
+    let failCount = batch.failCount;
+    let chunksCompleted = batch.chunksCompleted;
+    let k = Math.min(maxOpsPerChunk, queue.length || 1);
+    let head = 0;
+    let aborted = false;
+
+    while (head < queue.length && !aborted) {
+      const chunk = queue.slice(head, head + k);
+
+      log.info(`batch:chunk_start id=${batchId} head=${head} ops=${chunk.length} k=${k}`);
+
+      const simResult = await simulateChunk(chunk.map((r) => ({ address: r.address, amount: r.amount })));
+
+      if (!simResult.success) {
+        if (simResult.resourceLimitExceeded && k > MIN_OPS_PER_CHUNK) {
+          // Halve chunk size and retry the same head position
+          k = Math.max(MIN_OPS_PER_CHUNK, Math.floor(k / 2));
+          log.warn(`batch:adaptive_k id=${batchId} reduced_to=${k}`);
+          continue;
+        }
+
+        // Simulation failed for a non-resource reason, or k is already minimum
+        const reason = simResult.errorMessage || 'simulation failed';
+        for (const r of chunk) {
+          r.status = RECIPIENT_STATUS.FAILED;
+          r.errorMessage = reason;
+        }
+        failCount += chunk.length;
+
+        if (failMode === 'abort') {
+          aborted = true;
+          break;
+        }
+
+        head += chunk.length;
+        _checkpoint(batchId, queue, { successCount, failCount, chunksCompleted });
+        continue;
+      }
+
+      // Simulation passed — submit the chunk
+      const submitResult = await submitChunk(chunk.map((r) => ({ address: r.address, amount: r.amount })));
+
+      if (submitResult.success) {
+        for (const r of chunk) {
+          r.status = RECIPIENT_STATUS.SUCCESS;
+          r.txHash = submitResult.txHash ?? null;
+        }
+        // Apply any per-recipient errors reported by the contract (partial ops failure)
+        if (submitResult.recipientErrors) {
+          for (const [addr, errMsg] of Object.entries(submitResult.recipientErrors)) {
+            const r = chunk.find((c) => c.address === addr);
+            if (r) {
+              r.status = RECIPIENT_STATUS.FAILED;
+              r.errorMessage = errMsg;
+            }
+          }
+        }
+        const chunkSuccess = chunk.filter((r) => r.status === RECIPIENT_STATUS.SUCCESS).length;
+        const chunkFail = chunk.filter((r) => r.status === RECIPIENT_STATUS.FAILED).length;
+        successCount += chunkSuccess;
+        failCount += chunkFail;
+      } else {
+        const reason = submitResult.errorMessage || 'submission failed';
+        for (const r of chunk) {
+          r.status = RECIPIENT_STATUS.FAILED;
+          r.errorMessage = reason;
+        }
+        failCount += chunk.length;
+        if (failMode === 'abort') {
+          head += chunk.length;
+          _checkpoint(batchId, queue, { successCount, failCount, chunksCompleted });
+          aborted = true;
+          break;
+        }
+      }
+
+      chunksCompleted += 1;
+      head += chunk.length;
+      _checkpoint(batchId, queue, { successCount, failCount, chunksCompleted });
+    }
+
+    // Recompute totals from recipient state so that resumed batches
+    // (where a previously-failed recipient was reset to pending and retried)
+    // report accurate counts rather than accumulated deltas.
+    const finalBatch = store.getBatch(batchId);
+    const finalSuccess = finalBatch.recipients.filter((r) => r.status === RECIPIENT_STATUS.SUCCESS).length;
+    const finalFail = finalBatch.recipients.filter((r) => r.status === RECIPIENT_STATUS.FAILED).length;
+
+    const finalStatus = aborted
+      ? BATCH_STATUS.FAILED
+      : finalFail > 0
+        ? BATCH_STATUS.PARTIAL
+        : BATCH_STATUS.COMPLETED;
+
+    store.updateBatch(batchId, {
+      status: finalStatus,
+      successCount: finalSuccess,
+      failCount: finalFail,
+      chunksCompleted,
+      completedAt: new Date().toISOString(),
+    });
+
+    return store.getBatch(batchId);
+  }
+
+  /**
+   * Flush the current in-memory queue state back to the persistent store.
+   * Called after every chunk so a crash can be resumed mid-batch.
+   *
+   * @param {string} batchId
+   * @param {RecipientRecord[]} queue
+   * @param {{ successCount: number; failCount: number; chunksCompleted: number }} counters
+   */
+  function _checkpoint(batchId, queue, counters) {
+    const batch = store.getBatch(batchId);
+    if (!batch) return;
+
+    const queueMap = new Map(queue.map((r) => [r.address, r]));
+    const merged = batch.recipients.map((r) => {
+      const updated = queueMap.get(r.address);
+      return updated
+        ? { ...r, status: updated.status, txHash: updated.txHash, errorMessage: updated.errorMessage }
+        : r;
+    });
+
+    store.updateBatch(batchId, { recipients: merged, ...counters });
+  }
+
+  /** @param {string} batchId @returns {BatchRecord | undefined} */
+  function getBatch(batchId) {
+    return store.getBatch(batchId);
+  }
+
+  /** @returns {BatchRecord[]} */
+  function listBatches() {
+    return store.listBatches();
+  }
+
+  return { registerBatch, executeBatch, getBatch, listBatches };
+}
+
+// ── internal helpers (exported for unit tests) ────────────────────────────────
+
+/**
+ * Split an array into chunks of at most `size` elements.
+ * @template T
+ * @param {T[]} arr
+ * @param {number} size
+ * @returns {T[][]}
+ */
+export function chunkArray(arr, size) {
+  if (size <= 0) size = 1;
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}

--- a/backend/src/services/batchPayoutService.test.js
+++ b/backend/src/services/batchPayoutService.test.js
@@ -1,0 +1,392 @@
+// @ts-check
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createBatchPayoutService,
+  createInMemoryBatchStore,
+  chunkArray,
+  RECIPIENT_STATUS,
+  BATCH_STATUS,
+  BatchPayoutError,
+} from './batchPayoutService.js';
+
+// ── chunkArray helper ─────────────────────────────────────────────────────────
+
+test('chunkArray splits an array into equal-sized chunks', () => {
+  assert.deepEqual(chunkArray([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+});
+
+test('chunkArray returns one chunk when size >= array length', () => {
+  assert.deepEqual(chunkArray([1, 2, 3], 10), [[1, 2, 3]]);
+});
+
+test('chunkArray returns one-element chunks when size is 1', () => {
+  assert.deepEqual(chunkArray(['a', 'b'], 1), [['a'], ['b']]);
+});
+
+test('chunkArray returns empty array for empty input', () => {
+  assert.deepEqual(chunkArray([], 5), []);
+});
+
+// ── in-memory store ───────────────────────────────────────────────────────────
+
+test('createInMemoryBatchStore round-trips a record', () => {
+  const store = createInMemoryBatchStore();
+  const rec = {
+    id: 'b1',
+    campaignId: 'c1',
+    status: BATCH_STATUS.PENDING,
+    recipients: [],
+    totalRecipients: 0,
+    successCount: 0,
+    failCount: 0,
+    chunksCompleted: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    completedAt: null,
+  };
+  store.saveBatch(rec);
+  assert.equal(store.getBatch('b1').id, 'b1');
+});
+
+test('createInMemoryBatchStore returns undefined for unknown batchId', () => {
+  const store = createInMemoryBatchStore();
+  assert.equal(store.getBatch('nope'), undefined);
+});
+
+test('updateBatch throws for unknown batchId', () => {
+  const store = createInMemoryBatchStore();
+  assert.throws(() => store.updateBatch('ghost', { status: BATCH_STATUS.RUNNING }), BatchPayoutError);
+});
+
+// ── registerBatch ─────────────────────────────────────────────────────────────
+
+function makeService(overrides = {}) {
+  const silentLog = { info() {}, warn() {}, error() {} };
+  return createBatchPayoutService({
+    simulateChunk: async () => ({ success: true, resourceLimitExceeded: false }),
+    submitChunk: async () => ({ success: true, txHash: 'TX_HASH' }),
+    store: createInMemoryBatchStore(),
+    maxOpsPerChunk: 3,
+    failMode: 'continue',
+    log: silentLog,
+    ...overrides,
+  });
+}
+
+const RECIPIENTS = [
+  { address: 'GAAA', amount: '100' },
+  { address: 'GBBB', amount: '200' },
+  { address: 'GCCC', amount: '300' },
+];
+
+test('registerBatch creates a batch in PENDING state', () => {
+  const svc = makeService();
+  const batch = svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  assert.equal(batch.id, 'b1');
+  assert.equal(batch.status, BATCH_STATUS.PENDING);
+  assert.equal(batch.totalRecipients, 3);
+  assert.equal(batch.successCount, 0);
+  assert.equal(batch.failCount, 0);
+});
+
+test('registerBatch is idempotent — second call returns the same record', () => {
+  const svc = makeService();
+  const first = svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  const second = svc.registerBatch({
+    batchId: 'b1',
+    recipients: [{ address: 'GDDD', amount: '99' }],
+    campaignId: 'c2',
+  });
+  assert.deepEqual(first, second);
+  assert.equal(second.totalRecipients, 3); // original recipients preserved
+});
+
+test('registerBatch rejects empty recipients array', () => {
+  const svc = makeService();
+  assert.throws(
+    () => svc.registerBatch({ batchId: 'b1', recipients: [], campaignId: 'c1' }),
+    BatchPayoutError,
+  );
+});
+
+test('registerBatch rejects a recipient missing amount', () => {
+  const svc = makeService();
+  assert.throws(
+    () =>
+      svc.registerBatch({
+        batchId: 'b1',
+        recipients: [{ address: 'GAAA', amount: '' }],
+        campaignId: 'c1',
+      }),
+    BatchPayoutError,
+  );
+});
+
+// ── executeBatch — happy path ─────────────────────────────────────────────────
+
+test('executeBatch marks all recipients SUCCESS when everything passes', async () => {
+  const svc = makeService();
+  svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  assert.equal(result.status, BATCH_STATUS.COMPLETED);
+  assert.equal(result.successCount, 3);
+  assert.equal(result.failCount, 0);
+  for (const r of result.recipients) {
+    assert.equal(r.status, RECIPIENT_STATUS.SUCCESS);
+    assert.equal(r.txHash, 'TX_HASH');
+  }
+});
+
+test('executeBatch uses the correct number of chunks (ceil(N/k))', async () => {
+  let chunkCallCount = 0;
+  const svc = makeService({
+    simulateChunk: async () => ({ success: true, resourceLimitExceeded: false }),
+    submitChunk: async () => {
+      chunkCallCount += 1;
+      return { success: true, txHash: 'TX' };
+    },
+    maxOpsPerChunk: 2,
+  });
+  svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' }); // 3 recipients, k=2 → 2 chunks
+  await svc.executeBatch('b1');
+  assert.equal(chunkCallCount, 2);
+});
+
+test('executeBatch skips already-completed batch without re-running', async () => {
+  let callCount = 0;
+  const svc = makeService({
+    submitChunk: async () => {
+      callCount += 1;
+      return { success: true, txHash: 'TX' };
+    },
+  });
+  svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  await svc.executeBatch('b1');
+  const firstCallCount = callCount;
+  await svc.executeBatch('b1'); // second call — should be a no-op
+  assert.equal(callCount, firstCallCount);
+});
+
+test('executeBatch rejects if batch does not exist', async () => {
+  const svc = makeService();
+  await assert.rejects(() => svc.executeBatch('ghost'), BatchPayoutError);
+});
+
+test('executeBatch rejects concurrent execution of the same batch', async () => {
+  let resolveSubmit;
+  const submitDone = new Promise((r) => { resolveSubmit = r; });
+
+  const svc = makeService({
+    submitChunk: async () => {
+      await submitDone;
+      return { success: true, txHash: 'TX' };
+    },
+  });
+  svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  const first = svc.executeBatch('b1');
+  await assert.rejects(() => svc.executeBatch('b1'), BatchPayoutError);
+  resolveSubmit();
+  await first;
+});
+
+// ── executeBatch — adaptive k ─────────────────────────────────────────────────
+
+test('executeBatch halves k on resourceLimitExceeded and retries', async () => {
+  const simulateCalls = [];
+  let firstCall = true;
+
+  const svc = makeService({
+    simulateChunk: async (ops) => {
+      simulateCalls.push(ops.length);
+      if (firstCall && ops.length > 1) {
+        firstCall = false;
+        return { success: false, resourceLimitExceeded: true };
+      }
+      return { success: true, resourceLimitExceeded: false };
+    },
+    maxOpsPerChunk: 4,
+  });
+
+  const recipients = [
+    { address: 'GA', amount: '1' },
+    { address: 'GB', amount: '2' },
+    { address: 'GC', amount: '3' },
+    { address: 'GD', amount: '4' },
+  ];
+  svc.registerBatch({ batchId: 'b1', recipients, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  // First simulate call was 4 ops (failed), second was 2 (halved)
+  assert.equal(simulateCalls[0], 4);
+  assert.equal(simulateCalls[1], 2);
+  assert.equal(result.successCount, 4);
+  assert.equal(result.status, BATCH_STATUS.COMPLETED);
+});
+
+test('executeBatch fails ops when resource limit hits k=1 (cannot halve further)', async () => {
+  const svc = makeService({
+    simulateChunk: async () => ({ success: false, resourceLimitExceeded: true, errorMessage: 'too big' }),
+    maxOpsPerChunk: 1,
+  });
+  const recipients = [{ address: 'GA', amount: '1' }, { address: 'GB', amount: '2' }];
+  svc.registerBatch({ batchId: 'b1', recipients, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  assert.equal(result.failCount, 2);
+  assert.equal(result.status, BATCH_STATUS.PARTIAL);
+  for (const r of result.recipients) {
+    assert.equal(r.status, RECIPIENT_STATUS.FAILED);
+  }
+});
+
+// ── executeBatch — fail modes ─────────────────────────────────────────────────
+
+test('continue mode: marks failed chunk and processes the rest', async () => {
+  let callIndex = 0;
+  const svc = makeService({
+    simulateChunk: async () => ({ success: true, resourceLimitExceeded: false }),
+    submitChunk: async () => {
+      callIndex += 1;
+      if (callIndex === 1) return { success: false, errorMessage: 'rpc error' };
+      return { success: true, txHash: 'TX2' };
+    },
+    maxOpsPerChunk: 1,
+    failMode: 'continue',
+  });
+  const recipients = [{ address: 'GA', amount: '1' }, { address: 'GB', amount: '2' }];
+  svc.registerBatch({ batchId: 'b1', recipients, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  assert.equal(result.failCount, 1);
+  assert.equal(result.successCount, 1);
+  assert.equal(result.status, BATCH_STATUS.PARTIAL);
+});
+
+test('abort mode: stops after first submission failure', async () => {
+  let submitCount = 0;
+  const svc = makeService({
+    simulateChunk: async () => ({ success: true, resourceLimitExceeded: false }),
+    submitChunk: async () => {
+      submitCount += 1;
+      return { success: false, errorMessage: 'rpc error' };
+    },
+    maxOpsPerChunk: 1,
+    failMode: 'abort',
+  });
+  const recipients = [
+    { address: 'GA', amount: '1' },
+    { address: 'GB', amount: '2' },
+    { address: 'GC', amount: '3' },
+  ];
+  svc.registerBatch({ batchId: 'b1', recipients, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  assert.equal(submitCount, 1); // stopped after first failure
+  assert.equal(result.status, BATCH_STATUS.FAILED);
+});
+
+test('abort mode: stops after first simulation failure', async () => {
+  let simCount = 0;
+  const svc = makeService({
+    simulateChunk: async () => {
+      simCount += 1;
+      return { success: false, resourceLimitExceeded: false, errorMessage: 'sim error' };
+    },
+    maxOpsPerChunk: 1,
+    failMode: 'abort',
+  });
+  const recipients = [{ address: 'GA', amount: '1' }, { address: 'GB', amount: '2' }];
+  svc.registerBatch({ batchId: 'b1', recipients, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  assert.equal(simCount, 1);
+  assert.equal(result.status, BATCH_STATUS.FAILED);
+});
+
+// ── executeBatch — per-recipient errors ───────────────────────────────────────
+
+test('per-recipient errors from submitChunk are recorded correctly', async () => {
+  const svc = makeService({
+    submitChunk: async (ops) => ({
+      success: true,
+      txHash: 'TX1',
+      recipientErrors: { [ops[0].address]: 'account frozen' },
+    }),
+    maxOpsPerChunk: 3,
+  });
+  svc.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  const result = await svc.executeBatch('b1');
+
+  const frozen = result.recipients.find((r) => r.address === 'GAAA');
+  assert.equal(frozen.status, RECIPIENT_STATUS.FAILED);
+  assert.equal(frozen.errorMessage, 'account frozen');
+  assert.equal(result.failCount, 1);
+  assert.equal(result.successCount, 2);
+  assert.equal(result.status, BATCH_STATUS.PARTIAL);
+});
+
+// ── executeBatch — checkpointing / resume ─────────────────────────────────────
+
+test('executeBatch resumes from first pending recipient after partial failure', async () => {
+  const store = createInMemoryBatchStore();
+  const silentLog = { info() {}, warn() {}, error() {} };
+  let submitCount = 0;
+
+  function makeSvc(failFirst) {
+    return createBatchPayoutService({
+      simulateChunk: async () => ({ success: true, resourceLimitExceeded: false }),
+      submitChunk: async () => {
+        submitCount += 1;
+        if (failFirst && submitCount === 1) return { success: false, errorMessage: 'transient' };
+        return { success: true, txHash: 'TX_OK' };
+      },
+      store,
+      maxOpsPerChunk: 1,
+      failMode: 'continue',
+      log: silentLog,
+    });
+  }
+
+  // First run: first op fails
+  const svc1 = makeSvc(true);
+  svc1.registerBatch({ batchId: 'b1', recipients: RECIPIENTS, campaignId: 'c1' });
+  const partial = await svc1.executeBatch('b1');
+  assert.equal(partial.status, BATCH_STATUS.PARTIAL);
+  assert.equal(partial.failCount, 1);
+  assert.equal(partial.successCount, 2);
+
+  // Reset submit counter; second run should not re-submit already-succeeded recipients
+  submitCount = 0;
+  const svc2 = makeSvc(false);
+  // Force the failed recipient back to pending so it can be retried
+  const stored = store.getBatch('b1');
+  stored.recipients[0].status = RECIPIENT_STATUS.PENDING;
+  stored.recipients[0].errorMessage = null;
+  store.updateBatch('b1', { recipients: stored.recipients, status: BATCH_STATUS.PENDING });
+
+  const final = await svc2.executeBatch('b1');
+  assert.equal(submitCount, 1); // only the previously-failed recipient was resubmitted
+  assert.equal(final.successCount, 3);
+  assert.equal(final.status, BATCH_STATUS.COMPLETED);
+});
+
+// ── getBatch / listBatches ────────────────────────────────────────────────────
+
+test('getBatch returns undefined for unknown batchId', () => {
+  const svc = makeService();
+  assert.equal(svc.getBatch('ghost'), undefined);
+});
+
+test('listBatches returns all registered batches in reverse-creation order', async () => {
+  const svc = makeService();
+  svc.registerBatch({ batchId: 'b1', recipients: [{ address: 'GA', amount: '1' }], campaignId: 'c1' });
+  // Small delay so createdAt strings differ
+  await new Promise((r) => setTimeout(r, 2));
+  svc.registerBatch({ batchId: 'b2', recipients: [{ address: 'GB', amount: '2' }], campaignId: 'c1' });
+
+  const list = svc.listBatches();
+  assert.equal(list.length, 2);
+  assert.equal(list[0].id, 'b2'); // most recent first
+});


### PR DESCRIPTION
## Summary

- Adds `batchPayoutService` — a server-side builder that packs up to **k** `batch_credit` ops per Soroban transaction, respecting tx size/resource limits
- **Adaptive k**: simulation failures caused by resource limits halve the chunk size and retry automatically; reduces to 1-op chunks as a last resort
- **Checkpointing**: per-recipient status is flushed to the store after every chunk, so a crashed or retried execution resumes from the first still-pending recipient
- **Idempotency**: re-submitting the same `batchId` returns the existing record without re-running, preventing double-pay on network retries
- **Fail modes**: `continue` (default) marks a failed chunk's recipients as failed and proceeds; `abort` halts the whole batch on first failure
- **Per-recipient error attribution**: the submit layer can return `recipientErrors` keyed by address; those recipients are marked failed while the rest of the chunk succeeds
- **Admin API** (`POST /api/v1/batch-payouts`, `GET /api/v1/batch-payouts`, `GET /api/v1/batch-payouts/:batchId`) for launching and monitoring batches
- **25 unit tests** — all passing — covering chunking arithmetic, adaptive k, both fail modes, per-recipient errors, idempotency, and mid-batch resume

## Test plan

- [x] `node --test src/services/batchPayoutService.test.js` — 25/25 pass
- [x] Adaptive k: first simulate call with N ops returns `resourceLimitExceeded`; service halves k and retries (verified in test)
- [x] Resume: force first recipient back to `pending` after a partial run; second `executeBatch` call only resubmits that one recipient
- [x] Idempotency: second `registerBatch` with the same `batchId` returns original record unchanged
- [x] Abort mode: stops after first failure, leaving remaining recipients unprocessed

Closes #553
Closes #595
Closes #607
Closes #618