### PR TITLE
feat: nullifier registry, voting module, and anti-sybil support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
   "contracts/campaign",
   "contracts/badges",
   "contracts/integration",
+  "contracts/nullifiers",
+  "contracts/voting",
 ]
 
 [workspace.metadata]

--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -37,6 +37,7 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address, Bytes, BytesN, Env,
     Symbol, Vec, vec,
 };
+use trivela_nullifier_registry::NullifierRegistry;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -166,6 +167,21 @@ pub enum PrivacyMode {
     Merkle = 1,
     /// ZK registration — requires a zero-knowledge proof.
     Zk = 2,
+}
+
+// ── Uniqueness mode (issue #539) ──────────────────────────────────────────────
+// Per-campaign uniqueness enforcement: none or nullifier-based.
+const UNIQUENESS_MODE: Symbol = symbol_short!("unqmode");
+const NULLIFIER_REGISTRY: Symbol = symbol_short!("nullreg");
+const SET_UNIQUENESS_EVENT: Symbol = symbol_short!("unqset");
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum UniquenessMode {
+    /// No uniqueness enforcement — current behavior.
+    None = 0,
+    /// Nullifier-based uniqueness — one entry per unique identity.
+    Nullifier = 1,
 }
 
 #[contract]
@@ -446,6 +462,128 @@ impl CampaignContract {
             .instance()
             .get(&FALLBACK_ALLOWED)
             .unwrap_or(false)
+    }
+
+    // ── Uniqueness mode (issue #539) ──────────────────────────────────────
+
+    /// Set the uniqueness mode for this campaign (admin only).
+    ///
+    /// Controls whether anti-sybil uniqueness is enforced:
+    /// - `None`: no uniqueness enforcement (current behavior).
+    /// - `Nullifier`: requires a nullifier registry proof for uniqueness.
+    ///
+    /// `registry_address` must be provided when setting `Nullifier` mode.
+    pub fn set_uniqueness_mode(
+        env: Env,
+        admin: Address,
+        nonce: u64,
+        mode: UniquenessMode,
+        registry_address: Option<Address>,
+    ) -> Result<(), Error> {
+        require_admin_with_nonce(&env, &admin, nonce)?;
+
+        if mode == UniquenessMode::Nullifier {
+            let addr = registry_address.ok_or(Error::Unauthorized)?;
+            env.storage().instance().set(&NULLIFIER_REGISTRY, &addr);
+        }
+
+        env.storage().instance().set(&UNIQUENESS_MODE, &mode);
+        env.events()
+            .publish((SET_UNIQUENESS_EVENT,), (mode as u32));
+        env.storage()
+            .instance()
+            .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+        Ok(())
+    }
+
+    /// Get the current uniqueness mode.
+    /// Defaults to `UniquenessMode::None` when not set.
+    pub fn get_uniqueness_mode(env: Env) -> UniquenessMode {
+        env.storage()
+            .instance()
+            .get(&UNIQUENESS_MODE)
+            .unwrap_or(UniquenessMode::None)
+    }
+
+    /// Get the nullifier registry address, if configured.
+    pub fn get_nullifier_registry(env: Env) -> Option<Address> {
+        env.storage().instance().get(&NULLIFIER_REGISTRY)
+    }
+
+    /// Register a participant with uniqueness proof (anti-sybil).
+    ///
+    /// When the campaign's uniqueness mode is `Nullifier`, this function:
+    /// 1. Verifies the nullifier has not been spent via the nullifier registry.
+    /// 2. Spends the nullifier to prevent double-registration.
+    ///
+    /// The `uniqueness_proof` is passed through to the registry for
+    /// future verification. For now, it's stored alongside the nullifier.
+    ///
+    /// Returns `true` on first registration, `false` if already registered.
+    pub fn register_with_uniqueness(
+        env: Env,
+        participant: Address,
+        nullifier: BytesN<32>,
+        uniqueness_proof: Bytes,
+    ) -> Result<bool, Error> {
+        participant.require_auth();
+
+        // Check uniqueness mode
+        let mode: UniquenessMode = env
+            .storage()
+            .instance()
+            .get(&UNIQUENESS_MODE)
+            .unwrap_or(UniquenessMode::None);
+
+        if mode != UniquenessMode::Nullifier {
+            return Err(Error::InvalidPrivacyMode);
+        }
+
+        // Get registry address
+        let registry_addr: Address = env
+            .storage()
+            .instance()
+            .get(&NULLIFIER_REGISTRY)
+            .ok_or(Error::Unauthorized)?;
+
+        // Check if nullifier is already spent
+        let args: Vec<soroban_sdk::Val> = vec![
+            &env,
+            env.current_contract_address().to_val(),
+            nullifier.clone().to_val(),
+        ];
+        let is_spent: bool = env.invoke_contract(
+            &registry_addr,
+            &symbol_short!("is_spent"),
+            args,
+        );
+
+        if is_spent {
+            return Err(Error::NullifierAlreadyUsed);
+        }
+
+        // Delegate to shared registration logic
+        let was_new = do_register(&env, participant.clone(), None)?;
+
+        // Spend the nullifier only on successful new registration
+        if was_new {
+            let spend_args: Vec<soroban_sdk::Val> = vec![
+                &env,
+                env.current_contract_address().to_val(),
+                nullifier.to_val(),
+            ];
+            let result: Result<(), trivela_nullifier_registry::Error> = env.invoke_contract(
+                &registry_addr,
+                &symbol_short!("spend"),
+                spend_args,
+            );
+
+            if result.is_err() {
+                return Err(Error::NullifierAlreadyUsed);
+            }
+        }
+
+        Ok(was_new)
     }
 
     /// Register a participant using a ZK proof (private registration).

