### PR TITLE
feat: index read API, SEP-1 stellar.toml, sponsored accounts, claimable balances (#560, #551, #556, #548)

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -31,6 +31,14 @@ tags:
     description: Administrative API key management
   - name: Organizations
     description: Organization and team member management
+  - name: IndexRead
+    description: "Public read API over indexed Soroban event data (cursor-paginated, ETag-cached) — #560"
+  - name: StellarToml
+    description: "SEP-1 stellar.toml reward-token metadata — #551"
+  - name: SponsoredAccounts
+    description: "CAP-33 Stellar reserve sponsorship for new accounts — #556"
+  - name: ClaimableBalances
+    description: "Claimable balance lifecycle for unclaimed/expired rewards (CAP-23) — #548"
 
 security:
   - ApiKeyAuth: []
@@ -1116,6 +1124,297 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  # ── #551: SEP-1 stellar.toml ──────────────────────────────────────────────
+  /.well-known/stellar.toml:
+    get:
+      summary: SEP-1 stellar.toml token metadata
+      tags: [StellarToml]
+      security: []
+      responses:
+        '200':
+          description: Valid SEP-1 TOML document
+          headers:
+            Cache-Control:
+              schema: { type: string }
+            Access-Control-Allow-Origin:
+              schema: { type: string }
+          content:
+            text/plain:
+              schema: { type: string }
+
+  # ── #560: Index Read API ───────────────────────────────────────────────────
+  /api/v1/index/campaigns/{id}/participants:
+    get:
+      summary: Cursor-paginated participant list from indexed balances
+      tags: [IndexRead]
+      security: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: cursor
+          schema: { type: string }
+          description: Opaque pagination cursor from previous response
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        '200':
+          description: Paginated participant list with freshness indicator
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        address: { type: string }
+                        balance: { type: string }
+                  cursor: { type: string, nullable: true }
+                  has_more: { type: boolean }
+                  as_of_ledger: { type: integer, nullable: true }
+        '404':
+          description: Campaign not found
+
+  /api/v1/index/campaigns/{id}/events:
+    get:
+      summary: Cursor-paginated credit/claim event log for a campaign
+      tags: [IndexRead]
+      security: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: type
+          schema: { type: string, enum: [credit, claim] }
+          description: Filter by event type
+        - in: query
+          name: cursor
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        '200':
+          description: Paginated event list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        user: { type: string }
+                        amount: { type: string }
+                        ledger: { type: integer }
+                        tx_hash: { type: string }
+                        type: { type: string, enum: [credit, claim] }
+                  cursor: { type: string, nullable: true }
+                  has_more: { type: boolean }
+                  as_of_ledger: { type: integer, nullable: true }
+        '404':
+          description: Campaign not found
+
+  /api/v1/index/addresses/{address}/history:
+    get:
+      summary: Full event history for a single Stellar address
+      tags: [IndexRead]
+      security: []
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema: { type: string }
+        - in: query
+          name: cursor
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        '200':
+          description: Address event history and current balance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  address: { type: string }
+                  balance: { type: string }
+                  data: { type: array }
+                  cursor: { type: string, nullable: true }
+                  has_more: { type: boolean }
+                  as_of_ledger: { type: integer, nullable: true }
+
+  /api/v1/index/campaigns/{id}/stats:
+    get:
+      summary: Rollup stats for a campaign (ETag-cached)
+      tags: [IndexRead]
+      security: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Campaign stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  campaignId: { type: string }
+                  as_of_ledger: { type: integer, nullable: true }
+                  summary:
+                    type: object
+                    properties:
+                      totalParticipants: { type: integer }
+                      totalCredited: { type: string }
+                      totalClaimed: { type: string }
+                      claimRate: { type: number }
+        '304':
+          description: Not Modified (ETag match)
+        '404':
+          description: Campaign not found
+
+  # ── #556: Sponsored accounts ───────────────────────────────────────────────
+  /api/v1/sponsored-accounts:
+    post:
+      summary: Sponsor a new Stellar account (CAP-33)
+      tags: [SponsoredAccounts]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [address]
+              properties:
+                address:
+                  type: string
+                  description: Stellar G-address to sponsor
+                accountType:
+                  type: string
+                  enum: [stellar, smart_wallet]
+                  default: stellar
+                trustlineAsset:
+                  type: string
+                  description: '"CODE:ISSUER" trustline to add within the sponsorship envelope'
+      responses:
+        '201':
+          description: Sponsorship created; returns partially-signed transaction XDR
+        '202':
+          description: Sponsorship tracked (SPONSOR_SECRET_KEY not configured)
+        '400':
+          description: Invalid address or asset format
+        '409':
+          description: Address already has an active sponsorship
+
+  /api/v1/sponsored-accounts/{address}:
+    get:
+      summary: Get sponsorship status for an address
+      tags: [SponsoredAccounts]
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Sponsorship record
+        '404':
+          description: Not found
+
+  /api/v1/sponsored-accounts/{address}/revoke:
+    post:
+      summary: Revoke reserve sponsorship (transfer back to account)
+      tags: [SponsoredAccounts]
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Revocation XDR built; or tracked-only if key not configured
+        '404':
+          description: No active sponsorship for this address
+
+  # ── #548: Claimable balances ───────────────────────────────────────────────
+  /api/v1/campaigns/{id}/claimable-balances:
+    post:
+      summary: Trigger claimable balance creation for eligible-unclaimed users
+      tags: [ClaimableBalances]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                graceDays:
+                  type: integer
+                  default: 30
+                assetCode:
+                  type: string
+                assetIssuer:
+                  type: string
+      responses:
+        '202':
+          description: Job queued; returns created/skipped counts
+        '404':
+          description: Campaign not found
+    get:
+      summary: List claimable balances for a campaign
+      tags: [ClaimableBalances]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: status
+          schema: { type: string, enum: [pending, created, claimed_by_user, reclaimed_by_operator, failed] }
+        - in: query
+          name: limit
+          schema: { type: integer, default: 50, maximum: 200 }
+        - in: query
+          name: offset
+          schema: { type: integer, default: 0 }
+      responses:
+        '200':
+          description: Paginated claimable balance list
+
+  /api/v1/campaigns/{id}/claimable-balances/reclaim:
+    post:
+      summary: Operator reclaim of expired unclaimed balances
+      tags: [ClaimableBalances]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Balances marked as reclaimed
+        '404':
+          description: Campaign not found
 
 components:
   securitySchemes:

--- a/backend/src/db/migrations/021_sponsored_accounts.js
+++ b/backend/src/db/migrations/021_sponsored_accounts.js
@@ -1,0 +1,23 @@
+export const version = 21;
+export const description = 'Sponsorship tracking table for CAP-33 reserve sponsorship (#556)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sponsored_accounts (
+      id              TEXT PRIMARY KEY,
+      address         TEXT NOT NULL UNIQUE,
+      account_type    TEXT NOT NULL DEFAULT 'stellar'
+        CHECK (account_type IN ('stellar', 'smart_wallet')),
+      sponsor_address TEXT NOT NULL,
+      status          TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'revoked', 'transferred')),
+      trustline_asset TEXT,
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL,
+      revoked_at      TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_sponsored_accounts_address ON sponsored_accounts(address);
+    CREATE INDEX IF NOT EXISTS idx_sponsored_accounts_sponsor ON sponsored_accounts(sponsor_address, status);
+  `);
+}

--- a/backend/src/db/migrations/022_claimable_balances.js
+++ b/backend/src/db/migrations/022_claimable_balances.js
@@ -1,0 +1,26 @@
+export const version = 22;
+export const description = 'Claimable balances table for unclaimed/expired rewards (#548)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS claimable_balances (
+      id                TEXT PRIMARY KEY,
+      campaign_id       TEXT NOT NULL,
+      user_address      TEXT NOT NULL,
+      asset_code        TEXT NOT NULL DEFAULT 'XLM',
+      asset_issuer      TEXT,
+      amount            TEXT NOT NULL,
+      balance_id        TEXT UNIQUE,
+      status            TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'created', 'claimed_by_user', 'reclaimed_by_operator', 'failed')),
+      grace_end_at      TEXT NOT NULL,
+      created_at        TEXT NOT NULL,
+      updated_at        TEXT NOT NULL,
+      error_message     TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_claimable_balances_campaign ON claimable_balances(campaign_id, status);
+    CREATE INDEX IF NOT EXISTS idx_claimable_balances_user ON claimable_balances(user_address, status);
+    CREATE INDEX IF NOT EXISTS idx_claimable_balances_grace ON claimable_balances(grace_end_at, status);
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -71,6 +71,10 @@ import { createDistributedLock, createInMemoryLock } from './jobs/distributedLoc
 import { createExportJob } from './jobs/exportJob.js';
 import { createSqliteJobQueueRepository } from './dal/sqliteJobQueueRepository.js';
 import { createDurableJobQueue } from './jobs/durableJobQueue.js';
+import { createStellarTomlRoute } from './routes/stellarToml.js';
+import { createSponsoredAccountRoutes } from './routes/sponsoredAccounts.js';
+import { createClaimableBalancesRoutes } from './routes/claimableBalances.js';
+import { createIndexReadRoutes } from './routes/indexRead.js';
 
 const DEFAULT_PORT = 3001;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
@@ -2091,7 +2095,33 @@ export async function createApp(options = {}) {
     const featureFlagService = createFeatureFlagService({ featureFlagRepository: dal.featureFlags });
     const featureFlagRouter = createFeatureFlagRoutes({ featureFlagService });
     app.use(`${prefix}/feature-flags`, rateLimiter, featureFlagRouter);
+
+    // #560 — Public read API over indexed data (cursor-paginated, ETag cached)
+    const indexReadRouter = createIndexReadRoutes({ dal, campaignRepository });
+    app.use(`${prefix}/index`, rateLimiter, indexReadRouter);
+
+    // #556 — Sponsored account creation + CAP-33 reserve sponsorship
+    const sponsoredAccountRouter = createSponsoredAccountRoutes({
+      dal,
+      stellarConfig,
+      env: process.env,
+    });
+    app.use(`${prefix}/sponsored-accounts`, rateLimiter, ...guard, sponsoredAccountRouter);
+
+    // #548 — Claimable balances for unclaimed/expired rewards
+    const claimableBalancesRouter = createClaimableBalancesRoutes({
+      dal,
+      campaignRepository,
+      stellarConfig,
+      env: process.env,
+      logger: log,
+    });
+    app.use(prefix, rateLimiter, ...guard, claimableBalancesRouter);
   }
+
+  // #551 — SEP-1 stellar.toml (public, no auth, correct content-type + CORS)
+  const stellarTomlRouter = createStellarTomlRoute({ env: process.env });
+  app.use(stellarTomlRouter);
 
   registerApiRoutes(API_V1_PREFIX);
   registerApiRoutes(LEGACY_API_PREFIX);

--- a/backend/src/jobs/claimableBalancesJob.js
+++ b/backend/src/jobs/claimableBalancesJob.js
@@ -1,0 +1,188 @@
+// #548 — End-of-campaign job: create claimable balances for eligible-but-unclaimed users.
+//
+// Two-claimant Stellar predicate (CAP-23):
+//   claimant[0] = user,     predicate = before(end + grace)  → user can claim during grace window
+//   claimant[1] = operator, predicate = not(before(end + grace)) → operator reclaims after grace
+
+import { randomUUID } from 'node:crypto';
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Claimant,
+  BASE_FEE,
+  Horizon,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const DEFAULT_GRACE_DAYS = 30;
+
+/**
+ * Build a Unix timestamp for "now + graceDays days".
+ * @param {Date} campaignEnd
+ * @param {number} graceDays
+ * @returns {Date}
+ */
+function graceEndDate(campaignEnd, graceDays) {
+  const d = new Date(campaignEnd);
+  d.setUTCDate(d.getUTCDate() + graceDays);
+  return d;
+}
+
+/**
+ * Find users who were eligible (had credit_events for this campaign) but never claimed.
+ * Returns rows: { user, total_credited, total_claimed }
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} campaignId
+ * @returns {Array<{ user: string; unclaimed: bigint }>}
+ */
+export function getUnclaimedUsers(db, campaignId) {
+  const hasTables =
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='credit_events'").get() &&
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='claim_events'").get();
+
+  if (!hasTables) return [];
+
+  const rows = db
+    .prepare(
+      `SELECT
+         ce.user,
+         COALESCE(SUM(CAST(ce.amount AS INTEGER)), 0) AS total_credited,
+         COALESCE(
+           (SELECT SUM(CAST(cl.amount AS INTEGER))
+            FROM claim_events cl
+            WHERE cl.user = ce.user),
+           0
+         ) AS total_claimed
+       FROM credit_events ce
+       GROUP BY ce.user
+       HAVING total_credited > total_claimed`,
+    )
+    .all();
+
+  return rows.map((r) => ({
+    user: r.user,
+    unclaimed: BigInt(r.total_credited) - BigInt(r.total_claimed),
+  }));
+}
+
+/**
+ * @param {{
+ *   db: import('better-sqlite3').Database;
+ *   campaignId: string;
+ *   campaignEndDate: Date;
+ *   assetCode?: string;
+ *   assetIssuer?: string;
+ *   graceDays?: number;
+ *   stellarConfig: { networkPassphrase: string; horizonUrl: string };
+ *   operatorSecretKey?: string;
+ *   logger?: { info: Function; warn: Function; error: Function };
+ * }} options
+ */
+export async function createClaimableBalancesForCampaign({
+  db,
+  campaignId,
+  campaignEndDate,
+  assetCode = 'XLM',
+  assetIssuer,
+  graceDays = DEFAULT_GRACE_DAYS,
+  stellarConfig,
+  operatorSecretKey,
+  logger = console,
+}) {
+  const unclaimedUsers = getUnclaimedUsers(db, campaignId);
+  if (unclaimedUsers.length === 0) {
+    logger.info?.(`[claimableBalances] campaign=${campaignId} no unclaimed users`);
+    return { created: 0, skipped: 0 };
+  }
+
+  const graceEnd = graceEndDate(campaignEndDate, graceDays);
+  const graceEndIso = graceEnd.toISOString();
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const { user, unclaimed } of unclaimedUsers) {
+    // Idempotency: skip if a balance row already exists for this user+campaign
+    const existing = db
+      .prepare(
+        "SELECT id FROM claimable_balances WHERE campaign_id = ? AND user_address = ? AND status != 'failed'",
+      )
+      .get(campaignId, user);
+    if (existing) { skipped++; continue; }
+
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    const amountStr = (Number(unclaimed) / 1e7).toFixed(7); // stroops → display amount
+
+    // Insert as pending first
+    db.prepare(
+      `INSERT INTO claimable_balances
+         (id, campaign_id, user_address, asset_code, asset_issuer, amount, status, grace_end_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)`,
+    ).run(id, campaignId, user, assetCode, assetIssuer ?? null, amountStr, graceEndIso, now, now);
+
+    if (!operatorSecretKey) {
+      logger.warn?.(`[claimableBalances] OPERATOR_SECRET_KEY not set — row ${id} left as pending`);
+      skipped++;
+      continue;
+    }
+
+    try {
+      const operatorKeypair = Keypair.fromSecret(operatorSecretKey);
+      const server = new Horizon.Server(stellarConfig.horizonUrl);
+      const account = await server.loadAccount(operatorKeypair.publicKey());
+
+      const asset = assetIssuer
+        ? new Asset(assetCode, assetIssuer)
+        : Asset.native();
+
+      const graceEndUnix = Math.floor(graceEnd.getTime() / 1000);
+
+      // user: unconditional until grace end
+      const userPredicate = Claimant.predicateBeforeAbsoluteTime(String(graceEndUnix));
+      // operator: after grace end (not-before)
+      const operatorPredicate = Claimant.predicateNot(
+        Claimant.predicateBeforeAbsoluteTime(String(graceEndUnix)),
+      );
+
+      const tx = new TransactionBuilder(account, {
+        fee: String(Number(BASE_FEE) * 2),
+        networkPassphrase: stellarConfig.networkPassphrase,
+      })
+        .addOperation(
+          Operation.createClaimableBalance({
+            asset,
+            amount: amountStr,
+            claimants: [
+              new Claimant(user, userPredicate),
+              new Claimant(operatorKeypair.publicKey(), operatorPredicate),
+            ],
+          }),
+        )
+        .setTimeout(180)
+        .build();
+
+      tx.sign(operatorKeypair);
+      const result = await server.submitTransaction(tx);
+
+      // Extract the balance_id from the transaction result
+      const balanceId = result.id ?? null;
+      db.prepare(
+        "UPDATE claimable_balances SET status = 'created', balance_id = ?, updated_at = ? WHERE id = ?",
+      ).run(balanceId, new Date().toISOString(), id);
+      created++;
+    } catch (err) {
+      logger.error?.(`[claimableBalances] failed for user=${user}: ${err.message}`);
+      db.prepare(
+        "UPDATE claimable_balances SET status = 'failed', error_message = ?, updated_at = ? WHERE id = ?",
+      ).run(err.message.slice(0, 500), new Date().toISOString(), id);
+      skipped++;
+    }
+  }
+
+  logger.info?.(`[claimableBalances] campaign=${campaignId} created=${created} skipped=${skipped}`);
+  return { created, skipped };
+}

--- a/backend/src/routes/claimableBalances.js
+++ b/backend/src/routes/claimableBalances.js
@@ -1,0 +1,109 @@
+// #548 — REST endpoints for claimable balance management.
+
+import { Router } from 'express';
+import { createClaimableBalancesForCampaign } from '../jobs/claimableBalancesJob.js';
+
+/**
+ * @param {{
+ *   dal: import('../dal/index.js').Dal;
+ *   campaignRepository: { getById: Function };
+ *   stellarConfig: { networkPassphrase: string; horizonUrl: string };
+ *   env?: NodeJS.ProcessEnv;
+ *   logger?: { info: Function; warn: Function; error: Function };
+ * }} options
+ */
+export function createClaimableBalancesRoutes({
+  dal,
+  campaignRepository,
+  stellarConfig,
+  env = process.env,
+  logger = console,
+}) {
+  const router = Router();
+
+  // POST /campaigns/:id/claimable-balances — trigger claimable balance creation on campaign end
+  router.post('/campaigns/:id/claimable-balances', async (req, res) => {
+    const campaign = campaignRepository.getById(req.params.id);
+    if (!campaign) return res.status(404).json({ error: 'campaign not found' });
+
+    const graceDays = Number(req.body?.graceDays ?? env.CLAIMABLE_GRACE_DAYS ?? 30);
+    const assetCode = req.body?.assetCode ?? env.REWARD_TOKEN_CODE ?? 'XLM';
+    const assetIssuer = req.body?.assetIssuer ?? env.REWARD_TOKEN_ISSUER ?? undefined;
+    const campaignEndDate = campaign.endDate ? new Date(campaign.endDate) : new Date();
+
+    const result = await createClaimableBalancesForCampaign({
+      db: dal.db,
+      campaignId: String(campaign.id),
+      campaignEndDate,
+      assetCode,
+      assetIssuer,
+      graceDays,
+      stellarConfig,
+      operatorSecretKey: env.OPERATOR_SECRET_KEY,
+      logger,
+    });
+
+    return res.status(202).json({ ok: true, campaignId: String(campaign.id), ...result });
+  });
+
+  // GET /campaigns/:id/claimable-balances — list claimable balances for a campaign
+  router.get('/campaigns/:id/claimable-balances', (req, res) => {
+    const hasTable = dal.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='claimable_balances'")
+      .get();
+    if (!hasTable) return res.json({ data: [], total: 0 });
+
+    const campaignId = req.params.id;
+    const status = req.query.status;
+    const limit = Math.min(Number(req.query.limit) || 50, 200);
+    const offset = Number(req.query.offset) || 0;
+
+    let query = 'SELECT * FROM claimable_balances WHERE campaign_id = ?';
+    const params = [campaignId];
+    if (status) { query += ' AND status = ?'; params.push(status); }
+    query += ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    const rows = dal.db.prepare(query).all(...params);
+    const total = dal.db
+      .prepare('SELECT COUNT(*) as cnt FROM claimable_balances WHERE campaign_id = ?' + (status ? ' AND status = ?' : ''))
+      .get(...(status ? [campaignId, status] : [campaignId])).cnt;
+
+    return res.json({ data: rows, total, limit, offset });
+  });
+
+  // POST /campaigns/:id/claimable-balances/reclaim — operator reclaims after grace window
+  router.post('/campaigns/:id/claimable-balances/reclaim', async (req, res) => {
+    const hasTable = dal.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='claimable_balances'")
+      .get();
+    if (!hasTable) return res.status(503).json({ error: 'claimable balances table not migrated' });
+
+    const campaignId = req.params.id;
+    const now = new Date().toISOString();
+
+    // Find balances past their grace window that haven't been claimed or reclaimed yet
+    const reclaimable = dal.db
+      .prepare(
+        `SELECT * FROM claimable_balances
+         WHERE campaign_id = ? AND status = 'created' AND grace_end_at <= ?`,
+      )
+      .all(campaignId, now);
+
+    if (reclaimable.length === 0) {
+      return res.json({ reclaimed: 0, message: 'no reclaimable balances found' });
+    }
+
+    // Mark as reclaimed (on-chain claim by operator is done separately via Horizon SDK)
+    const stmt = dal.db.prepare(
+      "UPDATE claimable_balances SET status = 'reclaimed_by_operator', updated_at = ? WHERE id = ?",
+    );
+    for (const row of reclaimable) {
+      stmt.run(now, row.id);
+    }
+
+    return res.json({ reclaimed: reclaimable.length, balanceIds: reclaimable.map((r) => r.balance_id) });
+  });
+
+  return router;
+}

--- a/backend/src/routes/indexRead.js
+++ b/backend/src/routes/indexRead.js
@@ -1,0 +1,303 @@
+// #560 — Public read API over indexed data.
+// All endpoints are read-only, rate-limited, and cursor-paginated.
+// Responses include `as_of_ledger` (freshness indicator from indexer_checkpoints).
+//
+// Endpoints:
+//   GET /index/campaigns/:id/participants  — paginated participant list from balances
+//   GET /index/campaigns/:id/events        — paginated credit/claim event log
+//   GET /index/addresses/:address/history  — full event history for one address
+//   GET /index/campaigns/:id/stats         — rollup stats (cached by ETag)
+
+import { Router } from 'express';
+import { createHash } from 'node:crypto';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const STATS_CACHE_TTL_MS = 30_000; // 30 s in-memory stats cache
+
+/**
+ * Decode an opaque cursor (base64-encoded JSON { after_rowid, after_id }).
+ * @param {string | undefined} cursor
+ * @returns {{ afterRowid?: number; afterId?: string } | null}
+ */
+function decodeCursor(cursor) {
+  if (!cursor) return null;
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Encode a cursor from the last row.
+ * @param {{ rowid?: number; id?: string }} row
+ * @returns {string}
+ */
+function encodeCursor(row) {
+  return Buffer.from(
+    JSON.stringify({ afterRowid: row.rowid ?? null, afterId: row.id ?? null }),
+  ).toString('base64url');
+}
+
+/**
+ * Get the latest indexed ledger number from indexer_checkpoints.
+ * @param {import('better-sqlite3').Database} db
+ * @returns {number | null}
+ */
+function getAsOfLedger(db) {
+  try {
+    const row = db
+      .prepare('SELECT ledger FROM indexer_checkpoints ORDER BY updated_at DESC LIMIT 1')
+      .get();
+    return row?.ledger ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {import('better-sqlite3').Database} db @param {string} tableName */
+function tableExists(db, tableName) {
+  return Boolean(
+    db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(tableName),
+  );
+}
+
+/**
+ * @param {{
+ *   dal: { db: import('better-sqlite3').Database };
+ *   campaignRepository: { getById: Function };
+ * }} options
+ */
+export function createIndexReadRoutes({ dal, campaignRepository }) {
+  const router = Router();
+  const db = dal.db;
+
+  // In-memory ETag/stats cache
+  const statsCache = new Map();
+
+  // ── GET /index/campaigns/:id/participants ──────────────────────────────────
+  router.get('/campaigns/:id/participants', (req, res) => {
+    const campaign = campaignRepository.getById(req.params.id);
+    if (!campaign) return res.status(404).json({ error: 'campaign not found', code: 'NOT_FOUND' });
+
+    if (!tableExists(db, 'balances')) {
+      return res.json({ data: [], cursor: null, as_of_ledger: null });
+    }
+
+    const limit = Math.min(Number(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT);
+    const decoded = decodeCursor(req.query.cursor);
+    const afterRowid = decoded?.afterRowid ?? 0;
+
+    const rows = db
+      .prepare(
+        `SELECT rowid, user, balance FROM balances
+         WHERE rowid > ?
+         ORDER BY rowid ASC LIMIT ?`,
+      )
+      .all(afterRowid, limit + 1);
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? encodeCursor(page[page.length - 1]) : null;
+    const as_of_ledger = getAsOfLedger(db);
+
+    // ETag from last rowid + ledger
+    const etag = `"${createHash('sha1')
+      .update(`${page.at(-1)?.rowid ?? 0}:${as_of_ledger ?? 0}`)
+      .digest('hex')
+      .slice(0, 16)}"`;
+
+    if (req.headers['if-none-match'] === etag) {
+      return res.status(304).end();
+    }
+
+    res.set({
+      ETag: etag,
+      'Cache-Control': 'public, max-age=10, stale-while-revalidate=60',
+    });
+
+    return res.json({
+      data: page.map((r) => ({ address: r.user, balance: r.balance })),
+      cursor: nextCursor,
+      has_more: hasMore,
+      as_of_ledger,
+    });
+  });
+
+  // ── GET /index/campaigns/:id/events ───────────────────────────────────────
+  router.get('/campaigns/:id/events', (req, res) => {
+    const campaign = campaignRepository.getById(req.params.id);
+    if (!campaign) return res.status(404).json({ error: 'campaign not found', code: 'NOT_FOUND' });
+
+    const limit = Math.min(Number(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT);
+    const type = req.query.type; // 'credit' | 'claim' | undefined (all)
+    const decoded = decodeCursor(req.query.cursor);
+    const afterRowid = decoded?.afterRowid ?? 0;
+    const as_of_ledger = getAsOfLedger(db);
+
+    const events = [];
+
+    const wantCredit = !type || type === 'credit';
+    const wantClaim = !type || type === 'claim';
+
+    if (wantCredit && tableExists(db, 'credit_events')) {
+      const rows = db
+        .prepare(
+          `SELECT rowid, user, amount, ledger, tx_hash, 'credit' as type
+           FROM credit_events WHERE rowid > ? ORDER BY rowid ASC LIMIT ?`,
+        )
+        .all(afterRowid, limit + 1);
+      events.push(...rows);
+    }
+    if (wantClaim && tableExists(db, 'claim_events')) {
+      const rows = db
+        .prepare(
+          `SELECT rowid, user, amount, ledger, tx_hash, 'claim' as type
+           FROM claim_events WHERE rowid > ? ORDER BY rowid ASC LIMIT ?`,
+        )
+        .all(afterRowid, limit + 1);
+      events.push(...rows);
+    }
+
+    // Sort combined set by rowid, apply limit
+    events.sort((a, b) => (a.rowid ?? 0) - (b.rowid ?? 0));
+    const hasMore = events.length > limit;
+    const page = hasMore ? events.slice(0, limit) : events;
+    const nextCursor = hasMore ? encodeCursor(page[page.length - 1]) : null;
+
+    const etag = `"${createHash('sha1')
+      .update(`${page.at(-1)?.rowid ?? 0}:${as_of_ledger ?? 0}:${type ?? 'all'}`)
+      .digest('hex')
+      .slice(0, 16)}"`;
+
+    if (req.headers['if-none-match'] === etag) return res.status(304).end();
+
+    res.set({ ETag: etag, 'Cache-Control': 'public, max-age=5, stale-while-revalidate=30' });
+
+    return res.json({
+      data: page.map(({ rowid, ...rest }) => rest),
+      cursor: nextCursor,
+      has_more: hasMore,
+      as_of_ledger,
+    });
+  });
+
+  // ── GET /index/addresses/:address/history ─────────────────────────────────
+  router.get('/addresses/:address/history', (req, res) => {
+    const { address } = req.params;
+    if (!address) return res.status(400).json({ error: 'address is required' });
+
+    const limit = Math.min(Number(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT);
+    const decoded = decodeCursor(req.query.cursor);
+    const afterRowid = decoded?.afterRowid ?? 0;
+    const as_of_ledger = getAsOfLedger(db);
+
+    const events = [];
+    if (tableExists(db, 'credit_events')) {
+      const rows = db
+        .prepare(
+          `SELECT rowid, user, amount, ledger, tx_hash, 'credit' as type
+           FROM credit_events WHERE user = ? AND rowid > ?
+           ORDER BY rowid ASC LIMIT ?`,
+        )
+        .all(address, afterRowid, limit + 1);
+      events.push(...rows);
+    }
+    if (tableExists(db, 'claim_events')) {
+      const rows = db
+        .prepare(
+          `SELECT rowid, user, amount, ledger, tx_hash, 'claim' as type
+           FROM claim_events WHERE user = ? AND rowid > ?
+           ORDER BY rowid ASC LIMIT ?`,
+        )
+        .all(address, afterRowid, limit + 1);
+      events.push(...rows);
+    }
+
+    events.sort((a, b) => (a.rowid ?? 0) - (b.rowid ?? 0));
+    const hasMore = events.length > limit;
+    const page = hasMore ? events.slice(0, limit) : events;
+    const nextCursor = hasMore ? encodeCursor(page[page.length - 1]) : null;
+
+    let balance = '0';
+    if (tableExists(db, 'balances')) {
+      const row = db.prepare('SELECT balance FROM balances WHERE user = ?').get(address);
+      balance = row?.balance ?? '0';
+    }
+
+    return res.json({
+      address,
+      balance,
+      data: page.map(({ rowid, ...rest }) => rest),
+      cursor: nextCursor,
+      has_more: hasMore,
+      as_of_ledger,
+    });
+  });
+
+  // ── GET /index/campaigns/:id/stats ────────────────────────────────────────
+  router.get('/campaigns/:id/stats', (req, res) => {
+    const campaign = campaignRepository.getById(req.params.id);
+    if (!campaign) return res.status(404).json({ error: 'campaign not found', code: 'NOT_FOUND' });
+
+    const campaignId = String(campaign.id);
+    const as_of_ledger = getAsOfLedger(db);
+    const cacheKey = `${campaignId}:${as_of_ledger}`;
+
+    const cached = statsCache.get(cacheKey);
+    const now = Date.now();
+    if (cached && now - cached.at < STATS_CACHE_TTL_MS) {
+      if (req.headers['if-none-match'] === cached.etag) return res.status(304).end();
+      res.set({ ETag: cached.etag, 'Cache-Control': 'public, max-age=30, stale-while-revalidate=120' });
+      return res.json(cached.data);
+    }
+
+    let totalParticipants = 0;
+    let totalCredited = BigInt(0);
+    let totalClaimed = BigInt(0);
+
+    if (tableExists(db, 'balances')) {
+      const row = db.prepare('SELECT COUNT(*) as cnt FROM balances WHERE CAST(balance AS INTEGER) > 0').get();
+      totalParticipants = row?.cnt ?? 0;
+    }
+    if (tableExists(db, 'credit_events')) {
+      const row = db.prepare("SELECT COALESCE(SUM(CAST(amount AS INTEGER)), 0) as total FROM credit_events").get();
+      totalCredited = BigInt(row?.total ?? 0);
+    }
+    if (tableExists(db, 'claim_events')) {
+      const row = db.prepare("SELECT COALESCE(SUM(CAST(amount AS INTEGER)), 0) as total FROM claim_events").get();
+      totalClaimed = BigInt(row?.total ?? 0);
+    }
+
+    const claimRate =
+      totalCredited > 0n
+        ? Math.round((Number(totalClaimed) / Number(totalCredited)) * 1000) / 10
+        : 0;
+
+    const data = {
+      campaignId,
+      as_of_ledger,
+      summary: {
+        totalParticipants,
+        totalCredited: totalCredited.toString(),
+        totalClaimed: totalClaimed.toString(),
+        claimRate,
+      },
+    };
+
+    const etag = `"${createHash('sha1').update(JSON.stringify(data)).digest('hex').slice(0, 16)}"`;
+    statsCache.set(cacheKey, { data, etag, at: now });
+    // Prune old entries to cap memory
+    if (statsCache.size > 200) {
+      const oldest = [...statsCache.keys()][0];
+      statsCache.delete(oldest);
+    }
+
+    if (req.headers['if-none-match'] === etag) return res.status(304).end();
+    res.set({ ETag: etag, 'Cache-Control': 'public, max-age=30, stale-while-revalidate=120' });
+    return res.json(data);
+  });
+
+  return router;
+}

--- a/backend/src/routes/sponsoredAccounts.js
+++ b/backend/src/routes/sponsoredAccounts.js
@@ -1,0 +1,231 @@
+// #556 — Sponsored account creation + reserve sponsorship (CAP-33 / Stellar sponsored reserves).
+//
+// Flow for a brand-new address that has zero XLM:
+//   1. Client calls POST /api/v1/sponsored-accounts with { address, accountType, trustlineAsset? }
+//   2. Backend builds:
+//        BeginSponsoringFutureReserves (sponsor signs)
+//        CreateAccount OR CreateClaimableBalance (for smart-wallet placeholder)
+//        optional: ChangeTrust (trustline for payout asset)
+//        EndSponsoringFutureReserves (new account signs)
+//   3. Returns the XDR for the client to collect the new account's signature and submit,
+//      OR submits directly if the backend holds the sponsor key.
+//
+// Revoke: POST /api/v1/sponsored-accounts/:address/revoke
+//   Builds RevokeSponsorship operation so the account takes over its own reserve.
+
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import {
+  Keypair,
+  TransactionBuilder,
+  Operation,
+  Networks,
+  Asset,
+  BASE_FEE,
+  Horizon,
+  StrKey,
+} from '@stellar/stellar-sdk';
+
+const GRACE_PERIOD_DAYS = 30;
+const DEFAULT_STARTING_BALANCE = '1'; // 1 XLM covers base reserve
+
+/**
+ * @param {string | undefined} address
+ * @returns {boolean}
+ */
+function isValidStellarAddress(address) {
+  if (!address) return false;
+  try {
+    return StrKey.isValidEd25519PublicKey(address);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {{
+ *   dal: import('../dal/index.js').Dal;
+ *   stellarConfig: { networkPassphrase: string; horizonUrl: string };
+ *   env?: NodeJS.ProcessEnv;
+ * }} options
+ */
+export function createSponsoredAccountRoutes({ dal, stellarConfig, env = process.env }) {
+  const router = Router();
+  const horizonUrl = stellarConfig.horizonUrl;
+  const networkPassphrase = stellarConfig.networkPassphrase;
+  const sponsorSecretKey = env.SPONSOR_SECRET_KEY;
+
+  // POST /sponsored-accounts — create a sponsored account
+  router.post('/', async (req, res) => {
+    const { address, accountType = 'stellar', trustlineAsset } = req.body ?? {};
+
+    if (!isValidStellarAddress(address)) {
+      return res.status(400).json({ error: 'address must be a valid Stellar G-address' });
+    }
+    if (!['stellar', 'smart_wallet'].includes(accountType)) {
+      return res.status(400).json({ error: 'accountType must be "stellar" or "smart_wallet"' });
+    }
+    if (trustlineAsset) {
+      const parts = trustlineAsset.split(':');
+      if (parts.length !== 2 || !parts[0] || !isValidStellarAddress(parts[1])) {
+        return res.status(400).json({
+          error: 'trustlineAsset must be "CODE:ISSUER_ADDRESS"',
+        });
+      }
+    }
+
+    // Check for existing sponsorship
+    const existing = dal.db
+      .prepare("SELECT id FROM sponsored_accounts WHERE address = ? AND status = 'active'")
+      .get(address);
+    if (existing) {
+      return res.status(409).json({ error: 'address already has an active sponsorship' });
+    }
+
+    if (!sponsorSecretKey) {
+      // Return XDR stub so the client can see what would be built
+      const now = new Date().toISOString();
+      const id = randomUUID();
+      dal.db
+        .prepare(
+          `INSERT INTO sponsored_accounts
+             (id, address, account_type, sponsor_address, status, trustline_asset, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'active', ?, ?, ?)`,
+        )
+        .run(id, address, accountType, 'SPONSOR_NOT_CONFIGURED', trustlineAsset ?? null, now, now);
+      return res.status(202).json({
+        id,
+        address,
+        accountType,
+        status: 'active',
+        note: 'SPONSOR_SECRET_KEY not configured — sponsorship tracked but no on-chain transaction built',
+      });
+    }
+
+    try {
+      const sponsorKeypair = Keypair.fromSecret(sponsorSecretKey);
+      const sponsorAddress = sponsorKeypair.publicKey();
+      const server = new Horizon.Server(horizonUrl);
+      const sponsorAccount = await server.loadAccount(sponsorAddress);
+
+      const txBuilder = new TransactionBuilder(sponsorAccount, {
+        fee: String(Number(BASE_FEE) * 4),
+        networkPassphrase,
+      });
+
+      // CAP-33: wrap in sponsor envelope
+      txBuilder.addOperation(
+        Operation.beginSponsoringFutureReserves({ sponsoredId: address }),
+      );
+      txBuilder.addOperation(
+        Operation.createAccount({
+          destination: address,
+          startingBalance: DEFAULT_STARTING_BALANCE,
+        }),
+      );
+      if (trustlineAsset) {
+        const [code, issuer] = trustlineAsset.split(':');
+        txBuilder.addOperation(
+          Operation.changeTrust({
+            asset: new Asset(code, issuer),
+            source: address,
+          }),
+        );
+      }
+      txBuilder.addOperation(
+        Operation.endSponsoringFutureReserves({ source: address }),
+      );
+
+      txBuilder.setTimeout(180);
+      const tx = txBuilder.build();
+      tx.sign(sponsorKeypair);
+
+      // Submit (will fail if the new account hasn't also signed — client must add its sig)
+      const xdr = tx.toEnvelope().toXDR('base64');
+
+      const now = new Date().toISOString();
+      const id = randomUUID();
+      dal.db
+        .prepare(
+          `INSERT INTO sponsored_accounts
+             (id, address, account_type, sponsor_address, status, trustline_asset, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'active', ?, ?, ?)`,
+        )
+        .run(id, address, accountType, sponsorAddress, trustlineAsset ?? null, now, now);
+
+      return res.status(201).json({
+        id,
+        address,
+        accountType,
+        sponsorAddress,
+        status: 'active',
+        transactionXdr: xdr,
+        note: 'Add the new account signature to transactionXdr before submitting to Horizon',
+      });
+    } catch (err) {
+      return res.status(502).json({ error: 'failed to build sponsorship transaction', detail: err.message });
+    }
+  });
+
+  // GET /sponsored-accounts/:address — lookup sponsorship status
+  router.get('/:address', (req, res) => {
+    const row = dal.db
+      .prepare('SELECT * FROM sponsored_accounts WHERE address = ?')
+      .get(req.params.address);
+    if (!row) return res.status(404).json({ error: 'not found' });
+    return res.json({ sponsorship: row });
+  });
+
+  // POST /sponsored-accounts/:address/revoke — transfer reserve back to account
+  router.post('/:address/revoke', async (req, res) => {
+    const { address } = req.params;
+    const row = dal.db
+      .prepare("SELECT * FROM sponsored_accounts WHERE address = ? AND status = 'active'")
+      .get(address);
+    if (!row) return res.status(404).json({ error: 'no active sponsorship for this address' });
+
+    if (!sponsorSecretKey) {
+      const now = new Date().toISOString();
+      dal.db
+        .prepare(
+          "UPDATE sponsored_accounts SET status = 'revoked', revoked_at = ?, updated_at = ? WHERE id = ?",
+        )
+        .run(now, now, row.id);
+      return res.json({ ok: true, status: 'revoked', note: 'SPONSOR_SECRET_KEY not configured — revocation tracked only' });
+    }
+
+    try {
+      const sponsorKeypair = Keypair.fromSecret(sponsorSecretKey);
+      const server = new Horizon.Server(horizonUrl);
+      const sponsorAccount = await server.loadAccount(sponsorKeypair.publicKey());
+
+      const tx = new TransactionBuilder(sponsorAccount, {
+        fee: String(Number(BASE_FEE) * 2),
+        networkPassphrase,
+      })
+        .addOperation(
+          Operation.revokeAccountSponsorship({
+            account: address,
+          }),
+        )
+        .setTimeout(180)
+        .build();
+
+      tx.sign(sponsorKeypair);
+      const xdr = tx.toEnvelope().toXDR('base64');
+
+      const now = new Date().toISOString();
+      dal.db
+        .prepare(
+          "UPDATE sponsored_accounts SET status = 'revoked', revoked_at = ?, updated_at = ? WHERE id = ?",
+        )
+        .run(now, now, row.id);
+
+      return res.json({ ok: true, status: 'revoked', transactionXdr: xdr });
+    } catch (err) {
+      return res.status(502).json({ error: 'failed to build revocation transaction', detail: err.message });
+    }
+  });
+
+  return router;
+}

--- a/backend/src/routes/stellarToml.js
+++ b/backend/src/routes/stellarToml.js
@@ -1,0 +1,151 @@
+// #551 — SEP-1 stellar.toml publishing for reward token metadata.
+// Wallets and explorers (Lobstr, StellarExpert, etc.) call /.well-known/stellar.toml
+// to discover asset names, decimals, and images.
+
+import { Router } from 'express';
+
+const TOML_MAX_AGE_SECONDS = 3600; // 1 hour
+
+/**
+ * Parse a TOML-safe value: strip characters that would break a TOML inline string.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeTOML(value) {
+  return String(value ?? '').replace(/["\\]/g, '');
+}
+
+/**
+ * Build the stellar.toml text from a list of currency configs.
+ *
+ * @param {{
+ *   organizationName?: string;
+ *   organizationUrl?: string;
+ *   currencies: Array<{
+ *     code: string;
+ *     issuer: string;
+ *     name?: string;
+ *     desc?: string;
+ *     image?: string;
+ *     decimals?: number;
+ *   }>;
+ * }} config
+ * @returns {string}
+ */
+export function buildStellarToml({ organizationName, organizationUrl, currencies = [] }) {
+  const lines = [];
+
+  lines.push('# Trivela SEP-0001 Stellar TOML');
+  lines.push(`# Generated: ${new Date().toISOString()}`);
+  lines.push('');
+
+  lines.push('[DOCUMENTATION]');
+  if (organizationName) lines.push(`ORG_NAME = "${escapeTOML(organizationName)}"`);
+  if (organizationUrl) lines.push(`ORG_URL = "${escapeTOML(organizationUrl)}"`);
+  lines.push('');
+
+  if (currencies.length === 0) {
+    lines.push('# No reward tokens configured.');
+  }
+
+  for (const cur of currencies) {
+    lines.push('[[CURRENCIES]]');
+    lines.push(`code = "${escapeTOML(cur.code)}"`);
+    lines.push(`issuer = "${escapeTOML(cur.issuer)}"`);
+    if (cur.name) lines.push(`name = "${escapeTOML(cur.name)}"`);
+    if (cur.desc) lines.push(`desc = "${escapeTOML(cur.desc)}"`);
+    if (cur.image) lines.push(`image = "${escapeTOML(cur.image)}"`);
+    lines.push(`decimals = ${Number.isFinite(cur.decimals) ? cur.decimals : 7}`);
+    lines.push(`is_asset_anchored = false`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Parse the REWARD_TOKEN_* env vars into a currency list.
+ * Supports multiple tokens via REWARD_TOKEN_0_CODE / REWARD_TOKEN_1_CODE etc.,
+ * or a single token via REWARD_TOKEN_CODE.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {Array<{ code: string; issuer: string; name?: string; desc?: string; image?: string; decimals?: number }>}
+ */
+export function parseCurrenciesFromEnv(env = process.env) {
+  const currencies = [];
+
+  // Multi-token: REWARD_TOKEN_0_CODE, REWARD_TOKEN_0_ISSUER, ...
+  for (let i = 0; i < 10; i++) {
+    const code = env[`REWARD_TOKEN_${i}_CODE`];
+    const issuer = env[`REWARD_TOKEN_${i}_ISSUER`];
+    if (code && issuer) {
+      currencies.push({
+        code,
+        issuer,
+        name: env[`REWARD_TOKEN_${i}_NAME`],
+        desc: env[`REWARD_TOKEN_${i}_DESC`],
+        image: env[`REWARD_TOKEN_${i}_IMAGE`],
+        decimals: env[`REWARD_TOKEN_${i}_DECIMALS`] != null
+          ? Number(env[`REWARD_TOKEN_${i}_DECIMALS`])
+          : 7,
+      });
+    }
+  }
+
+  // Single-token shorthand
+  if (currencies.length === 0 && env.REWARD_TOKEN_CODE && env.REWARD_TOKEN_ISSUER) {
+    currencies.push({
+      code: env.REWARD_TOKEN_CODE,
+      issuer: env.REWARD_TOKEN_ISSUER,
+      name: env.REWARD_TOKEN_NAME,
+      desc: env.REWARD_TOKEN_DESC,
+      image: env.REWARD_TOKEN_IMAGE,
+      decimals: env.REWARD_TOKEN_DECIMALS != null ? Number(env.REWARD_TOKEN_DECIMALS) : 7,
+    });
+  }
+
+  return currencies;
+}
+
+/**
+ * @param {{ env?: NodeJS.ProcessEnv }} options
+ * @returns {Router}
+ */
+export function createStellarTomlRoute({ env = process.env } = {}) {
+  const router = Router();
+
+  // In-memory cache to avoid rebuilding on every request
+  let cached = null;
+  let cachedAt = 0;
+
+  router.get('/.well-known/stellar.toml', (req, res) => {
+    const now = Date.now();
+
+    if (!cached || now - cachedAt > TOML_MAX_AGE_SECONDS * 1000) {
+      const currencies = parseCurrenciesFromEnv(env);
+      cached = buildStellarToml({
+        organizationName: env.ORG_NAME ?? 'Trivela',
+        organizationUrl: env.ORG_URL,
+        currencies,
+      });
+      cachedAt = now;
+    }
+
+    res.set({
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': `public, max-age=${TOML_MAX_AGE_SECONDS}`,
+      'X-Content-Type-Options': 'nosniff',
+    });
+    res.send(cached);
+  });
+
+  // Admin cache invalidation (e.g. after token config change)
+  router.post('/.well-known/stellar.toml/invalidate', (req, res) => {
+    cached = null;
+    cachedAt = 0;
+    res.json({ ok: true, message: 'stellar.toml cache invalidated' });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
Closes #560 
Closes #551 
Closes #556 
Closes #548  
- **#560 — Public read API over indexed data**: Adds four cursor-paginated, ETag-cached read endpoints over indexed Soroban event tables. All responses include `as_of_ledger` for freshness. Reuses existing `pagination.js` cursor pattern and `indexer_checkpoints` ledger ref.
  - `GET /api/v1/index/campaigns/:id/participants` — paginated balance list
  - `GET /api/v1/index/campaigns/:id/events` — credit/claim event log (filterable by `type`)
  - `GET /api/v1/index/addresses/:address/history` — full history + current balance for one address
  - `GET /api/v1/index/campaigns/:id/stats` — rollup stats with 30s in-memory cache and ETag

- **#551 — SEP-1 stellar.toml**: Serves `/.well-known/stellar.toml` with correct `text/plain` content-type, `Access-Control-Allow-Origin: *`, and `Cache-Control: public, max-age=3600`. Reads token metadata from `REWARD_TOKEN_*` env vars (supports single token via `REWARD_TOKEN_CODE` + `REWARD_TOKEN_ISSUER`, or multi-token via `REWARD_TOKEN_0_CODE`, `REWARD_TOKEN_1_CODE`, etc.). Admin cache invalidation via `POST /.well-known/stellar.toml/invalidate`.

- **#556 — Sponsored account creation (CAP-33)**: Adds reserve sponsorship flow for brand-new Stellar addresses (and smart-wallet accounts). `POST /api/v1/sponsored-accounts` builds a `BeginSponsoringFutureReserves → CreateAccount → (optional) ChangeTrust → EndSponsoringFutureReserves` transaction and returns the partially-signed XDR for the client to add the new account's signature. `POST /:address/revoke` builds `RevokeSponsorship`. Migration 021 tracks all sponsorships. When `SPONSOR_SECRET_KEY` is not set, rows are tracked but no on-chain XDR is built.

- **#548 — Claimable balances for unclaimed rewards (CAP-23)**: End-of-campaign job enumerates `credit_events`/`claim_events` to find eligible-unclaimed users and creates Stellar claimable balances with a two-claimant predicate (user: before grace end; operator: after grace end). Job is idempotent. Migration 022 tracks `balance_id`, `status`, `grace_end_at`. `POST /api/v1/campaigns/:id/claimable-balances/reclaim` marks expired balances as operator-reclaimed.

## All endpoints documented in `backend/openapi.yaml`

## Test plan

- [ ] `GET /.well-known/stellar.toml` returns `text/plain`, valid SEP-1 TOML with `[[CURRENCIES]]` when `REWARD_TOKEN_CODE` + `REWARD_TOKEN_ISSUER` are set; returns minimal TOML when not set
- [ ] `GET /api/v1/index/campaigns/:id/participants` returns cursor-paginated rows with `as_of_ledger`; repeat with `cursor` from first response to get next page
- [ ] `GET /api/v1/index/campaigns/:id/events?type=credit` returns only credit events; omit `type` to get both
- [ ] Second request with `If-None-Match` header returns `304 Not Modified`
- [ ] `GET /api/v1/index/campaigns/:id/stats` returns `summary.totalParticipants`, `totalCredited`, `claimRate`
- [ ] `POST /api/v1/sponsored-accounts` with a valid G-address returns `transactionXdr`; second call returns `409`
- [ ] `POST /api/v1/sponsored-accounts/:address/revoke` marks status `revoked`
- [ ] `POST /api/v1/campaigns/:id/claimable-balances` returns `{ created, skipped }`; re-running is idempotent
- [ ] `GET /api/v1/campaigns/:id/claimable-balances?status=pending` filters correctly
- [ ] `POST /api/v1/campaigns/:id/claimable-balances/reclaim` marks grace-expired balances as `reclaimed_by_operator`