### PR TITLE
feat: graceful shutdown/readiness split, ESLint backend, repo sanity …

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,13 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run backend lint (if available)
-        run: |
-          if npm --workspace=backend run | rg -q "  lint"; then
-            npm run lint --workspace=backend
-          else
-            echo "No backend lint script found; skipping."
-          fi
+      - name: Run backend lint
+        run: npm run lint --workspace=backend
 
       - name: Run backend typecheck (if available)
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Sunday at 02:00 UTC
+    - cron: '0 2 * * 0'
+
+jobs:
+  analyze-javascript:
+    name: Analyze JavaScript
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript
+
+  analyze-rust:
+    name: Analyze Rust
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          queries: security-extended
+
+      - name: Build Rust workspace
+        run: cargo build --workspace
+        timeout-minutes: 20
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:rust

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -1,0 +1,38 @@
+name: Repo Sanity
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Workspace install (npm ci)
+        run: npm ci
+
+      - name: Verify lockfile is up to date
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          git diff --exit-code package-lock.json || {
+            echo "package-lock.json is out of date. Run 'npm install' locally and commit the updated lockfile."
+            exit 1
+          }
+
+      - name: npm audit
+        run: npm audit --audit-level=high
+
+      - name: Workspace dependency check
+        run: npm ls --workspaces --depth=0

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,22 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'coverage/'],
+  },
+];

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "test": "node --test src/**/*.test.js",
     "test:integration": "node --test src/integration/*.test.js",
     "test:contract": "node --test src/integration/openapi-contract.test.js",
+    "lint": "eslint src/",
     "typecheck": "tsc --noEmit --project jsconfig.json",
     "db:migrate": "node src/db/migrate.js",
     "openapi:validate": "node scripts/validateOpenApi.js",
@@ -46,6 +47,9 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0",
     "@readme/openapi-parser": "^2.6.0",
     "@redocly/cli": "^1.34.5",
     "@types/cors": "^2.8.0",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -668,9 +668,18 @@ export async function createApp(options = {}) {
     }
   }
 
+  let isShuttingDown = false;
+
   app.get('/health', async (_req, res) => {
     const payload = await buildHealthPayload();
     res.json(payload);
+  });
+
+  app.get('/ready', (_req, res) => {
+    if (isShuttingDown) {
+      return res.status(503).json({ status: 'shutting_down', ready: false });
+    }
+    return res.json({ status: 'ok', ready: true });
   });
 
   const siteOrigin =
@@ -786,6 +795,7 @@ export async function createApp(options = {}) {
       prefix: API_V1_PREFIX,
       endpoints: {
         health: 'GET /health',
+        ready: 'GET /ready',
         healthRpc: 'GET /health/rpc',
         metrics: 'GET /metrics',
         info: `GET ${API_V1_PREFIX}`,
@@ -2116,6 +2126,11 @@ export async function createApp(options = {}) {
   // Central error handler — must be registered after all routes
   app.use(errorHandler);
 
+  app._close = () => {
+    isShuttingDown = true;
+    try { dal.db.close(); } catch (_) {}
+  };
+
   return app;
 }
 
@@ -2152,6 +2167,7 @@ export async function startServer(options = {}) {
   async function gracefulShutdown(signal) {
     if (shuttingDown) return;
     shuttingDown = true;
+    app._close?.();
     log.info({ signal, graceMs: SHUTDOWN_GRACE_MS }, 'graceful shutdown started');
 
     const forceTimer = setTimeout(() => {


### PR DESCRIPTION
…CI, CodeQL (#138 #140 #145 #150)

- Closes #150: add GET /ready endpoint (503 during shutdown); close SQLite DB and flip readiness flag on SIGTERM/SIGINT via app._close() hook
- Closes #145: add backend eslint.config.js (Node ESM flat config); add lint script to backend/package.json; make backend-ci lint step unconditional
- Closes #138: add .github/workflows/repo-sanity.yml — npm ci, lockfile consistency check, npm audit --audit-level=high, workspace dep check
- Closes #140: add .github/workflows/codeql.yml — JS analysis + Rust analysis (cargo build) on push, PR, and weekly schedule