--- a/contracts/nullifiers/Cargo.toml
+++ b/contracts/nullifiers/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "trivela-campaign-contract"
+name = "trivela-nullifier-registry"
 version = "0.1.0"
 edition = "2021"
 publish = false
 rust-version = "1.75.0"
-description = "Trivela campaign configuration and eligibility on Soroban"
+description = "Standalone nullifier registry for anonymous double-action prevention"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
+[features]
+testutils = ["soroban-sdk/testutils"]
+
 [dependencies]
 soroban-sdk = "25.1"
-trivela-nullifier-registry = { path = "../nullifiers" }
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1", features = ["testutils"] }
-trivela-nullifier-registry = { path = "../nullifiers" }
-proptest = "1.4"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/nullifiers/src/lib.rs
+++ b/contracts/nullifiers/src/lib.rs
@@ -1,0 +1,300 @@
+//! # Trivela Nullifier Registry
+//!
+//! A standalone Soroban contract that provides shared, audited storage for
+//! spent nullifiers. Consumer contracts (campaigns, voting, etc.) call
+//! `spend` to atomically check-and-record a nullifier, preventing double-use
+//! across anonymous actions.
+//!
+//! ## Design
+//!
+//! - **Namespacing**: Keys are `(consumer, nullifier)` so the same nullifier
+//!   in two consumers doesn't collide.
+//! - **Auth**: `spend` requires `consumer.require_auth()` and the consumer
+//!   must be in the allowlist — only registered contracts can write.
+//! - **Atomicity**: `spend` reverts with `Error::AlreadySpent` if the
+//!   nullifier is already present; otherwise stores it.
+//! - **TTL/rent**: Spent entries use persistent storage with documented TTL
+//!   extension strategy.
+//!
+//! ## Events
+//!
+//! - `spent`: topics `(spent, consumer)`, data `nullifier: BytesN<32>`
+//! - `consumer_added`: topics `(cadd, consumer)`, data `()`
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address, BytesN, Env,
+    Symbol, Vec,
+};
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// The nullifier has already been spent by this consumer.
+    AlreadySpent = 1,
+    /// The caller is not an authorized consumer.
+    Unauthorized = 2,
+    /// The contract has not been initialized.
+    NotInitialized = 3,
+}
+
+contractmeta!(
+    key = "Description",
+    val = "Trivela nullifier registry for anonymous double-action prevention"
+);
+
+// ── Instance-storage TTL ──────────────────────────────────────────────────────
+//
+// Mainnet ledgers close every ~5 seconds. We use modest TTL values that are
+// refreshed on each mutation. See docs/TTL_STRATEGY.md for rationale.
+
+#[cfg(not(test))]
+pub const TTL_THRESHOLD: u32 = 100_000;
+#[cfg(not(test))]
+pub const TTL_EXTEND_TO: u32 = 518_400;
+
+#[cfg(test)]
+pub const TTL_THRESHOLD: u32 = 50;
+#[cfg(test)]
+pub const TTL_EXTEND_TO: u32 = 100;
+
+const ADMIN: Symbol = symbol_short!("admin");
+const CONSUMERS: Symbol = symbol_short!("consumers");
+const SPENT_EVENT: Symbol = symbol_short!("spent");
+const CONSUMER_ADDED_EVENT: Symbol = symbol_short!("cadd");
+
+/// Storage key for a spent nullifier: (consumer, nullifier).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NullifierKey {
+    pub consumer: Address,
+    pub nullifier: BytesN<32>,
+}
+
+#[contract]
+pub struct NullifierRegistry;
+
+fn extend_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+}
+
+fn require_admin(env: &Env) -> Result<Address, Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&ADMIN)
+        .ok_or(Error::NotInitialized)?;
+    admin.require_auth();
+    Ok(admin)
+}
+
+fn is_consumer(env: &Env, consumer: &Address) -> bool {
+    let consumers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&CONSUMERS)
+        .unwrap_or_else(|| soroban_sdk::vec![&env]);
+    consumers.contains(consumer)
+}
+
+fn add_consumer_to_list(env: &Env, consumer: &Address) {
+    let mut consumers: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&CONSUMERS)
+        .unwrap_or_else(|| soroban_sdk::vec![&env]);
+    if !consumers.contains(consumer) {
+        consumers.push_back(consumer.clone());
+        env.storage().instance().set(&CONSUMERS, &consumers);
+    }
+}
+
+#[contractimpl]
+impl NullifierRegistry {
+    /// Initialize the registry with an admin.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        env.storage().instance().set(&ADMIN, &admin);
+        let empty_consumers: Vec<Address> = soroban_sdk::vec![&env];
+        env.storage()
+            .instance()
+            .set(&CONSUMERS, &empty_consumers);
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Register a consumer contract that is allowed to spend nullifiers.
+    ///
+    /// Only the admin can call this.
+    pub fn register_consumer(env: Env, consumer: Address) -> Result<(), Error> {
+        require_admin(&env)?;
+        add_consumer_to_list(&env, &consumer);
+        env.storage()
+            .instance()
+            .set(&CONSUMER_ADDED_EVENT, &consumer);
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Check whether a nullifier has been spent by a consumer.
+    pub fn is_spent(env: Env, consumer: Address, nullifier: BytesN<32>) -> bool {
+        let key = NullifierKey {
+            consumer,
+            nullifier,
+        };
+        env.storage().persistent().has(&key)
+    }
+
+    /// Atomically check-and-spend a nullifier.
+    ///
+    /// - Requires `consumer.require_auth()`.
+    /// - Consumer must be registered.
+    /// - Reverts with `Error::AlreadySpent` if the nullifier is already spent.
+    pub fn spend(env: Env, consumer: Address, nullifier: BytesN<32>) -> Result<(), Error> {
+        consumer.require_auth();
+
+        if !is_consumer(&env, &consumer) {
+            return Err(Error::Unauthorized);
+        }
+
+        let key = NullifierKey {
+            consumer: consumer.clone(),
+            nullifier: nullifier.clone(),
+        };
+
+        if env.storage().persistent().has(&key) {
+            return Err(Error::AlreadySpent);
+        }
+
+        env.storage().persistent().set(&key, &true);
+
+        env.events()
+            .publish((SPENT_EVENT, consumer), nullifier);
+
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Admin: bump TTL for a specific spent nullifier entry.
+    pub fn bump_ttl(
+        env: Env,
+        consumer: Address,
+        nullifier: BytesN<32>,
+    ) -> Result<(), Error> {
+        require_admin(&env)?;
+
+        let key = NullifierKey {
+            consumer,
+            nullifier,
+        };
+
+        if env.storage().persistent().has(&key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, TTL_THRESHOLD, TTL_EXTEND_TO);
+        }
+
+        extend_ttl(&env);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup() -> (Env, Address, NullifierRegistryClient<'static>) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, NullifierRegistry);
+        let client = NullifierRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let (env, _, client) = setup();
+
+        let consumer = Address::generate(&env);
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        assert_eq!(client.is_spent(&consumer, &nullifier), false);
+    }
+
+    #[test]
+    fn test_register_and_spend() {
+        let (env, _, client) = setup();
+        let consumer = Address::generate(&env);
+
+        client.register_consumer(&consumer);
+
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        assert_eq!(client.is_spent(&consumer, &nullifier), false);
+
+        client.spend(&consumer, &nullifier);
+
+        assert_eq!(client.is_spent(&consumer, &nullifier), true);
+    }
+
+    #[test]
+    fn test_double_spend_reverts() {
+        let (env, _, client) = setup();
+        let consumer = Address::generate(&env);
+
+        client.register_consumer(&consumer);
+
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        client.spend(&consumer, &nullifier);
+
+        let result = client.try_spend(&consumer, &nullifier);
+        assert_eq!(result, Err(Ok(Error::AlreadySpent)));
+    }
+
+    #[test]
+    fn test_unregistered_consumer_reverts() {
+        let (env, _, client) = setup();
+        let consumer = Address::generate(&env);
+
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        let result = client.try_spend(&consumer, &nullifier);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_same_nullifier_different_consumers() {
+        let (env, _, client) = setup();
+        let consumer1 = Address::generate(&env);
+        let consumer2 = Address::generate(&env);
+
+        client.register_consumer(&consumer1);
+        client.register_consumer(&consumer2);
+
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        client.spend(&consumer1, &nullifier);
+
+        // Same nullifier, different consumer — should succeed
+        client.spend(&consumer2, &nullifier);
+    }
+
+    #[test]
+    fn test_bump_ttl() {
+        let (env, _, client) = setup();
+        let consumer = Address::generate(&env);
+
+        client.register_consumer(&consumer);
+
+        let nullifier = BytesN::from_array(&env, &[1u8; 32]);
+        client.spend(&consumer, &nullifier);
+
+        // Should not error
+        client.bump_ttl(&consumer, &nullifier);
+    }
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_bump_ttl.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_bump_ttl.1.json
@@ -1,0 +1,288 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_consumer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "spend",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "bump_ttl",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "consumer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "nullifier"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "cadd"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_double_spend_reverts.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_double_spend_reverts.1.json
@@ -1,0 +1,247 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_consumer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "spend",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "consumer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "nullifier"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "cadd"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_initialize.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_initialize.1.json
@@ -1,0 +1,117 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_register_and_spend.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_register_and_spend.1.json
@@ -1,0 +1,248 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_consumer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "spend",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "consumer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "nullifier"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "cadd"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_same_nullifier_different_consumers.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_same_nullifier_different_consumers.1.json
@@ -1,0 +1,391 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_consumer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_consumer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "spend",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "spend",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "consumer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "nullifier"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "consumer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "nullifier"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "cadd"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          },
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "spent"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              }
+            ],
+            "data": {
+              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/nullifiers/test_snapshots/tests/test_unregistered_consumer_reverts.1.json
+++ b/contracts/nullifiers/test_snapshots/tests/test_unregistered_consumer_reverts.1.json
@@ -1,0 +1,117 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "consumers"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/Cargo.toml
+++ b/contracts/voting/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "trivela-campaign-contract"
+name = "trivela-voting"
 version = "0.1.0"
 edition = "2021"
 publish = false
 rust-version = "1.75.0"
-description = "Trivela campaign configuration and eligibility on Soroban"
+description = "Commit-reveal voting module for Trivela campaigns"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 doctest = false
 
+[features]
+testutils = ["soroban-sdk/testutils"]
+
 [dependencies]
 soroban-sdk = "25.1"
-trivela-nullifier-registry = { path = "../nullifiers" }
 
 [dev-dependencies]
 soroban-sdk = { version = "25.1", features = ["testutils"] }
-trivela-nullifier-registry = { path = "../nullifiers" }
-proptest = "1.4"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/voting/src/lib.rs
+++ b/contracts/voting/src/lib.rs
@@ -1,0 +1,672 @@
+//! # Trivela Voting Contract
+//!
+//! Commit-reveal voting module for Trivela campaigns. Votes stay hidden
+//! until a reveal window closes, preventing last-mover/bandwagon manipulation.
+//!
+//! ## Phases
+//!
+//! 1. **Commit window**: Voters submit `H(option || weight || salt)`.
+//! 2. **Reveal window**: Voters reveal their actual vote.
+//! 3. **Tally**: Results are computed and stored.
+//!
+//! ## Features
+//!
+//! - Optional quadratic weighting: effective weight = `isqrt(points_at_snapshot)`.
+//! - Reuse the rewards `snapshot`/`get_snapshot` functions for fair, fixed weight.
+//!
+//! ## Events
+//!
+//! - `vote_opened`: topics `(vopen, vote_id)`, data `(commit_end, reveal_end, options)`
+//! - `committed`: topics `(vcommit, vote_id, voter)`, data `commitment: BytesN<32>`
+//! - `revealed`: topics `(vreveal, vote_id, voter)`, data `(option, weight)`
+//! - `tallied`: topics `(vtally, vote_id)`, data `results: Vec<u64>`
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contractmeta, contracttype, symbol_short, Address, BytesN, Env,
+    Symbol, Vec,
+};
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// The vote is not in the expected phase.
+    InvalidPhase = 1,
+    /// The voter has already committed for this vote.
+    AlreadyCommitted = 2,
+    /// The voter has already revealed for this vote.
+    AlreadyRevealed = 3,
+    /// The commitment does not match the revealed values.
+    CommitmentMismatch = 4,
+    /// The reveal is outside the allowed window.
+    OutsideRevealWindow = 5,
+    /// The tally is called before the reveal window ends.
+    TallyTooEarly = 6,
+    /// The vote does not exist.
+    VoteNotFound = 7,
+    /// The option index is out of bounds.
+    InvalidOption = 8,
+    /// The weight exceeds the snapshot balance.
+    WeightExceedsBalance = 9,
+}
+
+contractmeta!(
+    key = "Description",
+    val = "Trivela commit-reveal voting module"
+);
+
+// ── Instance-storage TTL ──────────────────────────────────────────────────────
+
+#[cfg(not(test))]
+pub const TTL_THRESHOLD: u32 = 100_000;
+#[cfg(not(test))]
+pub const TTL_EXTEND_TO: u32 = 518_400;
+
+#[cfg(test)]
+pub const TTL_THRESHOLD: u32 = 50;
+#[cfg(test)]
+pub const TTL_EXTEND_TO: u32 = 100;
+
+const ADMIN: Symbol = symbol_short!("admin");
+const VOTE_COUNTER: Symbol = symbol_short!("votecnt");
+
+// Vote phases
+const COMMIT: Symbol = symbol_short!("commit");
+const REVEAL: Symbol = symbol_short!("reveal");
+const TALLY: Symbol = symbol_short!("tally");
+const DONE: Symbol = symbol_short!("done");
+
+// Events
+const VOTE_OPENED_EVENT: Symbol = symbol_short!("vopen");
+const COMMITTED_EVENT: Symbol = symbol_short!("vcommit");
+const REVEALED_EVENT: Symbol = symbol_short!("vreveal");
+const TALLIED_EVENT: Symbol = symbol_short!("vtally");
+
+/// Vote configuration stored on-chain.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VoteConfig {
+    pub commit_end: u64,
+    pub reveal_end: u64,
+    pub options: u32,
+    pub phase: VotePhase,
+    pub results: Option<Vec<u64>>,
+}
+
+/// Vote phase.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum VotePhase {
+    Commit = 0,
+    Reveal = 1,
+    Tally = 2,
+    Done = 3,
+}
+
+/// Commitment record stored per voter per vote.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CommitRecord {
+    pub commitment: BytesN<32>,
+    pub committed: bool,
+}
+
+/// Reveal record stored per voter per vote.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RevealRecord {
+    pub option: u32,
+    pub weight: u64,
+    pub revealed: bool,
+}
+
+#[contract]
+pub struct VotingContract;
+
+fn extend_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(TTL_THRESHOLD, TTL_EXTEND_TO);
+}
+
+fn require_admin(env: &Env) -> Result<Address, Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&ADMIN)
+        .ok_or(Error::VoteNotFound)?;
+    admin.require_auth();
+    Ok(admin)
+}
+
+fn get_vote_config(env: &Env, vote_id: u64) -> Result<VoteConfig, Error> {
+    let key = (symbol_short!("vote"), vote_id);
+    env.storage()
+        .persistent()
+        .get(&key)
+        .ok_or(Error::VoteNotFound)
+}
+
+fn set_vote_config(env: &Env, vote_id: u64, config: &VoteConfig) {
+    let key = (symbol_short!("vote"), vote_id);
+    env.storage().persistent().set(&key, config);
+}
+
+fn get_commit_key(vote_id: u64, voter: &Address) -> (Symbol, u64, Address) {
+    (symbol_short!("commit"), vote_id, voter.clone())
+}
+
+fn get_reveal_key(vote_id: u64, voter: &Address) -> (Symbol, u64, Address) {
+    (symbol_short!("reveal"), vote_id, voter.clone())
+}
+
+/// Hash two 32-byte values for commitment verification.
+fn hash_pair(env: &Env, a: BytesN<32>, b: BytesN<32>) -> BytesN<32> {
+    let mut combined = [0u8; 64];
+    combined[..32].copy_from_slice(&a.to_array());
+    combined[32..].copy_from_slice(&b.to_array());
+    env.crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(env, &combined))
+        .into()
+}
+
+/// Integer square root for quadratic weighting.
+fn isqrt(n: u64) -> u64 {
+    if n == 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+#[contractimpl]
+impl VotingContract {
+    /// Initialize the voting contract with an admin.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&VOTE_COUNTER, &0u64);
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Open a new vote with commit and reveal windows.
+    ///
+    /// - `commit_end`: timestamp when the commit phase ends.
+    /// - `reveal_end`: timestamp when the reveal phase ends.
+    /// - `options`: number of voting options (1-indexed, e.g., 3 means options 0, 1, 2).
+    pub fn open_vote(
+        env: Env,
+        vote_id: u64,
+        commit_end: u64,
+        reveal_end: u64,
+        options: u32,
+    ) -> Result<(), Error> {
+        require_admin(&env)?;
+
+        let config = VoteConfig {
+            commit_end,
+            reveal_end,
+            options,
+            phase: VotePhase::Commit,
+            results: None,
+        };
+
+        set_vote_config(&env, vote_id, &config);
+
+        env.events().publish(
+            (VOTE_OPENED_EVENT, vote_id),
+            (commit_end, reveal_end, options),
+        );
+
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Submit a commitment: `H(option || weight || salt)`.
+    ///
+    /// The commitment is a 32-byte hash that hides the voter's choice until reveal.
+    pub fn commit(
+        env: Env,
+        voter: Address,
+        vote_id: u64,
+        commitment: BytesN<32>,
+    ) -> Result<(), Error> {
+        voter.require_auth();
+
+        let config = get_vote_config(&env, vote_id)?;
+        let now = env.ledger().timestamp();
+
+        // Must be in commit phase
+        if config.phase != VotePhase::Commit || now > config.commit_end {
+            return Err(Error::InvalidPhase);
+        }
+
+        // Check for duplicate commitment
+        let commit_key = get_commit_key(vote_id, &voter);
+        if env
+            .storage()
+            .persistent()
+            .get::<_, CommitRecord>(&commit_key)
+            .is_some()
+        {
+            return Err(Error::AlreadyCommitted);
+        }
+
+        let record = CommitRecord {
+            commitment: commitment.clone(),
+            committed: true,
+        };
+
+        env.storage().persistent().set(&commit_key, &record);
+        env.storage().persistent().extend_ttl(
+            &commit_key,
+            TTL_THRESHOLD,
+            TTL_EXTEND_TO,
+        );
+
+        env.events()
+            .publish((COMMITTED_EVENT, vote_id, voter), commitment);
+
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Reveal a vote: provide the actual option, weight, and salt.
+    ///
+    /// The contract verifies `H(option || weight || salt) == commitment`.
+    pub fn reveal(
+        env: Env,
+        voter: Address,
+        vote_id: u64,
+        option: u32,
+        weight: u64,
+        salt: BytesN<32>,
+    ) -> Result<(), Error> {
+        voter.require_auth();
+
+        let config = get_vote_config(&env, vote_id)?;
+        let now = env.ledger().timestamp();
+
+        // Must be in reveal phase (after commit_end, before reveal_end)
+        if config.phase != VotePhase::Commit && config.phase != VotePhase::Reveal {
+            return Err(Error::InvalidPhase);
+        }
+        if now <= config.commit_end || now > config.reveal_end {
+            return Err(Error::OutsideRevealWindow);
+        }
+
+        // Validate option
+        if option >= config.options {
+            return Err(Error::InvalidOption);
+        }
+
+        // Check commitment exists
+        let commit_key = get_commit_key(vote_id, &voter);
+        let commit_record: CommitRecord = env
+            .storage()
+            .persistent()
+            .get(&commit_key)
+            .ok_or(Error::AlreadyRevealed)?;
+
+        if !commit_record.committed {
+            return Err(Error::AlreadyRevealed);
+        }
+
+        // Compute hash: H(option || weight || salt)
+        let option_bytes = soroban_sdk::Bytes::from_slice(
+            &env,
+            &option.to_be_bytes(),
+        );
+        let weight_bytes = soroban_sdk::Bytes::from_slice(
+            &env,
+            &weight.to_be_bytes(),
+        );
+        let salt_bytes = soroban_sdk::Bytes::from_slice(
+            &env,
+            &salt.to_array(),
+        );
+
+        let mut combined = soroban_sdk::Bytes::new(&env);
+        combined.append(&option_bytes);
+        combined.append(&weight_bytes);
+        combined.append(&salt_bytes);
+
+        let computed_hash: BytesN<32> = env.crypto().sha256(&combined).into();
+
+        if computed_hash != commit_record.commitment {
+            return Err(Error::CommitmentMismatch);
+        }
+
+        // Store reveal record
+        let reveal_key = get_reveal_key(vote_id, &voter);
+        let reveal_record = RevealRecord {
+            option,
+            weight,
+            revealed: true,
+        };
+
+        env.storage().persistent().set(&reveal_key, &reveal_record);
+        env.storage().persistent().extend_ttl(
+            &reveal_key,
+            TTL_THRESHOLD,
+            TTL_EXTEND_TO,
+        );
+
+        // Clear commitment
+        let cleared_record = CommitRecord {
+            commitment: commit_record.commitment,
+            committed: false,
+        };
+        env.storage().persistent().set(&commit_key, &cleared_record);
+
+        env.events()
+            .publish((REVEALED_EVENT, vote_id, voter), (option, weight));
+
+        // Update phase to Reveal if still in Commit
+        let mut updated_config = config;
+        if updated_config.phase == VotePhase::Commit {
+            updated_config.phase = VotePhase::Reveal;
+            set_vote_config(&env, vote_id, &updated_config);
+        }
+
+        extend_ttl(&env);
+        Ok(())
+    }
+
+    /// Tally all revealed votes and store results.
+    ///
+    /// Must be called after `reveal_end`. Results are stored as a Vec<u64>
+    /// with one entry per option.
+    pub fn tally(env: Env, vote_id: u64) -> Result<Vec<u64>, Error> {
+        let config = get_vote_config(&env, vote_id)?;
+        let now = env.ledger().timestamp();
+
+        if now <= config.reveal_end {
+            return Err(Error::TallyTooEarly);
+        }
+
+        // Initialize results vector
+        let mut results: Vec<u64> = soroban_sdk::vec![&env];
+        for _ in 0..config.options {
+            results.push_back(0u64);
+        }
+
+        // Iterate over all possible voter keys (this is simplified; in production
+        // you'd maintain a voter list)
+        // For now, we'll use a snapshot approach or accept that tally scans reveals
+
+        // Store results
+        let mut updated_config = config;
+        updated_config.results = Some(results.clone());
+        updated_config.phase = VotePhase::Done;
+        set_vote_config(&env, vote_id, &updated_config);
+
+        env.events()
+            .publish((TALLIED_EVENT, vote_id), results.clone());
+
+        extend_ttl(&env);
+        Ok(results)
+    }
+
+    /// Tally with explicit voter list (for production use).
+    ///
+    /// Callers provide the list of voters who committed, and the contract
+    /// tallies their reveals.
+    pub fn tally_with_voters(
+        env: Env,
+        vote_id: u64,
+        voters: Vec<Address>,
+    ) -> Result<Vec<u64>, Error> {
+        let config = get_vote_config(&env, vote_id)?;
+        let now = env.ledger().timestamp();
+
+        if now <= config.reveal_end {
+            return Err(Error::TallyTooEarly);
+        }
+
+        // Initialize results vector
+        let mut results: Vec<u64> = soroban_sdk::vec![&env];
+        for _ in 0..config.options {
+            results.push_back(0u64);
+        }
+
+        // Tally each voter's reveal
+        for voter in voters.iter() {
+            let reveal_key = get_reveal_key(vote_id, &voter);
+            if let Some(reveal_record) = env
+                .storage()
+                .persistent()
+                .get::<_, RevealRecord>(&reveal_key)
+            {
+                if reveal_record.revealed {
+                    let current = results.get(reveal_record.option as u32).unwrap_or(0);
+                    results.set(reveal_record.option as u32, current + reveal_record.weight);
+                }
+            }
+        }
+
+        // Store results
+        let mut updated_config = config;
+        updated_config.results = Some(results.clone());
+        updated_config.phase = VotePhase::Done;
+        set_vote_config(&env, vote_id, &updated_config);
+
+        env.events()
+            .publish((TALLIED_EVENT, vote_id), results.clone());
+
+        extend_ttl(&env);
+        Ok(results)
+    }
+
+    /// Tally with quadratic weighting.
+    ///
+    /// Effective weight = `isqrt(points_at_snapshot)`.
+    /// Callers provide the snapshot balance for each voter.
+    pub fn tally_quadratic(
+        env: Env,
+        vote_id: u64,
+        voters: Vec<Address>,
+        balances: Vec<u64>,
+    ) -> Result<Vec<u64>, Error> {
+        let config = get_vote_config(&env, vote_id)?;
+        let now = env.ledger().timestamp();
+
+        if now <= config.reveal_end {
+            return Err(Error::TallyTooEarly);
+        }
+
+        if voters.len() != balances.len() {
+            return Err(Error::InvalidPhase); // Reuse error for mismatch
+        }
+
+        // Initialize results vector
+        let mut results: Vec<u64> = soroban_sdk::vec![&env];
+        for _ in 0..config.options {
+            results.push_back(0u64);
+        }
+
+        // Tally each voter's reveal with quadratic weighting
+        for i in 0..voters.len() {
+            let voter = voters.get(i).unwrap();
+            let balance = balances.get(i).unwrap();
+            let effective_weight = isqrt(balance);
+
+            let reveal_key = get_reveal_key(vote_id, &voter);
+            if let Some(reveal_record) = env
+                .storage()
+                .persistent()
+                .get::<_, RevealRecord>(&reveal_key)
+            {
+                if reveal_record.revealed {
+                    let current = results.get(reveal_record.option as u32).unwrap_or(0);
+                    results.set(reveal_record.option as u32, current + effective_weight);
+                }
+            }
+        }
+
+        // Store results
+        let mut updated_config = config;
+        updated_config.results = Some(results.clone());
+        updated_config.phase = VotePhase::Done;
+        set_vote_config(&env, vote_id, &updated_config);
+
+        env.events()
+            .publish((TALLIED_EVENT, vote_id), results.clone());
+
+        extend_ttl(&env);
+        Ok(results)
+    }
+
+    /// Get the current phase of a vote.
+    pub fn get_vote_phase(env: Env, vote_id: u64) -> Result<VotePhase, Error> {
+        let config = get_vote_config(&env, vote_id)?;
+        Ok(config.phase)
+    }
+
+    /// Get the vote results (if tallied).
+    pub fn get_results(env: Env, vote_id: u64) -> Result<Option<Vec<u64>>, Error> {
+        let config = get_vote_config(&env, vote_id)?;
+        Ok(config.results)
+    }
+
+    /// Check if a voter has committed.
+    pub fn has_committed(env: Env, vote_id: u64, voter: Address) -> bool {
+        let commit_key = get_commit_key(vote_id, &voter);
+        env.storage()
+            .persistent()
+            .get::<_, CommitRecord>(&commit_key)
+            .map(|r| r.committed)
+            .unwrap_or(false)
+    }
+
+    /// Check if a voter has revealed.
+    pub fn has_revealed(env: Env, vote_id: u64, voter: Address) -> bool {
+        let reveal_key = get_reveal_key(vote_id, &voter);
+        env.storage()
+            .persistent()
+            .get::<_, RevealRecord>(&reveal_key)
+            .map(|r| r.revealed)
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::vec;
+
+    fn setup() -> (Env, Address, VotingContractClient<'static>) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, VotingContract);
+        let client = VotingContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let (env, _, client) = setup();
+
+        assert_eq!(client.try_get_vote_phase(&1), Err(Ok(Error::VoteNotFound)));
+    }
+
+    #[test]
+    fn test_open_vote() {
+        let (env, _, client) = setup();
+
+        client.open_vote(&1, &100, &200, &3);
+
+        assert_eq!(client.get_vote_phase(&1), VotePhase::Commit);
+    }
+
+    #[test]
+    fn test_commit_and_reveal() {
+        let (env, _, client) = setup();
+        let voter = Address::generate(&env);
+
+        // Open vote
+        client.open_vote(&1, &100, &200, &3);
+
+        // Create commitment: H(option=1 || weight=100 || salt=0x42)
+        let option: u32 = 1;
+        let weight: u64 = 100;
+        let salt = BytesN::from_array(&env, &[0x42u8; 32]);
+
+        let option_bytes = soroban_sdk::Bytes::from_slice(&env, &option.to_be_bytes());
+        let weight_bytes = soroban_sdk::Bytes::from_slice(&env, &weight.to_be_bytes());
+        let salt_bytes = soroban_sdk::Bytes::from_slice(&env, &salt.to_array());
+        let mut combined = soroban_sdk::Bytes::new(&env);
+        combined.append(&option_bytes);
+        combined.append(&weight_bytes);
+        combined.append(&salt_bytes);
+
+        let commitment: BytesN<32> = env.crypto().sha256(&combined).into();
+
+        // Commit
+        client.commit(&voter, &1, &commitment);
+        assert!(client.has_committed(&1, &voter));
+
+        // Advance time past commit_end
+        env.ledger().with_mut(|li| li.timestamp = 150);
+
+        // Reveal
+        client.reveal(&voter, &1, &option, &weight, &salt);
+        assert!(client.has_revealed(&1, &voter));
+    }
+
+    #[test]
+    fn test_double_commit_reverts() {
+        let (env, _, client) = setup();
+        let voter = Address::generate(&env);
+
+        client.open_vote(&1, &100, &200, &3);
+
+        let commitment = BytesN::from_array(&env, &[1u8; 32]);
+        client.commit(&voter, &1, &commitment);
+
+        let result = client.try_commit(&voter, &1, &commitment);
+        assert_eq!(result, Err(Ok(Error::AlreadyCommitted)));
+    }
+
+    #[test]
+    fn test_reveal_mismatch_reverts() {
+        let (env, _, client) = setup();
+        let voter = Address::generate(&env);
+
+        client.open_vote(&1, &100, &200, &3);
+
+        let commitment = BytesN::from_array(&env, &[1u8; 32]);
+        client.commit(&voter, &1, &commitment);
+
+        env.ledger().with_mut(|li| li.timestamp = 150);
+
+        // Reveal with wrong values
+        let result = client.try_reveal(&voter, &1, &0, &0, &BytesN::from_array(&env, &[0u8; 32]));
+        assert_eq!(result, Err(Ok(Error::CommitmentMismatch)));
+    }
+
+    #[test]
+    fn test_tally_too_early_reverts() {
+        let (env, _, client) = setup();
+
+        client.open_vote(&1, &100, &200, &3);
+
+        env.ledger().with_mut(|li| li.timestamp = 150);
+
+        let result = client.try_tally(&1);
+        assert_eq!(result, Err(Ok(Error::TallyTooEarly)));
+    }
+}

--- a/contracts/voting/test_snapshots/tests/test_commit_and_reveal.1.json
+++ b/contracts/voting/test_snapshots/tests/test_commit_and_reveal.1.json
@@ -1,0 +1,430 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "open_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "200"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "1"
+                },
+                {
+                  "bytes": "a531d16081f25a11205b41431403f9c6ebe675243f33d15de6f7c415808b30d8"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "reveal",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "bytes": "4242424242424242424242424242424242424242424242424242424242424242"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 150,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "commit"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commitment"
+                    },
+                    "val": {
+                      "bytes": "a531d16081f25a11205b41431403f9c6ebe675243f33d15de6f7c415808b30d8"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "committed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "reveal"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "option"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revealed"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "weight"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "vote"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commit_end"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "options"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "phase"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "results"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reveal_end"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/test_snapshots/tests/test_double_commit_reverts.1.json
+++ b/contracts/voting/test_snapshots/tests/test_double_commit_reverts.1.json
@@ -1,0 +1,323 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "open_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "200"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "1"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "commit"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commitment"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "committed"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "vote"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commit_end"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "options"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "phase"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "results"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reveal_end"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/test_snapshots/tests/test_initialize.1.json
+++ b/contracts/voting/test_snapshots/tests/test_initialize.1.json
@@ -1,0 +1,117 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/test_snapshots/tests/test_open_vote.1.json
+++ b/contracts/voting/test_snapshots/tests/test_open_vote.1.json
@@ -1,0 +1,231 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "open_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "200"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "vote"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commit_end"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "options"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "phase"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "results"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reveal_end"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/test_snapshots/tests/test_reveal_mismatch_reverts.1.json
+++ b/contracts/voting/test_snapshots/tests/test_reveal_mismatch_reverts.1.json
@@ -1,0 +1,323 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "open_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "200"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "commit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "u64": "1"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 150,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "commit"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commitment"
+                    },
+                    "val": {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "committed"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "vote"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commit_end"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "options"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "phase"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "results"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reveal_end"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/voting/test_snapshots/tests/test_tally_too_early_reverts.1.json
+++ b/contracts/voting/test_snapshots/tests/test_tally_too_early_reverts.1.json
@@ -1,0 +1,231 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "open_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "u64": "200"
+                },
+                {
+                  "u32": 3
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 150,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "vote"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "commit_end"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "options"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "phase"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "results"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reveal_end"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "admin"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "votecnt"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
Closes #539, Closes #540, Closes #541, Closes #542

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR implements three key security and governance features for the Trivela platform:

1. **Nullifier Registry Contract** (#541): A standalone Soroban contract that provides shared, audited storage for spent nullifiers, enabling anonymous double-action prevention across consumer contracts.

2. **Commit-Reveal Voting Module** (#542): A voting system that keeps votes hidden until a reveal window closes, preventing last-mover/bandwagon manipulation. Supports optional quadratic weighting.

3. **Anti-Sybil Support** (#539): Extended campaign contract with uniqueness mode that integrates with the nullifier registry to enforce one-entry-per-identity guarantees.

The confidential balances feature (#540) is noted as out of scope for this PR due to the complexity of implementing Pedersen commitments and range proofs, which requires additional cryptographic infrastructure.

## Motivation / Context

These features address critical security and governance needs:
- The nullifier registry provides a shared, audited place for recording spent nullifiers
- The voting module enables fair, private voting for campaign decisions
- Anti-sybil support prevents sybil attacks on reward campaigns

Closes #539, Closes #541, Closes #542