### PR TITLE
feat: realtime SSE subscription, registration risk scoring, embed claim event

### DIFF
--- a/backend/src/middleware/riskScoring.js
+++ b/backend/src/middleware/riskScoring.js
@@ -1,0 +1,121 @@
+import { log as logger } from './logger.js';
+
+const WINDOW_MS = 60_000;
+const DEFAULT_VELOCITY_LIMIT = 5;
+const DEFAULT_STEP_UP_THRESHOLD = 60;
+const DEFAULT_BLOCK_THRESHOLD = 85;
+
+// In-memory sliding window: key -> [timestamp, ...]
+const velocityStore = new Map();
+
+function pruneWindow(timestamps, now) {
+  const cutoff = now - WINDOW_MS;
+  return timestamps.filter((t) => t >= cutoff);
+}
+
+function getIp(req) {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) return String(forwarded).split(',')[0].trim();
+  return req.socket?.remoteAddress || 'unknown';
+}
+
+/**
+ * Score a registration attempt from 0 (clean) to 100 (high-risk).
+ *
+ * Signals:
+ *   - velocity: registrations per IP in the past 60 s
+ *   - fingerprint: device fingerprint hash supplied in X-Device-Fingerprint header
+ *   - timing: suspiciously fast form submission (< 2 s)
+ *
+ * @param {object} signals
+ * @returns {{ score: number, reasons: string[] }}
+ */
+function scoreRequest(signals) {
+  let score = 0;
+  const reasons = [];
+
+  const { velocityCount, velocityLimit, hasFingerprint, submissionMs } = signals;
+
+  // Velocity: linear ramp up to 50 points when at 2× the per-IP limit.
+  if (velocityCount > 0) {
+    const ratio = velocityCount / velocityLimit;
+    const velocityScore = Math.min(50, Math.round(ratio * 25));
+    if (velocityScore > 0) {
+      score += velocityScore;
+      reasons.push(`velocity:${velocityCount}/${velocityLimit}/min`);
+    }
+  }
+
+  // Missing device fingerprint: likely headless browser or script.
+  if (!hasFingerprint) {
+    score += 20;
+    reasons.push('no-fingerprint');
+  }
+
+  // Suspiciously fast submission (bot-like timing).
+  if (typeof submissionMs === 'number' && submissionMs < 2_000) {
+    score += 15;
+    reasons.push(`fast-submission:${submissionMs}ms`);
+  }
+
+  return { score: Math.min(100, score), reasons };
+}
+
+/**
+ * Express middleware factory for registration risk scoring.
+ *
+ * Attaches `req.riskScore` and `req.riskReasons` to the request.
+ * Responds with 429 when the score exceeds the block threshold,
+ * or sets `req.riskStepUp = true` for the step-up-challenge band.
+ *
+ * @param {object} [options]
+ * @param {number} [options.velocityLimit=5]       Max registrations per IP per minute before scoring starts.
+ * @param {number} [options.stepUpThreshold=60]    Score at which a step-up challenge is required.
+ * @param {number} [options.blockThreshold=85]     Score at which the request is soft-blocked.
+ * @returns {import('express').RequestHandler}
+ */
+export function createRiskScoring(options = {}) {
+  const velocityLimit = options.velocityLimit ?? DEFAULT_VELOCITY_LIMIT;
+  const stepUpThreshold = options.stepUpThreshold ?? DEFAULT_STEP_UP_THRESHOLD;
+  const blockThreshold = options.blockThreshold ?? DEFAULT_BLOCK_THRESHOLD;
+
+  return function riskScoringMiddleware(req, res, next) {
+    const now = Date.now();
+    const ip = getIp(req);
+
+    // Update velocity window.
+    const existing = pruneWindow(velocityStore.get(ip) ?? [], now);
+    existing.push(now);
+    velocityStore.set(ip, existing);
+
+    // Privacy-preserving: only check presence of the fingerprint header, never store it.
+    const hasFingerprint = Boolean(req.headers['x-device-fingerprint']);
+    const submissionMs = Number(req.headers['x-form-render-ms']) || undefined;
+
+    const { score, reasons } = scoreRequest({
+      velocityCount: existing.length,
+      velocityLimit,
+      hasFingerprint,
+      submissionMs,
+    });
+
+    req.riskScore = score;
+    req.riskReasons = reasons;
+    req.riskStepUp = false;
+
+    if (score >= blockThreshold) {
+      logger.warn({ ip, score, reasons }, 'registration soft-blocked by risk scoring');
+      return res.status(429).json({
+        error: 'Registration temporarily unavailable. Please try again later.',
+        code: 'RISK_BLOCKED',
+      });
+    }
+
+    if (score >= stepUpThreshold) {
+      req.riskStepUp = true;
+      logger.info({ ip, score, reasons }, 'registration step-up required');
+    }
+
+    return next();
+  };
+}

--- a/frontend/public/embed.js
+++ b/frontend/public/embed.js
@@ -17,6 +17,7 @@
  *   const widget = new TrivelaWidget({ campaign: 'id', partner: 'pid' });
  *   widget.on('trivela:ready',          (e) => console.log('loaded', e))
  *         .on('trivela:register_click', (e) => console.log('register clicked', e))
+ *         .on('trivela:claim',          (e) => console.log('reward claimed', e))
  *         .mount(document.getElementById('my-container'));
  *
  * Security:
@@ -104,6 +105,7 @@
    * Supported events:
    *   'trivela:ready'           — widget iframe has loaded the campaign
    *   'trivela:register_click'  — user clicked "Register on Trivela"
+   *   'trivela:claim'           — user completed a reward claim inside the widget
    *
    * @param {string}   event
    * @param {Function} handler
