### PR TITLE
feat: idempotency keys, event indexer, SEP-41 token, passkey wallet

### DIFF
--- a/backend/src/dal/index.js
+++ b/backend/src/dal/index.js
@@ -21,6 +21,7 @@ import { SqliteOrganizationRepository } from './sqliteOrganizationRepository.js'
 import { createSqliteOrgMemberRepository } from './sqliteOrgMemberRepository.js';
 import { createSqliteUsageRepository } from './sqliteUsageRepository.js';
 import { createSqliteFeatureFlagRepository } from './sqliteFeatureFlagRepository.js';
+import { createSqliteIdempotencyRepository } from './sqliteIdempotencyRepository.js';
 
 import { runPgMigrations } from './pg/migrate.js';
 import { createPgCampaignRepository } from './pg/pgCampaignRepository.js';
@@ -94,6 +95,7 @@ export async function createDal({
     orgMembers: createSqliteOrgMemberRepository({ db }),
     usage: createSqliteUsageRepository({ db }),
     featureFlags: createSqliteFeatureFlagRepository({ db }),
+    idempotency: createSqliteIdempotencyRepository({ db }),
     db,
     pgPool,
   };

--- a/backend/src/dal/sqliteIdempotencyRepository.js
+++ b/backend/src/dal/sqliteIdempotencyRepository.js
@@ -1,0 +1,43 @@
+export function createSqliteIdempotencyRepository({ db }) {
+  const insertStmt = db.prepare(`
+    INSERT INTO idempotency_keys (key, request_fingerprint, status_code, response_body, locked_at, completed_at, created_at, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now', '+1 day'))
+  `);
+
+  const findStmt = db.prepare(`SELECT * FROM idempotency_keys WHERE key = ?`);
+
+  const lockStmt = db.prepare(`
+    UPDATE idempotency_keys SET locked_at = datetime('now') WHERE key = ? AND completed_at IS NULL AND locked_at IS NULL
+  `);
+
+  const completeStmt = db.prepare(`
+    UPDATE idempotency_keys SET status_code = ?, response_body = ?, completed_at = datetime('now') WHERE key = ?
+  `);
+
+  const cleanupStmt = db.prepare(`DELETE FROM idempotency_keys WHERE expires_at < datetime('now')`);
+
+  return {
+    create(key, fingerprint) {
+      insertStmt.run(key, fingerprint, 0, '{}', null, null);
+      return findStmt.get(key);
+    },
+
+    find(key) {
+      return findStmt.get(key) ?? null;
+    },
+
+    tryLock(key) {
+      const result = lockStmt.run(key);
+      return result.changes > 0;
+    },
+
+    complete(key, statusCode, responseBody) {
+      completeStmt.run(statusCode, responseBody, key);
+    },
+
+    cleanup() {
+      const result = cleanupStmt.run();
+      return result.changes;
+    },
+  };
+}

--- a/backend/src/db/migrations/023_idempotency_keys.js
+++ b/backend/src/db/migrations/023_idempotency_keys.js
@@ -1,0 +1,19 @@
+export const version = 23;
+export const description = 'Idempotency keys table for write endpoint deduplication (#533)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS idempotency_keys (
+      key               TEXT PRIMARY KEY,
+      request_fingerprint TEXT NOT NULL,
+      status_code       INTEGER NOT NULL,
+      response_body     TEXT NOT NULL,
+      locked_at         TEXT,
+      completed_at      TEXT,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      expires_at        TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires ON idempotency_keys(expires_at);
+  `);
+}

--- a/backend/src/db/migrations/024_indexer_events.js
+++ b/backend/src/db/migrations/024_indexer_events.js
@@ -1,0 +1,30 @@
+export const version = 24;
+export const description = 'Indexed events table and indexer state for production-grade event indexing (#532)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS indexed_events (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      ledger            INTEGER NOT NULL,
+      tx_hash           TEXT NOT NULL,
+      contract_id       TEXT NOT NULL,
+      event_type        TEXT NOT NULL,
+      topic             TEXT NOT NULL,
+      data_json         TEXT NOT NULL,
+      event_index       INTEGER NOT NULL DEFAULT 0,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(tx_hash, event_index)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_indexed_events_ledger ON indexed_events(ledger);
+    CREATE INDEX IF NOT EXISTS idx_indexed_events_type ON indexed_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_indexed_events_contract ON indexed_events(contract_id);
+
+    CREATE TABLE IF NOT EXISTS indexer_state (
+      contract_id       TEXT PRIMARY KEY,
+      cursor            TEXT,
+      last_ledger       INTEGER NOT NULL DEFAULT 0,
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -67,8 +67,10 @@ import { requestTimeout } from './middleware/timeout.js';
 import { PoolSaturatedError } from './rpcPool.js';
 import { initializeWebSocket, getWebSocketServer } from './websocket/index.js';
 import { requireScope } from './middleware/rbac.js';
+import { createIdempotencyMiddleware } from './middleware/idempotency.js';
 import { createDistributedLock, createInMemoryLock } from './jobs/distributedLock.js';
 import { createExportJob } from './jobs/exportJob.js';
+import { createEventIndexer } from './jobs/eventIndexer.js';
 import { createSqliteJobQueueRepository } from './dal/sqliteJobQueueRepository.js';
 import { createDurableJobQueue } from './jobs/durableJobQueue.js';
 import { createStellarTomlRoute } from './routes/stellarToml.js';
@@ -267,6 +269,11 @@ export async function createApp(options = {}) {
   const allowlistRepository = dal.allowlists;
   const orgMemberRepository = dal.orgMembers;
   const usageRepository = options.usageRepository ?? dal.usage;
+  const idempotencyRepository = dal.idempotency;
+
+  const idempotencyMiddleware = createIdempotencyMiddleware({
+    repository: idempotencyRepository,
+  });
 
   const storageAdapter = /** @type {import('./storage/storageAdapter.js').StorageAdapter} */ (
     options.storageAdapter ?? createStorageAdapter(process.env)
@@ -452,6 +459,16 @@ export async function createApp(options = {}) {
     logger: log,
     retentionDays: exportRetentionDays,
     uploadDir: process.env.UPLOAD_DIR ?? './uploads',
+  });
+
+  const eventIndexer = createEventIndexer({
+    db: dal.db,
+    rpcPool,
+    logger: log,
+    referralBonus: normalizePositiveInteger(
+      /** @type {any} */ (options.referralBonus) ?? process.env.REFERRAL_BONUS,
+      0,
+    ),
   });
 
   // Durable job queue store — persistent across restarts (#565)
@@ -718,6 +735,18 @@ export async function createApp(options = {}) {
     });
   });
 
+  app.get('/health/indexer', (_req, res) => {
+    const health = eventIndexer?.getHealth?.() ?? {
+      status: 'unavailable',
+      lastLedger: 0,
+      lagLedgers: 0,
+      eventsTotal: 0,
+      errorsTotal: 0,
+    };
+    const isHealthy = health.status === 'ok' || health.status === 'idle';
+    res.status(isHealthy ? 200 : 503).json(health);
+  });
+
   app.get('/metrics', (_req, res) => {
     const uptimeSeconds = process.uptime();
     const routeLines = [...metrics.routeHits.entries()]
@@ -780,6 +809,12 @@ export async function createApp(options = {}) {
       '# HELP trivela_rpc_pool_unhealthy Unhealthy RPC endpoints in the pool.',
       '# TYPE trivela_rpc_pool_unhealthy gauge',
       `trivela_rpc_pool_unhealthy ${poolStatus.unhealthy}`,
+      // Indexer metrics (#532).
+      ...Object.entries(eventIndexer?.getMetrics?.() ?? {}).map(([key, value]) => [
+        `# HELP ${key.replace(/_/g, ' ')} Indexer metric.`,
+        `# TYPE ${key} gauge`,
+        `${key} ${value}`,
+      ]).flat(),
     ]
       .filter(Boolean)
       .join('\n');
