### PR TITLE
mainnet dwployment guide

### DIFF
--- a/docs/MAINNET_DEPLOY.md
+++ b/docs/MAINNET_DEPLOY.md
@@ -1,0 +1,324 @@
+# Mainnet Deployment Guide
+
+This guide walks through deploying Trivela to Stellar mainnet. Work through each section in order
+and check off every item before proceeding to the next.
+
+---
+
+## 1. Pre-flight
+
+### 1.1 Contract tests
+
+```bash
+cargo test --workspace
+```
+
+All tests must pass. Fix any failures before continuing.
+
+### 1.2 Binding sync
+
+Confirm that the generated TypeScript bindings match the compiled WASM. If `check-drift` exits
+non-zero the bindings are stale — regenerate them and commit before deploying.
+
+```bash
+npm run codegen:check
+```
+
+### 1.3 Dependency audit
+
+```bash
+cargo audit
+npm audit --audit-level=high
+```
+
+Resolve or justify every high/critical finding. A clean `cargo audit` output is required.
+
+### 1.4 No hardcoded testnet references
+
+```bash
+grep -r "testnet" frontend/src --include="*.ts" --include="*.tsx" -l
+grep -r "soroban-testnet\|horizon-testnet" backend/src --include="*.js" -l
+```
+
+All network references must come from environment variables.
+
+---
+
+## 2. Wallet Setup
+
+### 2.1 Generate a dedicated admin keypair
+
+The admin keypair controls `propose_admin`, `accept_admin`, and other privileged contract calls.
+**Use a hardware wallet** (Ledger, Trezor) for mainnet. Never store the secret key in plaintext or
+in any environment variable that is committed to version control.
+
+```bash
+# Generate a new keypair (software fallback — prefer hardware wallet)
+stellar keys generate trivela-admin --network mainnet
+stellar keys address trivela-admin
+```
+
+Record the public key (`G...`). Store the secret key in a hardware wallet or a secrets manager
+(Vault, AWS Secrets Manager, GCP Secret Manager).
+
+### 2.2 Fund the admin account
+
+The admin account needs XLM to cover:
+
+- Base reserve (1 XLM minimum)
+- Transaction fees for contract deployment (~0.1 XLM per contract)
+- Ongoing admin operations
+
+Send at least **10 XLM** to the admin public key before proceeding.
+
+```bash
+stellar account info --network mainnet <ADMIN_PUBLIC_KEY>
+```
+
+Confirm the account is funded and active (sequence number > 0).
+
+---
+
+## 3. Contract Deployment
+
+### 3.1 Build release WASM
+
+```bash
+cargo build --target wasm32-unknown-unknown --release \
+  -p trivela-rewards-contract \
+  -p trivela-campaign-contract \
+  -p trivela-badges-contract \
+  -p trivela-nullifiers-contract \
+  -p trivela-voting-contract
+```
+
+### 3.2 Deploy to mainnet
+
+The deploy script reads `STELLAR_NETWORK` and `STELLAR_SOURCE`. When `STELLAR_NETWORK=mainnet` you
+must also set `MAINNET_CONFIRMED=true` — this guard prevents accidental mainnet deploys.
+
+```bash
+STELLAR_NETWORK=mainnet \
+MAINNET_CONFIRMED=true \
+STELLAR_SOURCE=trivela-admin \
+TRIVELA_ENV_OUT=.env.mainnet \
+TRIVELA_BACKEND_ENV=backend/.env.mainnet \
+  bash ./scripts/deploy-testnet.sh
+```
+
+Or use the dedicated alias:
+
+```bash
+npm run deploy:mainnet
+```
+
+`deploy:mainnet` still requires `STELLAR_SOURCE` and `MAINNET_CONFIRMED=true` in the environment.
+
+### 3.3 Record contract IDs
+
+The script writes contract IDs to `.env.mainnet` and `backend/.env.mainnet`. Commit the **public**
+contract IDs (not secret keys) to the repository so they are auditable:
+
+```
+VITE_REWARDS_CONTRACT_ID=C...
+VITE_CAMPAIGN_CONTRACT_ID=C...
+```
+
+### 3.4 Verify on-chain
+
+```bash
+stellar contract invoke \
+  --id <REWARDS_CONTRACT_ID> \
+  --network mainnet \
+  --source trivela-admin \
+  -- admin
+```
+
+The output should be the admin public key you used to deploy.
+
+---
+
+## 4. Backend Configuration
+
+Set these environment variables in your secrets manager / deployment platform. Never commit secret
+values to git.
+
+### Required
+
+| Variable                | Description                                        | Mainnet value                                    |
+| ----------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `NODE_ENV`              | Runtime environment                                | `production`                                     |
+| `STELLAR_NETWORK`       | Network identifier                                 | `mainnet` (or `public` for some Stellar SDKs)   |
+| `SOROBAN_RPC_URL`       | Primary Soroban RPC endpoint                       | `https://soroban.stellar.org` or a private node  |
+| `HORIZON_URL`           | Horizon REST endpoint                              | `https://horizon.stellar.org`                    |
+| `DATABASE_URL`          | PostgreSQL connection string                       | `postgresql://user:pass@host:5432/trivela`        |
+| `TRIVELA_API_KEYS`      | Comma-separated admin API keys (min 32 chars each) | generated via `openssl rand -hex 32`              |
+| `TRIVELA_MASTER_KEY`    | Master API key for privileged operations           | generated via `openssl rand -hex 32`              |
+| `TRIVELA_JWT_SECRET`    | JWT signing secret (min 32 chars)                  | generated via `openssl rand -hex 32`              |
+| `STELLAR_SECRET_KEY`    | Secret key for SEP-10 / sponsored accounts         | hardware wallet export or secrets manager ref     |
+| `CORS_ALLOWED_ORIGINS`  | Comma-separated allowed origins                    | `https://trivela.com` (no trailing slash)         |
+| `REWARDS_CONTRACT_ID`   | Deployed rewards contract address                  | from step 3.3                                    |
+| `CAMPAIGN_CONTRACT_ID`  | Deployed campaign contract address                 | from step 3.3                                    |
+
+### Optional but recommended for production
+
+| Variable                        | Description                                  | Default      |
+| ------------------------------- | -------------------------------------------- | ------------ |
+| `SOROBAN_RPC_URLS`              | Additional RPC endpoints (comma-separated)   | —            |
+| `REDIS_URL`                     | Redis connection string for rate-limit store | in-memory    |
+| `PORT`                          | Listening port                               | `3001`       |
+| `RATE_LIMIT_WINDOW_MS`          | Rate-limit window in ms                      | `60000`      |
+| `RATE_LIMIT_MAX_REQUESTS`       | Max requests per window                      | `100`        |
+| `STORAGE_BACKEND`               | `local`, `s3`, or `gcs`                      | `local`      |
+| `AWS_REGION`                    | AWS region (when `STORAGE_BACKEND=s3`)       | —            |
+| `VAPID_PUBLIC_KEY`              | Web Push VAPID public key                    | —            |
+| `VAPID_PRIVATE_KEY`             | Web Push VAPID private key                   | —            |
+| `VAPID_SUBJECT`                 | Web Push subject (`mailto:` or URL)          | —            |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | OpenTelemetry collector endpoint             | —            |
+| `OTEL_SERVICE_NAME`             | Service name for traces                      | `trivela`    |
+| `SITE_URL`                      | Public site URL (used in emails/webhooks)    | —            |
+| `ENABLE_WEBSOCKET`              | Enable WebSocket server                      | `true`       |
+
+Validate the configuration before starting:
+
+```bash
+node ./scripts/validate-env.mjs
+```
+
+---
+
+## 5. Kubernetes / Helm
+
+Edit `helm/trivela/values.yaml` or provide a `values.mainnet.yaml` override file. The following
+values **must** change from their defaults for mainnet:
+
+```yaml
+backend:
+  image:
+    repository: ghcr.io/your-org/trivela-backend   # use your registry
+    tag: "v1.2.3"                                   # pin to a specific release tag — never "latest"
+    pullPolicy: IfNotPresent
+  replicaCount: 3                                   # minimum 3 for HA
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+frontend:
+  image:
+    repository: ghcr.io/your-org/trivela-frontend
+    tag: "v1.2.3"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+
+ingress:
+  host: trivela.com                                 # production domain
+  tls:
+    enabled: true
+    secretName: trivela-tls
+    clusterIssuer: letsencrypt-prod
+
+autoscaling:
+  minReplicas: 3
+  maxReplicas: 20
+
+config:
+  nodeEnv: production
+  corsOrigin: "https://trivela.com"
+
+secrets:
+  # Inject real values from your secrets manager — never commit here
+  databaseUrl: "postgresql://trivela_user:REAL_PASS@db.internal:5432/trivela_prod"
+  jwtSecret: "REAL_SECRET_AT_LEAST_32_CHARS"
+  sorobanRpcUrl: "https://soroban.stellar.org"
+```
+
+Deploy with:
+
+```bash
+helm upgrade --install trivela ./helm/trivela \
+  -f helm/trivela/values.yaml \
+  -f helm/values.mainnet.yaml \
+  --namespace trivela-prod \
+  --create-namespace \
+  --atomic \
+  --timeout 5m
+```
+
+---
+
+## 6. SSL / Nginx
+
+The nginx config lives in `nginx/trivela.conf.template`. It is processed by `deploy-blue-green.sh`
+using `envsubst`.
+
+**Required variables before running the nginx deployment:**
+
+| Variable                 | Mainnet value                       |
+| ------------------------ | ----------------------------------- |
+| `TRIVELA_BACKEND_HOST`   | Internal hostname of the backend    |
+| `TRIVELA_BACKEND_PORT`   | `3001` (blue) or `3002` (green)     |
+
+**CORS**: `CORS_ALLOWED_ORIGINS` in the backend env must be set to the exact production frontend
+origin (e.g., `https://trivela.com`). The wildcard `*` must **never** be used in production.
+
+**TLS**: Terminate TLS at the ingress controller or load balancer. The nginx template currently
+listens on port 80 — the ingress must redirect HTTP → HTTPS and attach the TLS certificate.
+The `Strict-Transport-Security` header is already included in the template.
+
+**CSP**: Review the `Content-Security-Policy` header if you add third-party scripts or CDN assets.
+The embed route allows `frame-ancestors *` — confirm this is intentional for your embed use case.
+
+---
+
+## 7. Smoke Test
+
+Run this checklist after deployment and before announcing mainnet availability.
+
+### Infrastructure
+
+- [ ] `GET https://trivela.com/health` returns `{"status":"ok"}` with HTTP 200
+- [ ] TLS certificate is valid, not expired, and covers the correct domain
+- [ ] HTTP → HTTPS redirect works (`curl -I http://trivela.com`)
+- [ ] `X-Content-Type-Options: nosniff` and `Strict-Transport-Security` headers present
+- [ ] Kubernetes pods are all in `Running` state: `kubectl get pods -n trivela-prod`
+- [ ] HPA is active: `kubectl get hpa -n trivela-prod`
+
+### Stellar / Contracts
+
+- [ ] Soroban RPC health endpoint responds: `GET <SOROBAN_RPC_URL>/health`
+- [ ] `stellar contract invoke -- admin` returns the expected admin public key for each contract
+- [ ] Horizon account lookup confirms admin account is funded: `GET <HORIZON_URL>/accounts/<ADMIN_KEY>`
+
+### Backend API
+
+- [ ] `GET /api/campaigns` returns a valid (possibly empty) list
+- [ ] `POST /api/campaigns` with a valid API key creates a campaign successfully
+- [ ] Invalid API key returns HTTP 401
+- [ ] Rate-limit headers (`X-RateLimit-*`) present on API responses
+
+### Frontend
+
+- [ ] Frontend loads at `https://trivela.com` without console errors
+- [ ] Network indicator shows "Mainnet" / "Public"
+- [ ] Freighter wallet connection succeeds on mainnet
+- [ ] Campaign list displays any contracts deployed in step 3
+
+### Observability
+
+- [ ] Logs flowing to your log aggregator (no gaps in backend logs)
+- [ ] Prometheus scraping `/metrics` if OpenTelemetry is configured
+- [ ] Alert channels (PagerDuty / Slack) receive a test notification
+
+---
+
+## References
+
+- [DEPLOYMENT.md](./DEPLOYMENT.md) — blue/green and restart policies
+- [KUBERNETES.md](./KUBERNETES.md) — full Kubernetes reference
+- [SECURITY.md](./SECURITY.md) — key rotation and incident response
+- [MAINNET_CHECKLIST.md](./MAINNET_CHECKLIST.md) — sign-off checklist for all contributors
+- [RUNBOOK.md](./RUNBOOK.md) — rollback and incident procedures

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,271 @@
+# Security Policy
+
+This document covers key management, incident response, and the admin transfer procedure for
+Trivela's Soroban contracts.
+
+---
+
+## Reporting a Vulnerability
+
+Do **not** open a public GitHub issue for security vulnerabilities. Email
+**security@trivela.com** with:
+
+- A description of the vulnerability and the component affected
+- Steps to reproduce (or a proof-of-concept)
+- Potential impact
+
+You will receive an acknowledgement within 48 hours. We aim to release a fix within 14 days for
+critical issues and 30 days for others. Please allow us to coordinate disclosure before publishing.
+
+---
+
+## Key Inventory
+
+| Key / Secret              | Purpose                                           | Storage requirement               |
+| ------------------------- | ------------------------------------------------- | --------------------------------- |
+| Admin keypair (`G...`)    | Contract admin calls (`propose_admin`, upgrades)  | Hardware wallet or HSM            |
+| `STELLAR_SECRET_KEY`      | SEP-10 / sponsored account signing                | Secrets manager (Vault, AWS SM)   |
+| `TRIVELA_MASTER_KEY`      | Privileged API operations                         | Secrets manager                   |
+| `TRIVELA_API_KEYS`        | Standard API access                               | Secrets manager                   |
+| `TRIVELA_JWT_SECRET`      | JWT signing                                       | Secrets manager, min 32 chars     |
+| `DATABASE_URL`            | PostgreSQL credentials                            | Secrets manager                   |
+| `VAPID_PRIVATE_KEY`       | Web Push signing                                  | Secrets manager                   |
+
+**Rules:**
+
+- Secrets must never be committed to git, logged, or sent over unencrypted channels.
+- Production secrets must differ from testnet secrets.
+- Rotate all secrets at least annually or immediately after any suspected compromise.
+
+---
+
+## Routine Key Rotation
+
+Follow this procedure to rotate any backend secret (JWT secret, API keys, database password, etc.)
+without downtime.
+
+### Backend secrets (zero-downtime rotation)
+
+1. **Generate** the new secret:
+   ```bash
+   openssl rand -hex 32
+   ```
+2. **Add** the new value to your secrets manager alongside the old one (if the system supports
+   multi-key validation, enable it so both old and new tokens are accepted temporarily).
+3. **Update** the environment variable in your deployment platform (Kubernetes secret, Helm values,
+   etc.) and roll out the new backend pods:
+   ```bash
+   kubectl rollout restart deployment/trivela-backend -n trivela-prod
+   kubectl rollout status deployment/trivela-backend -n trivela-prod
+   ```
+4. **Verify** that the new pods are healthy (`/health` returns 200) and that API clients can
+   authenticate with the new key.
+5. **Revoke** the old secret from the secrets manager.
+6. **Document** the rotation in your change log with the date and reason.
+
+### API key rotation (`TRIVELA_API_KEYS`)
+
+`TRIVELA_API_KEYS` accepts a comma-separated list, so you can add the new key before removing the
+old one:
+
+```bash
+# Phase 1 — add new key (old key still works)
+TRIVELA_API_KEYS="old-key,new-key"
+
+# Distribute new key to all consumers and confirm they have switched.
+
+# Phase 2 — remove old key
+TRIVELA_API_KEYS="new-key"
+```
+
+### `STELLAR_SECRET_KEY` rotation
+
+The `STELLAR_SECRET_KEY` is a Stellar keypair used for server-side signing (SEP-10, sponsored
+accounts). It does **not** control any contract admin authority.
+
+1. Generate a new Stellar keypair:
+   ```bash
+   stellar keys generate trivela-server-new --network mainnet
+   stellar keys address trivela-server-new
+   ```
+2. Fund the new account (minimum 1 XLM base reserve).
+3. Update `STELLAR_SECRET_KEY` in the secrets manager with the new secret key.
+4. Roll out the backend (step 3 of routine rotation above).
+5. Verify SEP-10 challenges are signed by the new key.
+6. The old keypair can be decommissioned (it holds no special on-chain authority).
+
+---
+
+## Compromised Admin Keypair — Incident Response
+
+The admin keypair is the highest-privilege credential in the system. If you believe it has been
+compromised, act immediately.
+
+### Step 1 — Contain
+
+- Revoke any cloud credentials that may have given access to the secret (rotate AWS/GCP IAM keys,
+  Vault tokens, etc.).
+- If the key is in a hardware wallet that has been lost or stolen, treat the key as compromised
+  regardless of PIN protection.
+
+### Step 2 — Initiate emergency admin transfer
+
+Use a backup admin keypair or a multisig key that was established during initial setup. If no
+backup key exists, you will need to coordinate with the Stellar network — a compromised admin with
+no backup is a critical situation; contact **security@trivela.com** immediately.
+
+Assuming you have a backup key (`trivela-admin-backup`):
+
+```bash
+# 1. Propose the backup key as the new admin (called from the COMPROMISED key if still accessible,
+#    or from any key that has been granted emergency authority).
+stellar contract invoke \
+  --id <REWARDS_CONTRACT_ID> \
+  --network mainnet \
+  --source trivela-admin-backup \
+  -- propose_admin \
+  --current_admin <CURRENT_ADMIN_PUBLIC_KEY> \
+  --new_admin <BACKUP_ADMIN_PUBLIC_KEY>
+
+# Repeat for each contract (campaign, badges, nullifiers, voting).
+```
+
+```bash
+# 2. Accept from the backup key.
+stellar contract invoke \
+  --id <REWARDS_CONTRACT_ID> \
+  --network mainnet \
+  --source trivela-admin-backup \
+  -- accept_admin \
+  --new_admin <BACKUP_ADMIN_PUBLIC_KEY>
+```
+
+```bash
+# 3. Confirm the transfer succeeded.
+stellar contract invoke \
+  --id <REWARDS_CONTRACT_ID> \
+  --network mainnet \
+  --source trivela-admin-backup \
+  -- admin
+# Should return BACKUP_ADMIN_PUBLIC_KEY.
+```
+
+### Step 3 — Rotate to a new permanent key
+
+Once the backup key is in control, generate a fresh keypair on a hardware wallet and transfer
+admin to it using the normal two-step procedure (see below).
+
+### Step 4 — Post-incident
+
+- Audit contract event logs for any unauthorized calls between the estimated compromise time and
+  the transfer.
+- Rotate all backend secrets as a precaution (the admin keypair is separate from backend secrets
+  but assume full breach).
+- Write an incident report covering timeline, root cause, and remediation.
+
+---
+
+## Admin Transfer — Two-Step Procedure
+
+Both the `rewards` and `campaign` contracts (and all other Trivela contracts) implement a
+**propose-then-accept** pattern. A one-step transfer to a wrong address cannot brick the contract
+because the current admin retains control until the new admin explicitly accepts.
+
+### Functions
+
+| Function                                  | Called by       | Effect                                            |
+| ----------------------------------------- | --------------- | ------------------------------------------------- |
+| `propose_admin(current_admin, new_admin)` | Current admin   | Writes `new_admin` to `pending_admin`; no change to `admin` slot |
+| `cancel_admin_transfer(current_admin)`    | Current admin   | Clears `pending_admin`; no transfer occurs        |
+| `accept_admin(new_admin)`                 | New admin       | Moves `new_admin` into `admin` slot; clears `pending_admin` |
+
+### Pre-rotation checklist
+
+- [ ] Generate the new admin keypair on the target hardware wallet. Do not copy the secret over
+      the wire.
+- [ ] Fund the new account (minimum 1 XLM).
+- [ ] Test that the new keypair can sign a no-op transaction on mainnet.
+- [ ] Confirm `pending_admin()` returns `None` (no in-flight transfer from a previous attempt).
+
+### Step 1 — Propose
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  --source <CURRENT_ADMIN_IDENTITY> \
+  -- propose_admin \
+  --current_admin <CURRENT_ADMIN_PUBLIC_KEY> \
+  --new_admin <NEW_ADMIN_PUBLIC_KEY>
+```
+
+Verify the `aproposed` event appears on-chain with the correct `new_admin` address.
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  --source <CURRENT_ADMIN_IDENTITY> \
+  -- pending_admin
+# Must return NEW_ADMIN_PUBLIC_KEY
+```
+
+If the address is wrong, call `cancel_admin_transfer` and start over. The current admin slot is
+unchanged until `accept_admin` is called.
+
+### Step 2 — Accept
+
+The new admin must call `accept_admin` within **30 days** (the instance-storage TTL). After that
+window `pending_admin` is cleared automatically by the ledger, and the proposal expires.
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  --source <NEW_ADMIN_IDENTITY> \
+  -- accept_admin \
+  --new_admin <NEW_ADMIN_PUBLIC_KEY>
+```
+
+### Verify
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  --source <NEW_ADMIN_IDENTITY> \
+  -- admin
+# Must return NEW_ADMIN_PUBLIC_KEY
+
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  --source <NEW_ADMIN_IDENTITY> \
+  -- pending_admin
+# Must return None
+```
+
+Repeat steps 1–2 and verify for **each deployed contract** (rewards, campaign, badges, nullifiers,
+voting).
+
+---
+
+## Defense-in-Depth Recommendations
+
+- **Multisig**: Consider a multisig signer policy (e.g., 2-of-3) on the admin keypair so that no
+  single person can initiate a transfer.
+- **Time-lock**: For non-emergency rotations, delay the `accept_admin` call by 24–48 hours to give
+  team members time to detect unauthorized proposals.
+- **Monitoring**: Alert on any `propose_admin` or `accept_admin` contract events in production.
+  These should be rare and always expected.
+- **Backup key**: Maintain a cold-storage backup admin key in a separate geographic location.
+  Test it annually.
+
+---
+
+## References
+
+- [MAINNET_DEPLOY.md](./MAINNET_DEPLOY.md) — production deployment guide
+- [DEPLOYMENT.md](./DEPLOYMENT.md) — admin transfer and blue/green deployment
+- [MAINNET_CHECKLIST.md](./MAINNET_CHECKLIST.md) — launch sign-off checklist
+- [RUNBOOK.md](./RUNBOOK.md) — incident response and rollback procedures

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:backend": "npm run test --workspace=backend",
     "test:frontend": "npm run test --workspace=frontend",
     "deploy:testnet": "bash ./scripts/deploy-testnet.sh",