@@ -216,6 +218,9 @@
       if (!data || typeof data !== 'object') return;
       if (data.source !== 'trivela-widget') return;
       if (typeof data.type !== 'string') return;
+      // Allowlist forwarded event types to prevent arbitrary event injection.
+      var ALLOWED_EVENTS = { 'trivela:ready': 1, 'trivela:register_click': 1, 'trivela:claim': 1 };
+      if (!ALLOWED_EVENTS[data.type]) return;
       self._emit(data.type, data.payload);
     };
 

--- a/frontend/src/hooks/useCampaignSubscription.js
+++ b/frontend/src/hooks/useCampaignSubscription.js
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getRealtimeUrl } from '../config';
+import { useCampaignPolling } from './useCampaignPolling';
+
+const MIN_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const MAX_EVENTS_PER_FLUSH = 50;
+
+function nextBackoff(current) {
+  return Math.min(current * 2, MAX_BACKOFF_MS);
+}
+
+/**
+ * Real-time campaign subscription via SSE with exponential-backoff reconnect
+ * and automatic fallback to polling when SSE is unavailable.
+ *
+ * Returns the same shape as useCampaignPolling so callers can swap them.
+ */
+export function useCampaignSubscription({ campaignId, contractId, enabled = true }) {
+  const realtimeUrl = getRealtimeUrl(campaignId);
+  const useRealtime = Boolean(realtimeUrl && campaignId && enabled);
+
+  // Polling fallback — always created, only active when SSE is unavailable.
+  const polling = useCampaignPolling({
+    campaignId,
+    contractId,
+    enabled: !useRealtime && enabled,
+  });
+
+  const [campaign, setCampaign] = useState(null);
+  const [isLive, setIsLive] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [error, setError] = useState('');
+  const [stateToast, setStateToast] = useState('');
+
+  const esRef = useRef(null);
+  const backoffRef = useRef(MIN_BACKOFF_MS);
+  const retryTimerRef = useRef(null);
+  const pendingRef = useRef([]);
+  const flushTimerRef = useRef(null);
+  const mountedRef = useRef(false);
+
+  const applyEvent = useCallback((payload) => {
+    if (!payload) return;
+    if (payload.campaign) setCampaign((prev) => ({ ...prev, ...payload.campaign }));
+    if (payload.participantCount !== undefined) {
+      setCampaign((prev) => prev ? { ...prev, participantCount: payload.participantCount } : prev);
+    }
+    setLastUpdated(new Date());
+    setStateToast('Live update received');
+  }, []);
+
+  const flushPending = useCallback(() => {
+    const batch = pendingRef.current.splice(0, MAX_EVENTS_PER_FLUSH);
+    for (const payload of batch) applyEvent(payload);
+    flushTimerRef.current = null;
+  }, [applyEvent]);
+
+  const scheduleFlush = useCallback(() => {
+    if (!flushTimerRef.current) {
+      flushTimerRef.current = window.setTimeout(flushPending, 0);
+    }
+  }, [flushPending]);
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current || !useRealtime) return;
+
+    const es = new EventSource(realtimeUrl, { withCredentials: true });
+    esRef.current = es;
+
+    es.onopen = () => {
+      if (!mountedRef.current) return;
+      backoffRef.current = MIN_BACKOFF_MS;
+      setIsLive(true);
+      setError('');
+    };
+
+    es.onmessage = (evt) => {
+      if (!mountedRef.current) return;
+      try {
+        const payload = JSON.parse(evt.data);
+        pendingRef.current.push(payload);
+        scheduleFlush();
+      } catch {
+        /* malformed event — skip */
+      }
+    };
+
+    es.onerror = () => {
+      if (!mountedRef.current) return;
+      es.close();
+      esRef.current = null;
+      setIsLive(false);
+
+      const delay = backoffRef.current;
+      backoffRef.current = nextBackoff(delay);
+      setError(`Connection lost — retrying in ${Math.round(delay / 1000)}s`);
+
+      retryTimerRef.current = window.setTimeout(() => {
+        if (mountedRef.current) connect();
+      }, delay);
+    };
+  }, [realtimeUrl, scheduleFlush, useRealtime]);
+
+  useEffect(() => {
+    if (!useRealtime) return undefined;
+
+    mountedRef.current = true;
+    connect();
+
+    return () => {
+      mountedRef.current = false;
+      esRef.current?.close();
+      esRef.current = null;
+      window.clearTimeout(retryTimerRef.current);
+      window.clearTimeout(flushTimerRef.current);
+      setIsLive(false);
+    };
+  }, [connect, useRealtime]);
+
+  useEffect(() => {
+    if (!stateToast) return undefined;
+    const t = window.setTimeout(() => setStateToast(''), 4000);
+    return () => window.clearTimeout(t);
+  }, [stateToast]);
+
+  if (!useRealtime) return polling;
+
+  return {
+    campaign: campaign ?? polling.campaign,
+    setCampaign,
+    onChainState: polling.onChainState,
+    isPolling: false,
+    isLive,
+    isPaused: false,
+    lastUpdated,
+    stateToast,
+    error,
+    refresh: polling.refresh,
+  };
+}


### PR DESCRIPTION
## Summary

- **#626** – Added `useCampaignSubscription` hook: SSE live updates with exponential-backoff reconnect and automatic fallback to polling when SSE is not configured
- **#596** – Added `createRiskScoring` middleware: IP velocity + device fingerprint + submission timing → 0–100 risk score; soft-blocks at 85, step-up challenge at 60, thresholds configurable per-campaign
- **#655** – Extended partner embed SDK: added `trivela:claim` event so partners receive a callback on reward claim; hardened `postMessage` handler with an explicit event-type allowlist to prevent injection

Closes #626, Closes #596, Closes #655