@@ -1714,8 +1749,8 @@ export async function createApp(options = {}) {
     app.get(`${prefix}/admin/audit/verify`, rateLimiter, requireMasterKey, verifyAuditChain);
     app.get(`${prefix}/indexer/cursor`, rateLimiter, getIndexerCursorState);
     app.post(`${prefix}/indexer/cursor`, rateLimiter, ...guard, setIndexerCursorState);
-    app.post(`${prefix}/campaigns`, rateLimiter, ...guard, requireScope('campaigns:write'), createCampaign);
-    app.post(`${prefix}/campaigns/:id/clone`, rateLimiter, ...guard, requireScope('campaigns:write'), cloneCampaign);
+    app.post(`${prefix}/campaigns`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), createCampaign);
+    app.post(`${prefix}/campaigns/:id/clone`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), cloneCampaign);
     app.post(`${prefix}/campaigns/:id/image`, rateLimiter, ...guard, requireScope('campaigns:write'), (req, res, next) => {
       imageUpload.single('image')(req, res, (err) => {
         if (err?.code === 'LIMIT_FILE_SIZE') {
@@ -1728,23 +1763,24 @@ export async function createApp(options = {}) {
         return uploadCampaignImageHandler(req, res);
       });
     });
-    app.put(`${prefix}/campaigns/:id`, rateLimiter, ...guard, requireScope('campaigns:write'), updateCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), updateCampaign);
     app.delete(`${prefix}/campaigns/:id`, rateLimiter, ...guard, requireScope('campaigns:write'), deleteCampaign);
-    app.put(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, updateCampaign);
-    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, requireApiKey, publishCampaign);
-    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, requireApiKey, archiveCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, requireApiKey, updateCampaign);
+    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, idempotencyMiddleware, requireApiKey, publishCampaign);
+    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, idempotencyMiddleware, requireApiKey, archiveCampaign);
     app.delete(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, deleteCampaign);
-    app.put(`${prefix}/campaigns/:id`, rateLimiter, ...guard, updateCampaign);
-    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, ...guard, publishCampaign);
-    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, ...guard, archiveCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, ...guard, updateCampaign);
+    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, idempotencyMiddleware, ...guard, publishCampaign);
+    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, idempotencyMiddleware, ...guard, archiveCampaign);
     app.delete(`${prefix}/campaigns/:id`, rateLimiter, ...guard, deleteCampaign);
 
-    app.post(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, createApiKeyHandler);
+    app.post(`${prefix}/admin/api-keys`, rateLimiter, idempotencyMiddleware, requireMasterKey, createApiKeyHandler);
     app.get(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, listApiKeysHandler);
     app.delete(`${prefix}/admin/api-keys/:id`, rateLimiter, requireMasterKey, revokeApiKeyHandler);
     app.put(
       `${prefix}/admin/api-keys/:id/rotate`,
       rateLimiter,
+      idempotencyMiddleware,
       requireMasterKey,
       rotateApiKeyHandler,
     );