+    "deploy:mainnet": "STELLAR_NETWORK=mainnet MAINNET_CONFIRMED=true bash ./scripts/deploy-testnet.sh",
     "contracts:build-bindings": "node scripts/build-bindings.js",
     "env:validate": "node ./scripts/validate-env.mjs",
     "labels:sync": "node ./scripts/sync-github-labels.js",

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -34,6 +34,14 @@ if [ -z "$SOURCE" ]; then
   err "STELLAR_SOURCE is required (set it to a funded Stellar identity or secret key)"
 fi
 
+# Mainnet guard — require explicit opt-in to prevent accidental production deploys.
+if [ "$NETWORK" = "mainnet" ] || [ "$NETWORK" = "public" ]; then
+  if [ "${MAINNET_CONFIRMED:-}" != "true" ]; then
+    err "Deploying to mainnet requires MAINNET_CONFIRMED=true. Set this variable only after reviewing docs/MAINNET_DEPLOY.md."
+  fi
+  echo "WARNING: Deploying to MAINNET. This action is irreversible." >&2
+fi
+
 if ! command -v cargo >/dev/null 2>&1; then
   err "cargo is required but not found in PATH"
 fi


### PR DESCRIPTION

docs/MAINNET_DEPLOY.md (new)
A 7-section step-by-step guide covering:
1. Pre-flight — cargo test, npm run codegen:check, cargo audit, testnet reference grep
2. Wallet setup — hardware wallet keygen, XLM funding
3. Contract deployment — build WASM, run with MAINNET_CONFIRMED=true guard, verify on-chain via stellar contract invoke -- admin
4. Backend config — full table of every env var found in the codebase (STELLAR_SECRET_KEY, TRIVELA_MASTER_KEY, TRIVELA_JWT_SECRET, VAPID keys, OTEL, etc.) split into required vs. optional
5. Kubernetes / Helm — exact values.yaml keys that must change (image tag, replicaCount: 3, resource limits, ingress.host, CORS)
6. SSL / Nginx — references nginx/trivela.conf.template, notes that CORS_ALLOWED_ORIGINS=* is forbidden in production
7. Smoke test checklist — infrastructure, Stellar/contracts, backend API, frontend, observability

docs/SECURITY.md (new)
Covers:
- Vulnerability reporting contact
- Key inventory table with storage requirements for each secret
- Routine key rotation procedure (zero-downtime, with TRIVELA_API_KEYS multi-key phase-in)
- STELLAR_SECRET_KEY rotation (separate from contract admin authority)
- Compromised admin keypair incident response (contain → emergency transfer → rotate to new key → post-incident audit)
- Full two-step propose_admin → accept_admin procedure with CLI commands, verification steps, and the 30-day TTL window
- Defense-in-depth recommendations (multisig, time-lock, monitoring, backup key)

scripts/deploy-testnet.sh (modified)
Added a guard block after the STELLAR_SOURCE check: if STELLAR_NETWORK is mainnet or public, the script errors out unless MAINNET_CONFIRMED=true is explicitly set, with a warning message printed to stderr.

package.json (modified)
Added "deploy:mainnet": "STELLAR_NETWORK=mainnet MAINNET_CONFIRMED=true bash ./scripts/deploy-testnet.sh" — still requires STELLAR_SOURCE in the caller's environment.


Closes #481 
Closes #484 
Closes #522 
Closes #517