@@ -1797,7 +1833,7 @@ export async function createApp(options = {}) {
 
     // Job dead-letter inspection / requeue (Issue #286)
     app.get(`${prefix}/jobs/failed`, rateLimiter, ...guard, listFailedJobsHandler);
-    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, ...guard, retryFailedJobHandler);
+    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, idempotencyMiddleware, ...guard, retryFailedJobHandler);
 
     // Durable job queue DLQ admin — inspect and replay dead jobs (#565)
     app.get(`${prefix}/admin/jobs/dlq`, rateLimiter, requireMasterKey, (req, res) => {
@@ -1808,7 +1844,7 @@ export async function createApp(options = {}) {
       return res.json({ data: items, pagination: { total, count: items.length, limit, offset } });
     });
 
-    app.post(`${prefix}/admin/jobs/:id/replay`, rateLimiter, requireMasterKey, async (req, res) => {
+    app.post(`${prefix}/admin/jobs/:id/replay`, rateLimiter, idempotencyMiddleware, requireMasterKey, async (req, res) => {
       const job = jobQueueStore.getById(req.params.id);
       if (!job) {
         return res.status(404).json({ error: 'Job not found', code: 'JOB_NOT_FOUND' });
@@ -1820,7 +1856,7 @@ export async function createApp(options = {}) {
     });
 
     // Webhook routes (Issue #287)
-    app.post(`${prefix}/webhooks`, rateLimiter, ...guard, (req, res) => {
+    app.post(`${prefix}/webhooks`, rateLimiter, idempotencyMiddleware, ...guard, (req, res) => {
       const { url, events, secret } = req.body;
       if (!url || !Array.isArray(events) || events.length === 0) {
         return res.status(400).json({
@@ -1852,7 +1888,7 @@ export async function createApp(options = {}) {
       return res.json(webhook);
     });
 
-    app.put(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
+    app.put(`${prefix}/webhooks/:id`, rateLimiter, idempotencyMiddleware, ...guard, (req, res) => {
       const { url, events, active } = req.body;
       const before = webhookRepository.getById(req.params.id);
       if (!before) {

--- a/backend/src/jobs/eventIndexer.js
+++ b/backend/src/jobs/eventIndexer.js
@@ -1,20 +1,28 @@
 /**
- * Event indexer for Trivela Soroban contract events.
+ * Enhanced event indexer for Trivela Soroban contract events.
  *
- * Subscribes to on-chain events and persists them to the database.
- * Snapshot events store a ledger reference so off-chain tools can
- * reconstruct user balances at that point using Horizon getLedgerEntries.
+ * Features:
+ * - Durable cursor persistence in indexer_state table
+ * - Idempotent upserts via UNIQUE(tx_hash, event_index) constraint
+ * - Prometheus metrics for monitoring
+ * - Health status endpoint
+ * - Projection handlers per event type
  */
 
 export function createEventIndexer({
   db,
   rpcPool,
   logger = console,
-  // Bonus (in reward units) auto-credited to a referrer when an on-chain
-  // `referred` event is indexed (issue #455). Defaults to 0 so deployments
-  // opt in explicitly.
   referralBonus = 0,
 } = {}) {
+  const metrics = {
+    lastLedger: 0,
+    lagLedgers: 0,
+    eventsTotal: 0,
+    errorsTotal: 0,
+    lastPollAt: null,
+  };
+
   const handlers = {
     credit: handleCreditEvent,
     claim: handleClaimEvent,
@@ -23,15 +31,45 @@ export function createEventIndexer({
     vclaim: handleVestedClaimEvent,
     referred: (event, database) => handleReferredEvent(event, database, referralBonus),
     refbonus: handleRefBonusEvent,
+    register: handleRegisterEvent,
+    deregister: handleDeregisterEvent,
   };
 
-  async function processEvent(event) {
+  async function processEvent(event, contractId) {
     const topic = event.topic?.[0];
     const handler = handlers[topic];
     if (!handler) return;
+
     try {
+      const txHash = event.txHash || 'unknown';
+      const eventIndex = event.eventIndex || 0;
+      const ledger = event.ledger || 0;
+
+      const existing = db.prepare(
+        'SELECT id FROM indexed_events WHERE tx_hash = ? AND event_index = ?'
+      ).get(txHash, eventIndex);
+
+      if (existing) {
+        return;
+      }
+
+      db.prepare(`
+        INSERT OR IGNORE INTO indexed_events (ledger, tx_hash, contract_id, event_type, topic, data_json, event_index)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        ledger,
+        txHash,
+        contractId,
+        topic,
+        JSON.stringify(event.topic || []),
+        JSON.stringify(event.data),
+        eventIndex,
+      );
+
       await handler(event, db);
+      metrics.eventsTotal++;
     } catch (err) {
+      metrics.errorsTotal++;
       logger.error?.(`eventIndexer:error topic=${topic}`, err);
     }
   }
@@ -44,16 +82,60 @@ export function createEventIndexer({
         cursor,
         limit: 200,
       });
+
       for (const event of events) {
-        await processEvent(event);
+        await processEvent(event, contractId);
       }
+
+      if (nextCursor) {
+        updateCursor(contractId, nextCursor, events.length > 0 ? events[events.length - 1].ledger : 0);
+      }
+
+      metrics.lastPollAt = new Date().toISOString();
       return nextCursor;
     } finally {
       rpcPool.release(rpc);
     }
   }
 
-  return { processEvent, poll };
+  function getCursor(contractId) {
+    const state = db.prepare('SELECT cursor FROM indexer_state WHERE contract_id = ?').get(contractId);
+    return state?.cursor || null;
+  }
+
+  function updateCursor(contractId, cursor, lastLedger) {
+    db.prepare(`
+      INSERT INTO indexer_state (contract_id, cursor, last_ledger, updated_at)
+      VALUES (?, ?, ?, datetime('now'))
+      ON CONFLICT(contract_id) DO UPDATE SET
+        cursor = excluded.cursor,
+        last_ledger = excluded.last_ledger,
+        updated_at = datetime('now')
+    `).run(contractId, cursor, lastLedger);
+    metrics.lastLedger = lastLedger;
+  }
+
+  function getHealth() {
+    return {
+      status: metrics.lastPollAt ? 'ok' : 'idle',
+      lastLedger: metrics.lastLedger,
+      lagLedgers: metrics.lagLedgers,
+      eventsTotal: metrics.eventsTotal,
+      errorsTotal: metrics.errorsTotal,
+      lastPollAt: metrics.lastPollAt,
+    };
+  }
+
+  function getMetrics() {
+    return {
+      indexer_last_ledger: metrics.lastLedger,
+      indexer_lag_ledgers: metrics.lagLedgers,
+      indexer_events_total: metrics.eventsTotal,
+      indexer_errors_total: metrics.errorsTotal,
+    };
+  }
+
+  return { processEvent, poll, getCursor, getHealth, getMetrics };
 }
 
 async function handleCreditEvent(event, db) {
@@ -87,94 +169,6 @@ async function handleClaimEvent(event, db) {
   ]);
 }
 
-/**
- * Index a snapshot event.
- *
- * The contract stores only a ledger reference — not a full balance copy.
- * Off-chain consumers can call Horizon getLedgerEntries with this ledger
- * number to reconstruct all user balances at that exact point in time.
- *
- * Pattern:
- *   1. Read `snapshot_ledger` from this event.
- *   2. Fetch all `BALANCE` storage entries at `snapshot_ledger` from Horizon.
- *   3. Persist the reconstructed balances to `snapshot_balances`.
- */
-/**
- * Index a `referred` event emitted by the campaign contract (issue #455).
- *
- * Topics are `(referred, referee, referrer)`. The contract has already
- * validated that the referrer is a registered participant and is not the
- * referee, so the indexer can trust the edge and auto-credit the referrer's
- * bonus without trusting the frontend.
- *
- * The credit mirrors `handleCreditEvent`: the referrer's balance is bumped and
- * a `credit_events` row records the on-chain reference. Recording is idempotent
- * per (referrer, referee) so re-indexing the same event does not double-credit.
- */
-async function handleReferredEvent(event, db, referralBonus = 0) {
-  const referee = event.topic?.[1];
-  const referrer = event.topic?.[2];
-  if (!referee || !referrer) return;
-
-  // Record the referral edge first; the UNIQUE(referee) guard makes replays
-  // a no-op and lets us skip the credit when nothing was inserted.
-  const recorded = await db.run(
-    `INSERT OR IGNORE INTO referral_credits (referee, referrer, ledger, tx_hash)
-     VALUES (?, ?, ?, ?)`,
-    [referee, referrer, event.ledger, event.txHash],
-  );
-  if (recorded && recorded.changes === 0) return;
-
-  const bonus = BigInt(referralBonus);
-  if (bonus <= 0n) return;
-
-  await db.run(
-    `INSERT OR IGNORE INTO balances (user) VALUES (?)
-     ON CONFLICT(user) DO UPDATE SET balance = balance + ?`,
-    [referrer, bonus.toString()],
-  );
-  await db.run(`INSERT INTO credit_events (user, amount, ledger, tx_hash) VALUES (?, ?, ?, ?)`, [
-    referrer,
-    bonus.toString(),
-    event.ledger,
-    event.txHash,
-  ]);
-}
-
-/**
- * Index a `ref_bonus` event emitted by the rewards contract's on-chain referral
- * engine (issue #656).
- *
- * Topics are `(refbonus, referrer, referee)`, data `(bonus, qualifying_amount)`.
- * The same payout also emits a standard `credit` event for the referrer, which
- * `handleCreditEvent` already applies to balances — so this handler records
- * *instrumentation only* (the attribution edge, bonus, and qualifying amount)
- * for referral-conversion metrics, and never touches balances to avoid
- * double-counting. The `UNIQUE(referee)` guard makes re-indexing idempotent,
- * mirroring the contract's one-bonus-per-referee invariant.
- */
-async function handleRefBonusEvent(event, db) {
-  const referrer = event.topic?.[1];
-  const referee = event.topic?.[2];
-  if (!referrer || !referee) return;
-
-  const [bonus, qualifyingAmount] = Array.isArray(event.data) ? event.data : [0, 0];
-  await db.run(
-    `INSERT OR IGNORE INTO referral_bonus_events
-       (referrer, referee, bonus, qualifying_amount, ledger, tx_hash, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    [
-      referrer,
-      referee,
-      String(bonus),
-      String(qualifyingAmount),
-      event.ledger,
-      event.txHash,
-      Date.now(),
-    ],
-  );
-}
-
 async function handleSnapshotEvent(event, db) {
   const snapshotId = BigInt(event.topic?.[1] ?? 0);
   const snapshotLedger = BigInt(event.data ?? 0);
@@ -202,5 +196,74 @@ async function handleVestedClaimEvent(event, db) {
     `INSERT INTO vested_claim_events (user, vest_id, amount, ledger, tx_hash)
      VALUES (?, ?, ?, ?, ?)`,
     [user, String(vestId), String(amount), event.ledger, event.txHash],
+  );
+}
+
+async function handleReferredEvent(event, db, referralBonus = 0) {
+  const referee = event.topic?.[1];
+  const referrer = event.topic?.[2];
+  if (!referee || !referrer) return;
+
+  const recorded = await db.run(
+    `INSERT OR IGNORE INTO referral_credits (referee, referrer, ledger, tx_hash)
+     VALUES (?, ?, ?, ?)`,
+    [referee, referrer, event.ledger, event.txHash],
+  );
+  if (recorded && recorded.changes === 0) return;
+
+  const bonus = BigInt(referralBonus);
+  if (bonus <= 0n) return;
+
+  await db.run(
+    `INSERT OR IGNORE INTO balances (user) VALUES (?)
+     ON CONFLICT(user) DO UPDATE SET balance = balance + ?`,
+    [referrer, bonus.toString()],
+  );
+  await db.run(`INSERT INTO credit_events (user, amount, ledger, tx_hash) VALUES (?, ?, ?, ?)`, [
+    referrer,
+    bonus.toString(),
+    event.ledger,
+    event.txHash,
+  ]);
+}
+
+async function handleRefBonusEvent(event, db) {
+  const referrer = event.topic?.[1];
+  const referee = event.topic?.[2];
+  if (!referrer || !referee) return;
+
+  const [bonus, qualifyingAmount] = Array.isArray(event.data) ? event.data : [0, 0];
+  await db.run(
+    `INSERT OR IGNORE INTO referral_bonus_events
+       (referrer, referee, bonus, qualifying_amount, ledger, tx_hash, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      referrer,
+      referee,
+      String(bonus),
+      String(qualifyingAmount),
+      event.ledger,
+      event.txHash,
+      Date.now(),
+    ],
+  );
+}
+
+async function handleRegisterEvent(event, db) {
+  const user = event.topic?.[1];
+  const campaignId = event.topic?.[2];
+  await db.run(
+    `INSERT OR IGNORE INTO participants (user, campaign_id, registered_at, tx_hash)
+     VALUES (?, ?, ?, ?)`,
+    [user, campaignId, event.ledger, event.txHash],
+  );
+}
+
+async function handleDeregisterEvent(event, db) {
+  const user = event.topic?.[1];
+  const campaignId = event.topic?.[2];
+  await db.run(
+    `DELETE FROM participants WHERE user = ? AND campaign_id = ?`,
+    [user, campaignId],
   );
 }

--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto';
+
+const IDEMPOTENCY_HEADER = 'Idempotency-Key';
+
+function fingerprint(req) {
+  const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {});
+  return createHash('sha256').update(`${req.method}:${req.originalUrl}:${body}`).digest('hex');
+}
+
+export function createIdempotencyMiddleware({ repository, ttlMs = 24 * 60 * 60 * 1000 } = {}) {
+  if (!repository) {
+    return (_req, _res, next) => next();
+  }
+
+  return async function idempotency(req, res, next) {
+    if (!['POST', 'PUT', 'PATCH'].includes(req.method)) {
+      return next();
+    }
+
+    const key = req.headers[IDEMPOTENCY_HEADER.toLowerCase()];
+    if (!key) {
+      return next();
+    }
+
+    if (typeof key !== 'string' || key.length < 8 || key.length > 256) {
+      return res.status(400).json({
+        error: 'Invalid Idempotency-Key format (8-256 characters required)',
+        code: 'INVALID_IDEMPOTENCY_KEY',
+      });
+    }
+
+    const fp = fingerprint(req);
+    const existing = repository.find(key);
+
+    if (existing) {
+      if (existing.completed_at) {
+        const expired = new Date(existing.expires_at) < new Date();
+        if (expired) {
+          repository.cleanup();
+          return next();
+        }
+        if (existing.request_fingerprint !== fp) {
+          return res.status(422).json({
+            error: 'Idempotency-Key reused with different request payload',
+            code: 'IDEMPOTENCY_KEY_MISMATCH',
+          });
+        }
+        res.setHeader('Idempotent-Previous-Request', 'true');
+        return res.status(existing.status_code).json(JSON.parse(existing.response_body));
+      }
+
+      if (existing.locked_at) {
+        return res.status(409).json({
+          error: 'Request already in progress',
+          code: 'IDEMPOTENCY_IN_PROGRESS',
+        });
+      }
+    }
+
+    if (!existing) {
+      repository.create(key, fp);
+    }
+
+    const locked = repository.tryLock(key);
+    if (!locked) {
+      return res.status(409).json({
+        error: 'Request already in progress',
+        code: 'IDEMPOTENCY_IN_PROGRESS',
+      });
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = function interceptJson(body) {
+      const statusCode = res.statusCode || 200;
+      try {
+        repository.complete(key, statusCode, JSON.stringify(body));
+      } catch (err) {
+        req.log?.warn?.({ err }, 'Failed to persist idempotency response');
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}

--- a/backend/src/middleware/idempotency.test.js
+++ b/backend/src/middleware/idempotency.test.js
@@ -1,0 +1,138 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import Database from 'better-sqlite3';
+import { createSqliteIdempotencyRepository } from '../dal/sqliteIdempotencyRepository.js';
+import { createIdempotencyMiddleware } from './idempotency.js';
+
+describe('idempotency middleware', () => {
+  let db;
+  let repository;
+  let middleware;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS idempotency_keys (
+        key               TEXT PRIMARY KEY,
+        request_fingerprint TEXT NOT NULL,
+        status_code       INTEGER NOT NULL,
+        response_body     TEXT NOT NULL,
+        locked_at         TEXT,
+        completed_at      TEXT,
+        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        expires_at        TEXT NOT NULL
+      );
+    `);
+    repository = createSqliteIdempotencyRepository({ db });
+    middleware = createIdempotencyMiddleware({ repository });
+  });
+
+  it('skips non-mutating methods', async () => {
+    const req = { method: 'GET', headers: {} };
+    const res = {};
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(called);
+  });
+
+  it('skips when no idempotency key header', async () => {
+    const req = { method: 'POST', headers: {}, body: {} };
+    const res = {};
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(called);
+  });
+
+  it('rejects invalid key format', async () => {
+    const req = { method: 'POST', headers: { 'idempotency-key': 'short' }, body: {} };
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { this.body = body; return this; },
+    };
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(!called);
+    assert.strictEqual(res.statusCode, 400);
+  });
+
+  it('processes first request and stores result', async () => {
+    const req = { method: 'POST', headers: { 'idempotency-key': 'test-key-12345678' }, body: { data: 'test' }, originalUrl: '/test', log: null };
+    const res = {
+      statusCode: 201,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { this.body = body; return this; },
+      setHeader() {},
+    };
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(called);
+
+    res.json({ id: 1, name: 'test' });
+    const stored = repository.find('test-key-12345678');
+    assert.ok(stored);
+    assert.strictEqual(stored.completed_at !== null, true);
+  });
+
+  it('replays stored response for duplicate key', async () => {
+    const key = 'duplicate-key-12345678';
+    repository.create(key, 'fingerprint1');
+    repository.tryLock(key);
+    repository.complete(key, 201, JSON.stringify({ id: 1 }));
+
+    const req = { method: 'POST', headers: { 'idempotency-key': key }, body: { data: 'test' }, originalUrl: '/test', log: null };
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { this.body = body; return this; },
+      setHeader() {},
+    };
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(!called);
+    assert.strictEqual(res.statusCode, 201);
+    assert.deepStrictEqual(res.body, { id: 1 });
+  });
+
+  it('returns 409 for in-progress request', async () => {
+    const key = 'progress-key-12345678';
+    repository.create(key, 'fingerprint1');
+    repository.tryLock(key);
+
+    const req = { method: 'POST', headers: { 'idempotency-key': key }, body: { data: 'test' }, originalUrl: '/test', log: null };
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { this.body = body; return this; },
+      setHeader() {},
+    };
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(!called);
+    assert.strictEqual(res.statusCode, 409);
+  });
+
+  it('returns 422 for mismatched payload', async () => {
+    const key = 'mismatch-key-12345678';
+    repository.create(key, 'fingerprint1');
+    repository.tryLock(key);
+    repository.complete(key, 200, JSON.stringify({ result: 'ok' }));
+
+    const req = { method: 'POST', headers: { 'idempotency-key': key }, body: { data: 'different' }, originalUrl: '/test', log: null };
+    const res = {
+      statusCode: null,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { this.body = body; return this; },
+      setHeader() {},
+    };
+    let called = false;
+    await middleware(req, res, () => { called = true; });
+    assert.ok(!called);
+    assert.strictEqual(res.statusCode, 422);
+  });
+});

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -56,6 +56,14 @@ pub enum Error {
     InvalidReferralConfig = 19,
     /// The computed referral bonus rounded down to zero.
     ZeroReferralBonus = 20,
+    /// SEP-41 token mode is not enabled.
+    TokenModeNotEnabled = 21,
+    /// SEP-41: allowance not sufficient for transfer_from.
+    AllowanceExceeded = 22,
+    /// SEP-41: approval expiration ledger has passed.
+    ApprovalExpired = 23,
+    /// SEP-41: invalid expiration ledger (must be > current ledger).
+    InvalidExpiration = 24,
 }
 
 /// Vesting schedule record stored per user per vest_id.
@@ -168,6 +176,20 @@ const REF_BONUS_EVENT: Symbol = symbol_short!("refbonus");
 // Upper bound on the configurable rate (1000%) to guard against fat-finger
 // configuration and keep `qualifying_amount * rate_bps` comfortably in range.
 const MAX_REFERRAL_RATE_BPS: u32 = 100_000;
+
+// ── SEP-41 Token Interface (issue #530) ─────────────────────────────────────
+// Optional token-backed mode where reward points are SEP-41-compliant tokens.
+// When token_mode is enabled, the contract exposes standard token functions.
+const TOKEN_MODE: Symbol = symbol_short!("tokmode");
+const TOKEN_DECIMALS: Symbol = symbol_short!("tokdec");
+const TOKEN_NAME: Symbol = symbol_short!("tokname");
+const TOKEN_SYMBOL: Symbol = symbol_short!("toksym");
+const ALLOWANCE: Symbol = symbol_short!("allow");
+
+// SEP-41 Events
+const SEP41_TRANSFER_EVENT: Symbol = symbol_short!("transfer");
+const SEP41_APPROVE_EVENT: Symbol = symbol_short!("approve");
+const SEP41_BURN_EVENT: Symbol = symbol_short!("burn");
 
 #[contract]
 pub struct RewardsContract;
@@ -1217,6 +1239,312 @@ impl RewardsContract {
     /// The referrer that was rewarded for `referee`, if any.
     pub fn rewarded_referrer_of(env: Env, referee: Address) -> Option<Address> {
         env.storage().instance().get(&(REF_PAID, referee))
+    }
+
+    // ── SEP-41 Token Interface (issue #530) ──────────────────────────────────
+
+    /// Enable token mode (admin only). One-way: once enabled, cannot be disabled.
+    /// This enables SEP-41-compliant token interface alongside existing points API.
+    pub fn enable_token_mode(
+        env: Env,
+        admin: Address,
+        name: Symbol,
+        symbol: Symbol,
+        decimals: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env, &admin)?;
+        if decimals > 18 {
+            return Err(Error::InvalidMultiplier);
+        }
+        env.storage().instance().set(&TOKEN_MODE, &true);
+        env.storage().instance().set(&TOKEN_NAME, &name);
+        env.storage().instance().set(&TOKEN_SYMBOL, &symbol);
+        env.storage().instance().set(&TOKEN_DECIMALS, &decimals);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// Check if token mode is enabled.
+    pub fn is_token_mode(env: Env) -> bool {
+        env.storage().instance().get(&TOKEN_MODE).unwrap_or(false)
+    }
+
+    /// SEP-41: Returns the balance of `id` as i128.
+    /// Maps internal u64 points to i128 per SEP-41 standard.
+    pub fn sep41_balance(env: Env, id: Address) -> i128 {
+        let balance: u64 = env.storage().instance().get(&(BALANCE, id)).unwrap_or(0);
+        balance as i128
+    }
+
+    /// SEP-41: Transfer `amount` from `from` to `to`.
+    /// Requires authorization from `from`.
+    pub fn sep41_transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        if !Self::is_token_mode(env.clone()) {
+            return Err(Error::TokenModeNotEnabled);
+        }
+        from.require_auth();
+        ensure_not_paused(&env)?;
+
+        if amount < 0 {
+            return Err(Error::Overflow);
+        }
+        let amount_u64 = amount as u64;
+
+        let from_key = (BALANCE, from.clone());
+        let from_balance: u64 = env.storage().instance().get(&from_key).unwrap_or(0);
+        let new_from_balance = from_balance
+            .checked_sub(amount_u64)
+            .ok_or(Error::InsufficientBalance)?;
+        env.storage().instance().set(&from_key, &new_from_balance);
+
+        let to_key = (BALANCE, to.clone());
+        let to_balance: u64 = env.storage().instance().get(&to_key).unwrap_or(0);
+        let new_to_balance = to_balance.checked_add(amount_u64).ok_or(Error::Overflow)?;
+        env.storage().instance().set(&to_key, &new_to_balance);
+
+        env.events()
+            .publish((SEP41_TRANSFER_EVENT, from, to), amount);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// SEP-41: Transfer `amount` from `from` to `to` using allowance.
+    /// Requires authorization from `spender`.
+    pub fn sep41_transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        if !Self::is_token_mode(env.clone()) {
+            return Err(Error::TokenModeNotEnabled);
+        }
+        spender.require_auth();
+        ensure_not_paused(&env)?;
+
+        if amount < 0 {
+            return Err(Error::Overflow);
+        }
+        let amount_u64 = amount as u64;
+
+        let allowance_key = (ALLOWANCE, from.clone(), spender.clone());
+        let (allowed, expiration): (u64, u32) = env
+            .storage()
+            .instance()
+            .get(&allowance_key)
+            .unwrap_or((0, 0));
+
+        if expiration > 0 && env.ledger().sequence() > expiration {
+            env.storage().instance().remove(&allowance_key);
+            return Err(Error::ApprovalExpired);
+        }
+
+        if allowed < amount_u64 {
+            return Err(Error::AllowanceExceeded);
+        }
+
+        let new_allowed = allowed - amount_u64;
+        if new_allowed == 0 {
+            env.storage().instance().remove(&allowance_key);
+        } else {
+            env.storage().instance().set(&allowance_key, &(new_allowed, expiration));
+        }
+
+        let from_key = (BALANCE, from.clone());
+        let from_balance: u64 = env.storage().instance().get(&from_key).unwrap_or(0);
+        let new_from_balance = from_balance
+            .checked_sub(amount_u64)
+            .ok_or(Error::InsufficientBalance)?;
+        env.storage().instance().set(&from_key, &new_from_balance);
+
+        let to_key = (BALANCE, to.clone());
+        let to_balance: u64 = env.storage().instance().get(&to_key).unwrap_or(0);
+        let new_to_balance = to_balance.checked_add(amount_u64).ok_or(Error::Overflow)?;
+        env.storage().instance().set(&to_key, &new_to_balance);
+
+        env.events()
+            .publish((SEP41_TRANSFER_EVENT, from, to), amount);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// SEP-41: Set allowance for `spender` to spend `amount` from caller's balance.
+    /// If expiration_ledger is 0, the allowance does not expire.
+    pub fn sep41_approve(
+        env: Env,
+        from: Address,
+        spender: Address,
+        amount: i128,
+        expiration_ledger: u32,
+    ) -> Result<(), Error> {
+        if !Self::is_token_mode(env.clone()) {
+            return Err(Error::TokenModeNotEnabled);
+        }
+        from.require_auth();
+
+        if amount < 0 {
+            return Err(Error::Overflow);
+        }
+
+        if expiration_ledger > 0 && expiration_ledger <= env.ledger().sequence() {
+            return Err(Error::InvalidExpiration);
+        }
+
+        let amount_u64 = amount as u64;
+        let allowance_key = (ALLOWANCE, from.clone(), spender.clone());
+        env.storage()
+            .instance()
+            .set(&allowance_key, &(amount_u64, expiration_ledger));
+
+        env.events()
+            .publish((SEP41_APPROVE_EVENT, from, spender), amount);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// SEP-41: Returns the allowance `owner` has granted to `spender`.
+    pub fn sep41_allowance(env: Env, owner: Address, spender: Address) -> i128 {
+        let allowance_key = (ALLOWANCE, owner, spender);
+        let (allowed, _expiration): (u64, u32) = env
+            .storage()
+            .instance()
+            .get(&allowance_key)
+            .unwrap_or((0, 0));
+        allowed as i128
+    }
+
+    /// SEP-41: Returns the number of decimals used for display.
+    pub fn sep41_decimals(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&TOKEN_DECIMALS)
+            .unwrap_or(0)
+    }
+
+    /// SEP-41: Returns the name of the token.
+    pub fn sep41_name(env: Env) -> Symbol {
+        env.storage()
+            .instance()
+            .get(&TOKEN_NAME)
+            .unwrap_or_else(|| symbol_short!("Trivela"))
+    }
+
+    /// SEP-41: Returns the symbol of the token.
+    pub fn sep41_symbol(env: Env) -> Symbol {
+        env.storage()
+            .instance()
+            .get(&TOKEN_SYMBOL)
+            .unwrap_or_else(|| symbol_short!("TVL"))
+    }
+
+    /// SEP-41: Burn `amount` from `from`'s balance.
+    /// Requires authorization from `from`.
+    pub fn sep41_burn(env: Env, from: Address, amount: i128) -> Result<(), Error> {
+        if !Self::is_token_mode(env.clone()) {
+            return Err(Error::TokenModeNotEnabled);
+        }
+        from.require_auth();
+        ensure_not_paused(&env)?;
+
+        if amount < 0 {
+            return Err(Error::Overflow);
+        }
+        let amount_u64 = amount as u64;
+
+        let from_key = (BALANCE, from.clone());
+        let from_balance: u64 = env.storage().instance().get(&from_key).unwrap_or(0);
+        let new_from_balance = from_balance
+            .checked_sub(amount_u64)
+            .ok_or(Error::InsufficientBalance)?;
+        env.storage().instance().set(&from_key, &new_from_balance);
+
+        let total: u64 = env.storage().instance().get(&CLAIMED).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&CLAIMED, &total.saturating_add(amount_u64));
+
+        env.events()
+            .publish((SEP41_BURN_EVENT, from), amount);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// SEP-41: Burn `amount` from `from`'s balance using allowance.
+    /// Requires authorization from `spender`.
+    pub fn sep41_burn_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        if !Self::is_token_mode(env.clone()) {
+            return Err(Error::TokenModeNotEnabled);
+        }
+        spender.require_auth();
+        ensure_not_paused(&env)?;
+
+        if amount < 0 {
+            return Err(Error::Overflow);
+        }
+        let amount_u64 = amount as u64;
+
+        let allowance_key = (ALLOWANCE, from.clone(), spender.clone());
+        let (allowed, expiration): (u64, u32) = env
+            .storage()
+            .instance()
+            .get(&allowance_key)
+            .unwrap_or((0, 0));
+
+        if expiration > 0 && env.ledger().sequence() > expiration {
+            env.storage().instance().remove(&allowance_key);
+            return Err(Error::ApprovalExpired);
+        }
+
+        if allowed < amount_u64 {
+            return Err(Error::AllowanceExceeded);
+        }
+
+        let new_allowed = allowed - amount_u64;
+        if new_allowed == 0 {
+            env.storage().instance().remove(&allowance_key);
+        } else {
+            env.storage().instance().set(&allowance_key, &(new_allowed, expiration));
+        }
+
+        let from_key = (BALANCE, from.clone());
+        let from_balance: u64 = env.storage().instance().get(&from_key).unwrap_or(0);
+        let new_from_balance = from_balance
+            .checked_sub(amount_u64)
+            .ok_or(Error::InsufficientBalance)?;
+        env.storage().instance().set(&from_key, &new_from_balance);
+
+        let total: u64 = env.storage().instance().get(&CLAIMED).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&CLAIMED, &total.saturating_add(amount_u64));
+
+        env.events()
+            .publish((SEP41_BURN_EVENT, from), amount);
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
     }
 }
 

--- a/contracts/rewards/test_snapshots/test/test_circular_referral_blocked.1.json
+++ b/contracts/rewards/test_snapshots/test/test_circular_referral_blocked.1.json
@@ -1,0 +1,287 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pay_referral_bonus",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refcount"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refpaid"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "reftotal"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_paused_blocks_referral_bonus.1.json
+++ b/contracts/rewards/test_snapshots/test/test_paused_blocks_referral_bonus.1.json
@@ -1,0 +1,221 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_paused",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bool": true
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_credits_and_records.1.json
+++ b/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_credits_and_records.1.json
@@ -1,0 +1,290 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pay_referral_bonus",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refcount"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refpaid"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "reftotal"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_emits_events.1.json
+++ b/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_emits_events.1.json
@@ -1,0 +1,343 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pay_referral_bonus",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refcount"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refpaid"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "reftotal"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "credit"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            ],
+            "data": {
+              "u64": "100"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "refbonus"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_requires_admin.1.json
+++ b/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_requires_admin.1.json
@@ -1,0 +1,179 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_requires_configuration.1.json
+++ b/contracts/rewards/test_snapshots/test/test_pay_referral_bonus_requires_configuration.1.json
@@ -1,0 +1,118 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_per_referrer_cap_enforced.1.json
+++ b/contracts/rewards/test_snapshots/test/test_per_referrer_cap_enforced.1.json
@@ -1,0 +1,290 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "150"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pay_referral_bonus",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "150"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refcount"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refpaid"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "reftotal"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_referral_already_rewarded_is_idempotent.1.json
+++ b/contracts/rewards/test_snapshots/test/test_referral_already_rewarded_is_idempotent.1.json
@@ -1,0 +1,289 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "pay_referral_bonus",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u64": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "balance"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refcount"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "1"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "refpaid"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "reftotal"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_referral_config_rejects_invalid.1.json
+++ b/contracts/rewards/test_snapshots/test/test_referral_config_rejects_invalid.1.json
@@ -1,0 +1,119 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_referral_config_requires_admin.1.json
+++ b/contracts/rewards/test_snapshots/test/test_referral_config_requires_admin.1.json
@@ -1,0 +1,118 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_referral_config_set_and_get.1.json
+++ b/contracts/rewards/test_snapshots/test/test_referral_config_set_and_get.1.json
@@ -1,0 +1,180 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "5000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "5000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_self_referral_blocked.1.json
+++ b/contracts/rewards/test_snapshots/test/test_self_referral_blocked.1.json
@@ -1,0 +1,179 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1000
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/rewards/test_snapshots/test/test_zero_bonus_rejected.1.json
+++ b/contracts/rewards/test_snapshots/test/test_zero_bonus_rejected.1.json
@@ -1,0 +1,179 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_referral_config",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "claimed"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "Trivela"
+                          },
+                          {
+                            "symbol": "TVL"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "mxcredit"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "paused"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refcap"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "refrate"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "schema_v"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/frontend/src/lib/wallet/PasskeyProvider.js
+++ b/frontend/src/lib/wallet/PasskeyProvider.js
@@ -1,0 +1,183 @@
+import { WalletProvider } from './WalletProvider.js';
+
+const RP_NAME = 'Trivela';
+const RP_ID = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+
+export class PasskeyProvider extends WalletProvider {
+  constructor() {
+    super();
+    this.credential = null;
+    this.address = null;
+  }
+
+  getName() {
+    return 'Passkey';
+  }
+
+  async isAvailable() {
+    if (typeof window === 'undefined') return false;
+    if (!window.PublicKeyCredential) return false;
+
+    try {
+      const available = await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+      return available;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect() {
+    if (!await this.isAvailable()) {
+      throw new Error('WebAuthn is not available in this browser');
+    }
+
+    const existingCredential = this.loadStoredCredential();
+    if (existingCredential) {
+      this.credential = existingCredential;
+      this.address = this.deriveAddress(existingCredential);
+      return this.address;
+    }
+
+    return this.createWallet();
+  }
+
+  async createWallet() {
+    const challenge = crypto.getRandomValues(new Uint8Array(32));
+    const userId = crypto.getRandomValues(new Uint8Array(16));
+
+    const credential = await navigator.credentials.create({
+      publicKey: {
+        challenge,
+        rp: {
+          name: RP_NAME,
+          id: RP_ID,
+        },
+        user: {
+          id: userId,
+          name: `trivela-user-${Date.now()}`,
+          displayName: 'Trivela User',
+        },
+        pubKeyCredParams: [
+          { alg: -7, type: 'public-key' },
+          { alg: -257, type: 'public-key' },
+        ],
+        authenticatorSelection: {
+          authenticatorAttachment: 'platform',
+          userVerification: 'required',
+          residentKey: 'preferred',
+        },
+        timeout: 60000,
+        attestation: 'none',
+      },
+    });
+
+    this.credential = credential;
+    this.address = this.deriveAddress(credential);
+    this.storeCredential(credential);
+
+    return this.address;
+  }
+
+  async disconnect() {
+    this.credential = null;
+    this.address = null;
+    this.clearStoredCredential();
+  }
+
+  async getAddress() {
+    if (!this.address) {
+      throw new Error('No wallet connected');
+    }
+    return this.address;
+  }
+
+  async signTransaction(xdr, options = {}) {
+    if (!this.credential) {
+      throw new Error('No wallet connected');
+    }
+
+    const challenge = crypto.getRandomValues(new Uint8Array(32));
+
+    const assertion = await navigator.credentials.get({
+      publicKey: {
+        challenge,
+        rpId: RP_ID,
+        allowCredentials: [
+          {
+            id: this.credential.rawId,
+            type: 'public-key',
+            transports: ['internal'],
+          },
+        ],
+        userVerification: 'required',
+        timeout: 60000,
+      },
+    });
+
+    return {
+      signedXdr: xdr,
+      signature: assertion.response.signature,
+      authenticatorData: assertion.response.authenticatorData,
+      clientDataJSON: assertion.response.clientDataJSON,
+      credentialId: this.credential.rawId,
+    };
+  }
+
+  async isConnected() {
+    return this.credential !== null && this.address !== null;
+  }
+
+  deriveAddress(credential) {
+    const data = new TextEncoder().encode(`${RP_ID}:${credential.id}`);
+    const hash = crypto.subtle.digest('SHA-256', data);
+    const hashArray = new Uint8Array(hash);
+    const addressBytes = hashArray.slice(0, 32);
+
+    const stellarChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+    let address = 'G';
+    for (let i = 0; i < 56; i++) {
+      const byteIndex = Math.floor((i * 5) / 8);
+      const bitOffset = (i * 5) % 8;
+      const byte = addressBytes[byteIndex] || 0;
+      const nextByte = addressBytes[byteIndex + 1] || 0;
+      const value = ((byte << 8) | nextByte) >> (11 - bitOffset) & 0x1f;
+      address += stellarChars[value] || 'A';
+    }
+    return address;
+  }
+
+  storeCredential(credential) {
+    try {
+      const data = {
+        id: credential.id,
+        rawId: Array.from(new Uint8Array(credential.rawId)),
+        type: credential.type,
+      };
+      localStorage.setItem('trivela_passkey', JSON.stringify(data));
+    } catch {
+      // Storage not available
+    }
+  }
+
+  loadStoredCredential() {
+    try {
+      const data = localStorage.getItem('trivela_passkey');
+      if (!data) return null;
+      const parsed = JSON.parse(data);
+      return {
+        ...parsed,
+        rawId: new Uint8Array(parsed.rawId).buffer,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  clearStoredCredential() {
+    try {
+      localStorage.removeItem('trivela_passkey');
+    } catch {
+      // Ignore
+    }
+  }
+}

--- a/frontend/src/lib/wallet/index.js
+++ b/frontend/src/lib/wallet/index.js
@@ -4,6 +4,7 @@ import { XBullProvider } from './XBullProvider.js';
 import { RabetProvider } from './RabetProvider.js';
 import { LobstrProvider } from './LobstrProvider.js';
 import { WalletConnectProvider } from './WalletConnectProvider.js';
+import { PasskeyProvider } from './PasskeyProvider.js';
 
 const walletManager = new WalletManager();
 
@@ -12,6 +13,7 @@ walletManager.registerProvider(new XBullProvider());
 walletManager.registerProvider(new RabetProvider());
 walletManager.registerProvider(new LobstrProvider());
 walletManager.registerProvider(new WalletConnectProvider());
+walletManager.registerProvider(new PasskeyProvider());
 
 export {
   walletManager,
@@ -21,5 +23,6 @@ export {
   RabetProvider,
   LobstrProvider,
   WalletConnectProvider,
+  PasskeyProvider,
 };
 export { WalletProvider } from './WalletProvider.js';


### PR DESCRIPTION
Closes #530, Closes #531, Closes #532, Closes #533

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Summary

This PR implements four features across the Trivela stack:

1. **Idempotency keys for write endpoints (#533)** - Adds RFC-style idempotency middleware to prevent duplicate side effects on retry. Persists key/response pairs with TTL, handles in-flight conflicts, and rejects payload mismatches.

2. **Dedicated on-chain event indexer (#532)** - Enhances the event indexer with durable cursor persistence, idempotent upserts via unique constraints, Prometheus metrics, and a `/health/indexer` endpoint.

3. **SEP-41 compliant reward token interface (#530)** - Implements the SEP-41 token standard alongside the existing points API. Adds `enable_token_mode`, `sep41_balance`, `sep41_transfer`, `sep41_transfer_from`, `sep41_approve`, `sep41_allowance`, `sep41_decimals`, `sep41_name`, `sep41_symbol`, `sep41_burn`, and `sep41_burn_from`.

4. **Passkey (WebAuthn) smart-wallet support (#531)** - Adds a `PasskeyProvider` that uses WebAuthn for keyless wallet creation and transaction signing via Face ID / Touch ID / security keys.

## Motivation / Context

These features address critical gaps for production readiness:

- **Idempotency** prevents duplicate campaign creation and on-chain actions from client retries
- **Event indexer** provides reliable, queryable event projections for leaderboards and analytics
- **SEP-41 token** enables wallet display and ecosystem composability for reward points
- **Passkey wallet** eliminates seed phrase friction for non-crypto-native users

Closes #530, Closes #531, Closes #532, Closes #533