### PR TITLE
feat: campaign export, deprecation notices, user profile, secrets scanning

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,26 @@
+name: Secrets Scanning
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          config-path: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+title = "Trivela Gitleaks Configuration"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-key"
+description = "Stellar secret key (S... 56-char base32)"
+regex = '''\bS[A-Z2-7]{55}\b'''
+tags = ["stellar", "secret-key"]
+
+[[rules]]
+id = "trivela-api-key"
+description = "Trivela API key pattern"
+regex = '''tvl_[a-zA-Z0-9]{32,}'''
+tags = ["trivela", "api-key"]
+
+[allowlist]
+description = "Safe paths — example files, test fixtures, docs"
+paths = [
+  '''.env\.example''',
+  '''test[s]?/fixtures/''',
+  '''docs/''',
+]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trivela
 
+[![Secrets Scanning](https://github.com/FinesseStudioLab/Trivela/actions/workflows/secrets-scan.yml/badge.svg)](https://github.com/FinesseStudioLab/Trivela/actions/workflows/secrets-scan.yml)
+
 > **New contributor?** Check out the [📖 FAQ](docs/FAQ.md) for common setup, contract, and contribution questions before getting started.
 > 🔤 **[Glossary](docs/GLOSSARY.md)** — definitions for Soroban, XDR, TTL, Freighter, Horizon, and all Trivela-specific terms.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,42 @@
 
 [![Secrets Scanning](https://github.com/FinesseStudioLab/Trivela/actions/workflows/secrets-scan.yml/badge.svg)](https://github.com/FinesseStudioLab/Trivela/actions/workflows/secrets-scan.yml)
 
-> **New contributor?** Check out the [📖 FAQ](docs/FAQ.md) for common setup, contract, and contribution questions before getting started.
-> 🔤 **[Glossary](docs/GLOSSARY.md)** — definitions for Soroban, XDR, TTL, Freighter, Horizon, and all Trivela-specific terms.
+> **New contributor?** Check out the [📖 FAQ](docs/FAQ.md) for common setup, contract, and
+> contribution questions before getting started. 🔤 **[Glossary](docs/GLOSSARY.md)** — definitions
+> for Soroban, XDR, TTL, Freighter, Horizon, and all Trivela-specific terms.
 
-**Trivela** is a Stellar Soroban–based **campaign and rewards platform**. It lets campaign operators create on-chain campaigns, register participants, award points via smart contracts, and let users claim rewards—all on the Stellar network. The project is built for the [Stellar Wave on Drips](https://www.drips.network/wave/stellar) and is designed for open-source contributors.
+**Trivela** is a Stellar Soroban–based **campaign and rewards platform**. It lets campaign operators
+create on-chain campaigns, register participants, award points via smart contracts, and let users
+claim rewards—all on the Stellar network. The project is built for the
+[Stellar Wave on Drips](https://www.drips.network/wave/stellar) and is designed for open-source
+contributors.
+
+---
+
+## 🚀 Live on Stellar Testnet
+
+Both contracts are **deployed and live on Stellar Testnet**, built from the latest `main` and
+verified end-to-end (initialize → credit/balance, initialize → register/participant-count).
+
+| Contract     | Contract ID (Testnet)                                      | Explorer                                                                                                            |
+| ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Rewards**  | `CB6KYDQ7X2V5B46FU7FKZCRCK5ZEYCHRUHZPVF73RA5M5AAUUBQA6IXZ` | [View ↗](https://stellar.expert/explorer/testnet/contract/CB6KYDQ7X2V5B46FU7FKZCRCK5ZEYCHRUHZPVF73RA5M5AAUUBQA6IXZ) |
+| **Campaign** | `CDDVJVHP6PUYWB42VQJ6YC7GEUQR622JEE5MY65ZIKUETGDT33QZPBQH` | [View ↗](https://stellar.expert/explorer/testnet/contract/CDDVJVHP6PUYWB42VQJ6YC7GEUQR622JEE5MY65ZIKUETGDT33QZPBQH) |
+
+- **Network:** Stellar Testnet (`Test SDF Network ; September 2015`)
+- **Deployer (public key):** `GA4S5DDI3M3H37IDZIK422IH7WPBECOATLAOYPKOJFLBYTKHU2BB4M6P`
+- **Soroban RPC:** `https://soroban-testnet.stellar.org`
+
+Wire these into the frontend via `.env.testnet`:
+
+```bash
+VITE_STELLAR_NETWORK=testnet
+VITE_REWARDS_CONTRACT_ID=CB6KYDQ7X2V5B46FU7FKZCRCK5ZEYCHRUHZPVF73RA5M5AAUUBQA6IXZ
+VITE_CAMPAIGN_CONTRACT_ID=CDDVJVHP6PUYWB42VQJ6YC7GEUQR622JEE5MY65ZIKUETGDT33QZPBQH
+```
+
+> Testnet deployments are periodically reset by the network. If a contract ID stops resolving,
+> redeploy with `STELLAR_SOURCE=<identity> npm run deploy:testnet` and update the values above.
 
 ---
 
@@ -15,9 +47,11 @@
 - **Rewards contract** – Tracks user points, credits (by admin/campaign), and claims.
 - **Campaign contract** – Stores campaign active flag and participant registration.
 - **Backend API** – REST API for campaign metadata, health checks, and integration.
-- **Frontend** – React app to list campaigns and (when wired) connect wallets and interact with contracts.
+- **Frontend** – React app to list campaigns and (when wired) connect wallets and interact with
+  contracts.
 
-Use cases: loyalty points, drip campaigns, bounties, and any flow where you need **on-chain rewards + off-chain campaign metadata**.
+Use cases: loyalty points, drip campaigns, bounties, and any flow where you need **on-chain
+rewards + off-chain campaign metadata**.
 
 ---
 
@@ -39,38 +73,39 @@ Trivela/
 
 ## Architecture
 
-For a quick system map (diagram, trust boundaries, and end-to-end data flows), see [`docs/ARCHITECTURE_OVERVIEW.md`](docs/ARCHITECTURE_OVERVIEW.md).
-For the supported Stellar testnet/mainnet presets and runtime config flow, see [`docs/STELLAR_NETWORKS.md`](docs/STELLAR_NETWORKS.md).
+For a quick system map (diagram, trust boundaries, and end-to-end data flows), see
+[`docs/ARCHITECTURE_OVERVIEW.md`](docs/ARCHITECTURE_OVERVIEW.md). For the supported Stellar
+testnet/mainnet presets and runtime config flow, see
+[`docs/STELLAR_NETWORKS.md`](docs/STELLAR_NETWORKS.md).
 
 ---
 
 ## Security & rate limiting
 
-All public `/api/*` and `/api/v1/*` routes are protected by a rate
-limiter that keys per **API key** when present and falls back to
-per-IP otherwise. Standard `X-RateLimit-Limit` / `-Remaining` / `-Reset`
-headers are emitted on every response; the limiter returns
-`429 Too Many Requests` + `Retry-After` once the bucket is exhausted.
+All public `/api/*` and `/api/v1/*` routes are protected by a rate limiter that keys per **API key**
+when present and falls back to per-IP otherwise. Standard `X-RateLimit-Limit` / `-Remaining` /
+`-Reset` headers are emitted on every response; the limiter returns `429 Too Many Requests` +
+`Retry-After` once the bucket is exhausted.
 
 Configuration via env (defaults below; see [`backend/.env.example`](./backend/.env.example)):
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `RATE_LIMIT_WINDOW_MS` | `60000` | Window size in milliseconds |
-| `RATE_LIMIT_MAX_REQUESTS` | `60` | Max requests per key per window |
+| Variable                   | Default   | Purpose                                                                               |
+| -------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| `RATE_LIMIT_WINDOW_MS`     | `60000`   | Window size in milliseconds                                                           |
+| `RATE_LIMIT_MAX_REQUESTS`  | `60`      | Max requests per key per window                                                       |
 | `REDIS_HOST` / `REDIS_URL` | _(unset)_ | When set, swaps the in-memory bucket store for Redis so multiple API pods share state |
 
-Full implementation details (header schema, 429 payload shape,
-Redis-store considerations) live in [`backend/README.md`](./backend/README.md).
-Middleware source is `backend/src/middleware/rateLimit.js`; unit tests are
-in `backend/src/middleware/rateLimit.test.js`.
+Full implementation details (header schema, 429 payload shape, Redis-store considerations) live in
+[`backend/README.md`](./backend/README.md). Middleware source is
+`backend/src/middleware/rateLimit.js`; unit tests are in `backend/src/middleware/rateLimit.test.js`.
 
 ---
 
 ## Prerequisites
 
 - **Rust** (for Soroban): [rustup](https://rustup.rs/)
-- **Stellar CLI** (optional but recommended): [Install Stellar CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
+- **Stellar CLI** (optional but recommended):
+  [Install Stellar CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - **Node.js** 18+
 
 ---
@@ -85,7 +120,9 @@ git add . && git commit -m "chore: initial Trivela scaffold"
 git branch -M main && git push -u origin main
 ```
 
-Use a [Personal Access Token (PAT)](https://github.com/settings/tokens) with `repo` scope when pushing over HTTPS, or switch to SSH: `git remote set-url origin git@github.com:FinesseStudioLab/Trivela.git`.
+Use a [Personal Access Token (PAT)](https://github.com/settings/tokens) with `repo` scope when
+pushing over HTTPS, or switch to SSH:
+`git remote set-url origin git@github.com:FinesseStudioLab/Trivela.git`.
 
 ---
 
@@ -99,9 +136,38 @@ cd Trivela
 npm install
 ```
 
+### Monorepo task runner (Turborepo)
+
+The repo uses [Turborepo](https://turbo.build/repo) to coordinate builds and tests across the
+`backend` and `frontend` workspaces with caching and parallelization. Prefer these root-level
+commands over running each workspace by hand:
+
+```bash
+npm run build   # build:contracts (cargo/stellar), then turbo run build (frontend)
+npm run test    # turbo run test  (backend + frontend in parallel)
+npm run lint    # turbo run lint  (all workspaces in parallel)
+npm run dev      # turbo run dev   (backend + frontend concurrently)
+```
+
+`npm run build` builds the Soroban contracts first (which produces the TypeScript bindings the
+frontend depends on) and then runs `turbo run build`. Turbo caches task outputs, so unchanged
+workspaces are skipped on subsequent runs.
+
+**Remote cache (optional):** remote caching is enabled in `turbo.json`. To share the cache across CI
+and machines, export a Vercel Remote Cache (or self-hosted) token:
+
+```bash
+export TURBO_TOKEN=<your-token>
+export TURBO_TEAM=<your-team>
+```
+
+Without these variables Turbo falls back to the local `.turbo` cache only.
+
 ### 2. Build and run contracts (Soroban)
 
-To build the smart contracts, ensure you have the [Stellar CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli) installed.
+To build the smart contracts, ensure you have the
+[Stellar CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
+installed.
 
 ```bash
 # Build both contracts using Stellar CLI
@@ -121,7 +187,8 @@ export STELLAR_NETWORK=testnet
 export STELLAR_SOURCE=alice
 ```
 
-`STELLAR_NETWORK` is your Stellar CLI network alias (for example `testnet` or `mainnet`), and `STELLAR_SOURCE` is the Stellar CLI identity to sign deploy transactions.
+`STELLAR_NETWORK` is your Stellar CLI network alias (for example `testnet` or `mainnet`), and
+`STELLAR_SOURCE` is the Stellar CLI identity to sign deploy transactions.
 
 Build commands:
 
@@ -146,11 +213,13 @@ stellar contract deploy \
 #### Deploying to Testnet
 
 1. **Configure an Identity**:
+
    ```bash
    stellar keys generate alice --network testnet
    ```
 
 2. **Deploy the WASM**:
+
    ```bash
    # Deploy Rewards Contract
    stellar contract deploy \
@@ -163,8 +232,8 @@ stellar contract deploy \
      --source alice --network testnet
    ```
 
-3. **Initialize the Contracts**:
-   After deployment, you will receive a Contract ID. Use it to call the `initialize` function:
+3. **Initialize the Contracts**: After deployment, you will receive a Contract ID. Use it to call
+   the `initialize` function:
    ```bash
    stellar contract invoke --id <CONTRACT_ID> --source alice --network testnet -- \
      initialize --admin alice --name "Trivela Rewards" --symbol "TVL"
@@ -191,7 +260,6 @@ VITE_REWARDS_CONTRACT_ID=...
 VITE_CAMPAIGN_CONTRACT_ID=...
 ```
 
-
 ### 3. Run backend
 
 ```bash
@@ -211,8 +279,8 @@ PUT    /api/v1/campaigns/:id
 DELETE /api/v1/campaigns/:id
 ```
 
-Migration note:
-Legacy `/api/*` campaign routes are still available for backward compatibility, but new integrations should target `/api/v1/*`.
+Migration note: Legacy `/api/*` campaign routes are still available for backward compatibility, but
+new integrations should target `/api/v1/*`.
 
 ### 4. Run frontend
 
@@ -228,9 +296,9 @@ App: http://localhost:5173 (proxies `/api` and `/api/v1` to the backend).
 docker compose up --build
 ```
 
-This starts the backend on `http://localhost:3001` and the frontend on `http://localhost:5173`.
-The backend container uses `CORS_ALLOWED_ORIGINS=http://localhost:5173` and the frontend container
-uses `VITE_API_URL=http://backend:3001` so the two services can talk to each other on the Compose
+This starts the backend on `http://localhost:3001` and the frontend on `http://localhost:5173`. The
+backend container uses `CORS_ALLOWED_ORIGINS=http://localhost:5173` and the frontend container uses
+`VITE_API_URL=http://backend:3001` so the two services can talk to each other on the Compose
 network.
 
 To add the optional Redis service for local experimentation, include the `redis` profile:
@@ -244,11 +312,12 @@ docker compose --profile redis up --build
 ## Testing
 
 ```bash
-# All tests (Contracts + Backend + Frontend E2E)
+# Backend + Frontend tests via Turborepo (parallel, cached)
 npm run test
 
-# Rust contracts
+# Rust contracts (run independently of the Turbo pipeline)
 cargo test --workspace
+npm run test:contracts
 
 # Backend tests
 npm run test:backend
@@ -258,20 +327,74 @@ npm run test:backend
 npm run build:frontend
 # 2. Run the tests
 npm run test:frontend
+
+# Frontend visual regression tests (Playwright + Storybook)
+cd frontend
+npm run test:visual                # Run visual tests
+npm run test:visual:update         # Update baseline snapshots
+npm run test:visual:report         # View detailed HTML report
 ```
 
-The frontend E2E tests use **Playwright**. They run against a local preview server (`npm run preview`). Ensure the backend is running if you want the tests to hit real API endpoints, otherwise they will show the "empty state" as expected in a isolated environment.
+The frontend E2E tests use **Playwright**. They run against a local preview server
+(`npm run preview`). Ensure the backend is running if you want the tests to hit real API endpoints,
+otherwise they will show the "empty state" as expected in a isolated environment.
+
+### Load Testing
+
+Load tests validate backend performance under synthetic traffic using [k6](https://k6.io/):
+
+```bash
+# Install k6: brew install k6 (macOS) or see https://k6.io/docs/get-started/installation/
+
+# Run from repo root (starts backend automatically via npm script)
+npm run load-test                                      # default: read-campaigns scenario
+LOAD_SCENARIO=burst-registration npm run load-test    # user registration spike
+LOAD_SCENARIO=claim-storm API_KEY=sk_dev npm run load-test  # reward claim surge
+```
+
+Available scenarios (`load-tests/scenarios/`):
+
+- **read-campaigns** (100 VUs, 30s) - Read-heavy GET requests
+- **write-campaigns** (10 VUs, 30s) - POST campaign creation
+- **mixed-read-write** (80R+20W VUs, 60s) - Combined traffic
+- **burst-registration** (0→200 VUs, 70s) - Registration spike
+- **claim-storm** (0→150 VUs, 75s) - Concurrent reward claims
+
+See [`load-tests/README.md`](load-tests/README.md) for thresholds, CI integration, and custom
+scenarios.
+
+### Visual Regression Testing
+
+Visual regression tests capture screenshots of Storybook components and detect unintended UI
+changes:
+
+```bash
+cd frontend
+
+# Run tests (starts Storybook automatically)
+npm run test:visual
+
+# Update snapshots after intentional design changes
+npm run test:visual:update
+
+# View detailed test report with diffs
+npm run test:visual:report
+```
+
+Tests run automatically in CI on PRs that touch frontend code. See
+[`frontend/tests/visual/README.md`](frontend/tests/visual/README.md) for adding new tests and
+troubleshooting.
 
 ---
 
 ## Tech Stack
 
-| Layer           | Stack |
-|----------------|--------|
-| Smart contracts| Rust, Soroban SDK |
-| Backend        | Node.js, Express |
-| Frontend       | React, Vite, @stellar/stellar-sdk |
-| Network        | Stellar (testnet/mainnet), Soroban RPC |
+| Layer           | Stack                                  |
+| --------------- | -------------------------------------- |
+| Smart contracts | Rust, Soroban SDK                      |
+| Backend         | Node.js, Express                       |
+| Frontend        | React, Vite, @stellar/stellar-sdk      |
+| Network         | Stellar (testnet/mainnet), Soroban RPC |
 
 ---
 
@@ -284,7 +407,8 @@ gh auth login
 npm run labels:sync -- --repo FinesseStudioLab/Trivela
 ```
 
-The taxonomy lives in [`scripts/github-labels.json`](scripts/github-labels.json) and the sync script is idempotent, so re-running it updates colors/descriptions instead of failing.
+The taxonomy lives in [`scripts/github-labels.json`](scripts/github-labels.json) and the sync script
+is idempotent, so re-running it updates colors/descriptions instead of failing.
 
 ## Creating the 50 contributor issues (maintainers)
 
@@ -294,11 +418,19 @@ After the repo is pushed, create labels and open all 50 issues in GitHub in one 
 node scripts/create-github-issues.js
 ```
 
-This reads `PAT` from `.env.local`, creates issues from `docs/issues-data.json`, and can still be used for bulk issue creation. For labels, prefer `npm run labels:sync` so maintainers can rely on `gh auth` instead of PAT-based automation.
+This reads `PAT` from `.env.local`, creates issues from `docs/issues-data.json`, and can still be
+used for bulk issue creation. For labels, prefer `npm run labels:sync` so maintainers can rely on
+`gh auth` instead of PAT-based automation.
 
 ## Contributing
 
-We welcome contributions, especially from the Stellar and Drip community. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and check the [open issues](https://github.com/FinesseStudioLab/Trivela/issues) for labeled tasks (backend, frontend, smart-contract, good first issue, etc.).
+We welcome contributions, especially from the Stellar and Drip community. Please read
+[CONTRIBUTING.md](CONTRIBUTING.md) and check the
+[open issues](https://github.com/FinesseStudioLab/Trivela/issues) for labeled tasks (backend,
+frontend, smart-contract, good first issue, etc.).
+
+For information about governance, RFCs, and decision-making processes, see
+[GOVERNANCE.md](docs/GOVERNANCE.md).
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -667,3 +667,35 @@ Orchestrators (Compose, Kubernetes, ECS) can use the resulting status:
 ```bash
 docker inspect --format '{{json .State.Health}}' <container-id>
 ```
+
+---
+
+## API Versioning & Deprecation Policy
+
+All stable endpoints are served under `/api/v1/`. The legacy `/api/` prefix is an alias kept for backwards-compatibility; it will be removed after a 90-day deprecation window.
+
+### Deprecation notices
+
+When an endpoint is deprecated:
+
+1. It is added to `backend/src/deprecations.js` with `deprecatedAt` and `removedAt` dates.
+2. Every response from that endpoint carries three headers (RFC 8594):
+   - `Deprecation: <RFC-7231 date>` — when it was deprecated
+   - `Sunset: <RFC-7231 date>` — when it will be removed (≥ 90 days after deprecation)
+   - `Link: <replacement_url>; rel="successor-version"` — the endpoint to migrate to
+3. A `WARN` log line is emitted for each hit, letting operators see real traffic before removal.
+4. The full registry is available at `GET /api/v1/deprecations` for programmatic checks.
+
+### 90-day notice minimum
+
+No endpoint may be removed until at least 90 days have passed since its `deprecatedAt` date. Operators watching the deprecation headers and the `/deprecations` endpoint will have ample time to migrate.
+
+### Content negotiation (v2 responses)
+
+Select endpoints support an early-access v2 response shape. Opt in with:
+
+```
+Accept: application/vnd.trivela.v2+json
+```
+
+Endpoints that honour this header document it in their section below. All others ignore it.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,17 +1,21 @@
 # Trivela Backend
 
-REST API for the Trivela campaign and rewards platform. Handles campaign metadata, health checks, and Soroban RPC configuration for the frontend.
+REST API for the Trivela campaign and rewards platform. Handles campaign metadata, health checks,
+and Soroban RPC configuration for the frontend.
 
 ## API Documentation
 
-The complete API specification is available in [OpenAPI 3.1 format](./openapi.yaml). You can view it using:
+The complete API specification is available in [OpenAPI 3.1 format](./openapi.yaml). You can view it
+using:
+
 - [Swagger Editor](https://editor.swagger.io/) - paste the spec content
 - [Redoc](https://redocly.github.io/redoc/) - for a clean documentation view
 - Any OpenAPI-compatible tool
 
 ### Migration Guide
 
-See the [API Migration Guide](../docs/API_MIGRATION.md) for details on v0 → v1 breaking changes, endpoint changelog, deprecation policy, and migration examples with curl snippets.
+See the [API Migration Guide](../docs/API_MIGRATION.md) for details on v0 → v1 breaking changes,
+endpoint changelog, deprecation policy, and migration examples with curl snippets.
 
 ## Setup
 
@@ -23,10 +27,12 @@ npm run dev
 
 ## Environment
 
-The backend validates configuration on startup and fails fast with clear messages when values are invalid.
+The backend validates configuration on startup and fails fast with clear messages when values are
+invalid.
 
 - `PORT`: Server port (default `3001`)
-- `CORS_ALLOWED_ORIGINS`: Comma-separated allowed origins for CORS (example: `https://app.example.com,https://admin.example.com`)
+- `CORS_ALLOWED_ORIGINS`: Comma-separated allowed origins for CORS (example:
+  `https://app.example.com,https://admin.example.com`)
 - `CORS_ORIGIN`: Legacy single-origin CORS setting (fallback when `CORS_ALLOWED_ORIGINS` is not set)
 - `JSON_BODY_LIMIT`: Max JSON request body size (default `100kb`; rejects larger bodies with `413`)
 - `STELLAR_NETWORK`: Explicit named network preset, `testnet` or `mainnet`
@@ -35,22 +41,24 @@ The backend validates configuration on startup and fails fast with clear message
 - `STELLAR_NETWORK_PASSPHRASE`: Optional passphrase override for the chosen network preset
 - `REWARDS_CONTRACT_ID`: Optional rewards contract ID exposed by `/api/v1/config`
 - `CAMPAIGN_CONTRACT_ID`: Optional campaign contract ID exposed by `/api/v1/config`
-- `TRIVELA_API_KEYS`: Optional comma-separated API keys for write endpoints (supports rotation; see below)
+- `TRIVELA_API_KEYS`: Optional comma-separated API keys for write endpoints (supports rotation; see
+  below)
 - `TRIVELA_API_KEY`: Legacy single API key (still supported)
 - `RATE_LIMIT_WINDOW_MS`: Rate limit window for `/api/*` and `/api/v1/*` routes (default `60000`)
 - `RATE_LIMIT_MAX_REQUESTS`: Max requests per API key or IP in each window (default `60`)
-- `RPC_HEALTH_POLL_INTERVAL_MS`: Background Soroban RPC health poll interval (default `60000`; set `0` to disable)
+- `RPC_HEALTH_POLL_INTERVAL_MS`: Background Soroban RPC health poll interval (default `60000`; set
+  `0` to disable)
 
 ## API Key Authentication
 
-Write endpoints (`POST`, `PUT`, `DELETE`) are protected by an **optional** API
-key. The behaviour depends on whether `TRIVELA_API_KEYS`/`TRIVELA_API_KEY` is set:
+Write endpoints (`POST`, `PUT`, `DELETE`) are protected by an **optional** API key. The behaviour
+depends on whether `TRIVELA_API_KEYS`/`TRIVELA_API_KEY` is set:
 
-| Config                                         | Behaviour                                                            |
-| ---------------------------------------------- | -------------------------------------------------------------------- |
-| **No keys set** (default)                      | All endpoints are open — convenient for local development.           |
-| `TRIVELA_API_KEYS=old,new` (comma-separated)   | Write endpoints accept any configured key (supports rotation).       |
-| `TRIVELA_API_KEY=single` (legacy)              | Write endpoints accept the single configured key.                    |
+| Config                                       | Behaviour                                                      |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| **No keys set** (default)                    | All endpoints are open — convenient for local development.     |
+| `TRIVELA_API_KEYS=old,new` (comma-separated) | Write endpoints accept any configured key (supports rotation). |
+| `TRIVELA_API_KEY=single` (legacy)            | Write endpoints accept the single configured key.              |
 
 ### Supplying the key
 
@@ -71,10 +79,9 @@ If the key is missing or wrong the API responds with `401 Unauthorized`.
 
 ## Rate limiting
 
-All `/api/*` and `/api/v1/*` routes are protected by an in-memory rate limiter.
-Requests are keyed by API key when one is present, otherwise by client IP.
-When the limit is exceeded the API returns `429 Too Many Requests` with a
-`Retry-After` header.
+All `/api/*` and `/api/v1/*` routes are protected by an in-memory rate limiter. Requests are keyed
+by API key when one is present, otherwise by client IP. When the limit is exceeded the API returns
+`429 Too Many Requests` with a `Retry-After` header.
 
 **Example (rate limit exceeded):**
 
@@ -97,7 +104,8 @@ Legacy routes remain available under `/api/*` for backward compatibility:
 - `GET /api/campaigns/:id`
 - `DELETE /api/campaigns/:id`
 
-**Migration note:** New integrations should use `/api/v1/*`. Existing clients on `/api/*` continue to work.
+**Migration note:** New integrations should use `/api/v1/*`. Existing clients on `/api/*` continue
+to work.
 
 ## Response schema versioning
 
@@ -107,13 +115,18 @@ All responses include a schema version header:
 X-Trivela-Schema-Version: 1
 ```
 
-Clients may also send `X-Trivela-Schema-Version` on requests. When present and unsupported, the API responds with `400` and includes the supported version in both the response header and body.
+Clients may also send `X-Trivela-Schema-Version` on requests. When present and unsupported, the API
+responds with `400` and includes the supported version in both the response header and body.
 
-**Schema stability:** Within a given schema version, responses aim to be backward compatible (additive changes are preferred; breaking changes require a new schema version).
+**Schema stability:** Within a given schema version, responses aim to be backward compatible
+(additive changes are preferred; breaking changes require a new schema version).
 
 ## Security Defaults
 
-The API sets baseline security headers on all responses (for example `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and a restrictive `Content-Security-Policy`). `Strict-Transport-Security` is only applied when requests are served over HTTPS (or when `X-Forwarded-Proto: https` is present).
+The API sets baseline security headers on all responses (for example `X-Content-Type-Options`,
+`X-Frame-Options`, `Referrer-Policy`, and a restrictive `Content-Security-Policy`).
+`Strict-Transport-Security` is only applied when requests are served over HTTPS (or when
+`X-Forwarded-Proto: https` is present).
 
 ## API Endpoints
 
@@ -528,7 +541,8 @@ curl -X DELETE http://localhost:3001/api/v1/campaigns/campaign-2 \
 
 ## Campaign Payload Validation
 
-`POST /api/v1/campaigns` and `PUT /api/v1/campaigns/:id` validate request bodies and return `400` with a list of errors when invalid.
+`POST /api/v1/campaigns` and `PUT /api/v1/campaigns/:id` validate request bodies and return `400`
+with a list of errors when invalid.
 
 Validation rules:
 
@@ -539,7 +553,8 @@ Validation rules:
 
 ## Audit Logs (Admin)
 
-Write operations on campaigns emit audit log entries. Audit logs are retrievable via an admin-only endpoint.
+Write operations on campaigns emit audit log entries. Audit logs are retrievable via an admin-only
+endpoint.
 
 #### GET /api/v1/audit-logs
 
@@ -554,10 +569,9 @@ Requires API key if `TRIVELA_API_KEY` is set.
 
 ## PostgreSQL (issue #284)
 
-The backend ships with two repository implementations behind a single DAL
-factory. `better-sqlite3` is the default, suitable for local dev and
-single-instance deployments. For multi-instance and managed cloud setups
-(Railway, Render, Fly.io, RDS), point the backend at PostgreSQL via
+The backend ships with two repository implementations behind a single DAL factory. `better-sqlite3`
+is the default, suitable for local dev and single-instance deployments. For multi-instance and
+managed cloud setups (Railway, Render, Fly.io, RDS), point the backend at PostgreSQL via
 `DATABASE_URL`:
 
 ```bash
@@ -568,12 +582,12 @@ npm run dev
 When `DATABASE_URL` starts with `postgres://` or `postgresql://`:
 
 - `dal.campaigns` and `dal.auditLogs` switch to the PG implementations.
-- A connection pool is created lazily with `pg` (`pg.Pool`). Pool size is
-  controlled by `PG_POOL_MAX` (default `10`).
-- SQL migrations in [`src/dal/pg/migrations/`](src/dal/pg/migrations/) run on
-  startup and are tracked in `_schema_migrations`.
-- `dal.webhooks`, `dal.referrals`, and `dal.apiKeys` continue to use SQLite —
-  porting them is a follow-up.
+- A connection pool is created lazily with `pg` (`pg.Pool`). Pool size is controlled by
+  `PG_POOL_MAX` (default `10`).
+- SQL migrations in [`src/dal/pg/migrations/`](src/dal/pg/migrations/) run on startup and are
+  tracked in `_schema_migrations`.
+- `dal.webhooks`, `dal.referrals`, and `dal.apiKeys` continue to use SQLite — porting them is a
+  follow-up.
 
 ### Local dev with Docker
 
@@ -585,9 +599,8 @@ DATABASE_URL=postgres://trivela:trivela@localhost:5432/trivela npm run dev
 
 ### Running the PG integration tests
 
-The unit-test target `npm test` skips the PG repository tests unless
-`TEST_DATABASE_URL` is set so a clean checkout stays green. To run them
-locally:
+The unit-test target `npm test` skips the PG repository tests unless `TEST_DATABASE_URL` is set so a
+clean checkout stays green. To run them locally:
 
 ```bash
 docker run --rm -d -p 55432:5432 -e POSTGRES_PASSWORD=trivela \
@@ -596,28 +609,27 @@ TEST_DATABASE_URL=postgres://postgres:trivela@localhost:55432/postgres \
   node --test src/dal/pg/pgCampaignRepository.test.js
 ```
 
-The CI workflow can mount the `postgres` profile in `compose.yaml` and
-export `TEST_DATABASE_URL` to exercise the same path on every PR.
+The CI workflow can mount the `postgres` profile in `compose.yaml` and export `TEST_DATABASE_URL` to
+exercise the same path on every PR.
 
 ## Docker
 
-The backend ships as a multi-stage Alpine image. The build stage compiles
-native modules (`better-sqlite3`) against Node 20 headers; the runtime
-stage contains only Node, the production `node_modules` tree, the
-application source, and `dumb-init` for clean signal forwarding. The
+The backend ships as a multi-stage Alpine image. The build stage compiles native modules
+(`better-sqlite3`) against Node 20 headers; the runtime stage contains only Node, the production
+`node_modules` tree, the application source, and `dumb-init` for clean signal forwarding. The
 container runs as the unprivileged `node` user (uid/gid `1000`).
 
 ### Build
 
-The Dockerfile expects the build context to be the repo root because the
-monorepo's `package-lock.json` lives there:
+The Dockerfile expects the build context to be the repo root because the monorepo's
+`package-lock.json` lives there:
 
 ```bash
 docker build -f backend/Dockerfile -t trivela-backend .
 ```
 
-A `.dockerignore` at the repo root keeps the context small (excludes
-`node_modules`, `target/`, `frontend/`, etc.).
+A `.dockerignore` at the repo root keeps the context small (excludes `node_modules`, `target/`,
+`frontend/`, etc.).
 
 ### Run
 
@@ -643,14 +655,13 @@ docker run --rm -p 3001:3001 \
   trivela-backend
 ```
 
-See the [Environment](#environment) section above for the full list of
-supported variables.
+See the [Environment](#environment) section above for the full list of supported variables.
 
 ### Persistence
 
-The container's filesystem is read-only for the application user except
-for the working directory. SQLite data lives under `backend/src/db/` by
-default; mount a volume there to persist data across container restarts:
+The container's filesystem is read-only for the application user except for the working directory.
+SQLite data lives under `backend/src/db/` by default; mount a volume there to persist data across
+container restarts:
 
 ```bash
 docker run --rm -p 3001:3001 \
@@ -661,8 +672,8 @@ docker run --rm -p 3001:3001 \
 
 ### Health
 
-The image declares a `HEALTHCHECK` that polls `GET /health` every 30s.
-Orchestrators (Compose, Kubernetes, ECS) can use the resulting status:
+The image declares a `HEALTHCHECK` that polls `GET /health` every 30s. Orchestrators (Compose,
+Kubernetes, ECS) can use the resulting status:
 
 ```bash
 docker inspect --format '{{json .State.Health}}' <container-id>

--- a/backend/src/deprecations.js
+++ b/backend/src/deprecations.js
@@ -1,0 +1,17 @@
+// @ts-check
+
+/**
+ * Deprecation registry — maps route patterns to lifecycle metadata.
+ * Add entries here before removing or replacing any endpoint.
+ *
+ * @type {Record<string, { deprecatedAt: string, removedAt: string, replacement: string, message: string }>}
+ */
+export const DEPRECATION_REGISTRY = {
+  // Example — uncomment when real deprecations land:
+  // 'GET /api/v1/campaigns/:id/stats': {
+  //   deprecatedAt: '2024-09-01',
+  //   removedAt: '2024-12-01',
+  //   replacement: '/api/v1/campaigns/:id/analytics',
+  //   message: 'Use the /analytics endpoint for richer campaign stats.',
+  // },
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -41,6 +41,9 @@ import {
 import { createStorageAdapter } from './storage/index.js';
 import { uploadCampaignImage, validateImageUpload, MAX_IMAGE_SIZE_BYTES } from './services/imageUpload.js';
 import { buildCampaignStats } from './services/campaignStatsService.js';
+import { createCampaignExportRoute } from './routes/campaignExport.js';
+import { createDeprecationMiddleware } from './middleware/deprecationNotice.js';
+import { DEPRECATION_REGISTRY } from './deprecations.js';
 
 const DEFAULT_PORT = 3001;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
@@ -291,6 +294,7 @@ export async function createApp(options = {}) {
   app.use(compression({ threshold: 1024 }));
   app.use(cors(createCorsOptions(allowedOrigins)));
   app.use(securityHeaders);
+  app.use(createDeprecationMiddleware({ log }));
   app.use(traceparentMiddleware());
   app.use(requestLogger);
   app.use(express.json({ limit: jsonBodyLimit }));
@@ -1034,6 +1038,8 @@ export async function createApp(options = {}) {
     app.get(`${prefix}/campaigns/by-slug/:slug`, rateLimiter, getCampaignBySlug);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
     app.get(`${prefix}/campaigns/:id/stats`, rateLimiter, getCampaignStats);
+    app.use(prefix, createCampaignExportRoute({ db: dal.db, campaignRepository, auditLogRepository, requireApiKey }));
+    app.get(`${prefix}/deprecations`, rateLimiter, (_req, res) => res.json({ deprecations: DEPRECATION_REGISTRY }));
     app.get(`${prefix}/audit-logs`, rateLimiter, requireApiKey, listAuditLogs);
     app.get(`${prefix}/indexer/cursor`, rateLimiter, getIndexerCursorState);
     app.post(`${prefix}/indexer/cursor`, rateLimiter, requireApiKey, setIndexerCursorState);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -19,6 +19,7 @@ import { pathToFileURL } from 'node:url';
 import Redis from 'ioredis';
 import createApiKeyAuth, { createMasterKeyAuth } from './middleware/apiKeyAuth.js';
 import { createRateLimiter, createRedisStore } from './middleware/rateLimit.js';
+import { createAuthLockout } from './middleware/authLockout.js';
 import requestLogger, { log } from './middleware/logger.js';
 import requestId from './middleware/requestId.js';
 import securityHeaders from './middleware/securityHeaders.js';
@@ -39,18 +40,59 @@ import {
   formatZodErrors,
 } from './schemas.js';
 import { createStorageAdapter } from './storage/index.js';
-import { uploadCampaignImage, validateImageUpload, MAX_IMAGE_SIZE_BYTES } from './services/imageUpload.js';
+import {
+  uploadCampaignImage,
+  validateImageUpload,
+  MAX_IMAGE_SIZE_BYTES,
+} from './services/imageUpload.js';
 import { buildCampaignStats } from './services/campaignStatsService.js';
 import { createCampaignExportRoute } from './routes/campaignExport.js';
 import { createDeprecationMiddleware } from './middleware/deprecationNotice.js';
 import { DEPRECATION_REGISTRY } from './deprecations.js';
+import { generateAllowlist } from './lib/allowlist/merkle.js';
+import { parseAllowlistCsv, validateGAddress, MAX_ALLOWLIST_ROWS } from './lib/allowlist/csv.js';
+import { createEmbedRoute } from './routes/embed.js';
+import { createVariantRoutes } from './routes/variants.js';
+import { createVariantService } from './services/variantService.js';
+import { createCohortRoutes } from './routes/cohorts.js';
+import { createCohortService } from './services/cohortService.js';
+import { createPushRoutes } from './routes/push.js';
+import { createOrgRoutes } from './routes/orgs.js';
+import { createAuditRouter } from './routes/audit.js';
+import { createAuditLogService } from './services/auditLogService.js';
+import { createWebPushService } from './services/webPushService.js';
+import { createOrganizationRoutes } from './routes/organizations.js';
+import { createUsageMeteringService } from './services/usageMeteringService.js';
+import { createFeatureFlagRoutes } from './routes/featureFlags.js';
+import { createFeatureFlagService } from './services/featureFlagService.js';
+import { createUsageMeteringMiddleware } from './middleware/usageMetering.js';
+import { requestTimeout } from './middleware/timeout.js';
+import { PoolSaturatedError } from './rpcPool.js';
+import { initializeWebSocket, getWebSocketServer } from './websocket/index.js';
+import { requireScope } from './middleware/rbac.js';
+import { createIdempotencyMiddleware } from './middleware/idempotency.js';
+import { createDistributedLock, createInMemoryLock } from './jobs/distributedLock.js';
+import { createExportJob } from './jobs/exportJob.js';
+import { createEventIndexer } from './jobs/eventIndexer.js';
+import { createSqliteJobQueueRepository } from './dal/sqliteJobQueueRepository.js';
+import { createDurableJobQueue } from './jobs/durableJobQueue.js';
+import { createStellarTomlRoute } from './routes/stellarToml.js';
+import { createSponsoredAccountRoutes } from './routes/sponsoredAccounts.js';
+import { createClaimableBalancesRoutes } from './routes/claimableBalances.js';
+import { createIndexReadRoutes } from './routes/indexRead.js';
+import { createSep10Routes, createRequireWalletAuth } from './routes/sep10.js';
+import { createZkInputsRoutes } from './routes/zkInputs.js';
 
 const DEFAULT_PORT = 3001;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 60;
+const DEFAULT_AUTH_LOCKOUT_SOFT_THRESHOLD = 5;
+const DEFAULT_AUTH_LOCKOUT_HARD_THRESHOLD = 10;
+const DEFAULT_AUTH_LOCKOUT_BASE_LOCKOUT_MS = 60_000;
 const DEFAULT_SHORT_CACHE_TTL_MS = 5_000;
 const DEFAULT_JSON_BODY_LIMIT = '100kb';
 const DEFAULT_RPC_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const LEGACY_API_PREFIX = '/api';
 const API_V1_PREFIX = '/api/v1';
 const CONTRACT_ID_PATTERN = /^C[A-Z2-7]{55}$/;
@@ -108,7 +150,10 @@ function createCorsOptions(allowedOrigins) {
   }
 
   return {
-    origin(/** @type {string | undefined} */ origin, /** @type {(err: Error | null, allow?: boolean) => void} */ callback) {
+    origin(
+      /** @type {string | undefined} */ origin,
+      /** @type {(err: Error | null, allow?: boolean) => void} */ callback,
+    ) {
       if (!origin || allowedOrigins.includes(origin)) {
         callback(null, true);
         return;
@@ -147,7 +192,9 @@ function validateContractId(value, label) {
 export async function createApp(options = {}) {
   const isProduction = process.env.NODE_ENV === 'production';
   const jsonBodyLimit =
-    /** @type {string} */ (options.jsonBodyLimit) ?? process.env.JSON_BODY_LIMIT ?? DEFAULT_JSON_BODY_LIMIT;
+    /** @type {string} */ (options.jsonBodyLimit) ??
+    process.env.JSON_BODY_LIMIT ??
+    DEFAULT_JSON_BODY_LIMIT;
   const corsAllowedOriginsRaw =
     /** @type {string | undefined} */ (options.corsAllowedOrigins) ??
     process.env.CORS_ALLOWED_ORIGINS ??
@@ -157,7 +204,8 @@ export async function createApp(options = {}) {
     network: /** @type {string} */ (options.stellarNetwork) ?? process.env.STELLAR_NETWORK,
     sorobanRpcUrl: /** @type {string} */ (options.sorobanRpcUrl) ?? process.env.SOROBAN_RPC_URL,
     horizonUrl: /** @type {string} */ (options.horizonUrl) ?? process.env.HORIZON_URL,
-    networkPassphrase: /** @type {string} */ (options.networkPassphrase) ?? process.env.STELLAR_NETWORK_PASSPHRASE,
+    networkPassphrase:
+      /** @type {string} */ (options.networkPassphrase) ?? process.env.STELLAR_NETWORK_PASSPHRASE,
   });
   const rewardsContractId = validateContractId(
     readOptionalConfigValue(options, 'REWARDS_CONTRACT_ID'),
@@ -168,17 +216,19 @@ export async function createApp(options = {}) {
     'CAMPAIGN_CONTRACT_ID',
   );
   const fetchImpl = /** @type {typeof fetch} */ (options.fetchImpl) ?? globalThis.fetch;
-  const rpcUrlsRaw = /** @type {string | undefined} */ (options.sorobanRpcUrls) ?? process.env.SOROBAN_RPC_URLS;
+  const rpcUrlsRaw =
+    /** @type {string | undefined} */ (options.sorobanRpcUrls) ?? process.env.SOROBAN_RPC_URLS;
   const rpcUrls = rpcUrlsRaw
-    ? String(rpcUrlsRaw).split(',').map(u => u.trim()).filter(Boolean)
+    ? String(rpcUrlsRaw)
+        .split(',')
+        .map((u) => u.trim())
+        .filter(Boolean)
     : [stellarConfig.sorobanRpcUrl];
   const rpcPool = createRpcPool(rpcUrls);
   const allowedOrigins = parseAllowedOrigins(corsAllowedOriginsRaw);
 
   if (isProduction && allowedOrigins.includes('*')) {
-    throw new Error(
-      'Wildcard origins are not permitted in production.',
-    );
+    throw new Error('Wildcard origins are not permitted in production.');
   }
 
   const rateLimitWindowMs = normalizePositiveInteger(
@@ -188,6 +238,20 @@ export async function createApp(options = {}) {
   const rateLimitMaxRequests = normalizePositiveInteger(
     /** @type {any} */ (options.rateLimit)?.maxRequests ?? process.env.RATE_LIMIT_MAX_REQUESTS,
     DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+  );
+
+  const authLockoutOptions = /** @type {any} */ (options.authLockout) ?? {};
+  const authLockoutSoftThreshold = normalizePositiveInteger(
+    authLockoutOptions.softThreshold ?? process.env.AUTH_LOCKOUT_SOFT_THRESHOLD,
+    DEFAULT_AUTH_LOCKOUT_SOFT_THRESHOLD,
+  );
+  const authLockoutHardThreshold = normalizePositiveInteger(
+    authLockoutOptions.hardThreshold ?? process.env.AUTH_LOCKOUT_HARD_THRESHOLD,
+    DEFAULT_AUTH_LOCKOUT_HARD_THRESHOLD,
+  );
+  const authLockoutBaseMs = normalizePositiveInteger(
+    authLockoutOptions.baseLockoutMs ?? process.env.AUTH_LOCKOUT_BASE_MS,
+    DEFAULT_AUTH_LOCKOUT_BASE_LOCKOUT_MS,
   );
 
   const seed = /** @type {any[]} */ (options.campaigns) ?? defaultSeed();
@@ -202,8 +266,20 @@ export async function createApp(options = {}) {
   const auditLogRepository = dal.auditLogs;
   const webhookRepository = dal.webhooks;
   const referralRepository = dal.referrals;
+  const variantRepository = dal.variants;
+  const cohortRepository = dal.cohorts;
+  const pushSubscriptionRepository = dal.pushSubscriptions;
   const apiKeyRepository = dal.apiKeys;
   const failedJobRepository = options.failedJobRepository ?? dal.failedJobs;
+  const allowlistRepository = dal.allowlists;
+  const orgMemberRepository = dal.orgMembers;
+  const usageRepository = options.usageRepository ?? dal.usage;
+  const idempotencyRepository = dal.idempotency;
+
+  const idempotencyMiddleware = createIdempotencyMiddleware({
+    repository: idempotencyRepository,
+  });
+
   const storageAdapter = /** @type {import('./storage/storageAdapter.js').StorageAdapter} */ (
     options.storageAdapter ?? createStorageAdapter(process.env)
   );
@@ -213,6 +289,21 @@ export async function createApp(options = {}) {
   });
   const webhookService = new WebhookService(webhookRepository, {
     fetchImpl,
+    logger: log,
+  });
+  const variantService = createVariantService({ variantRepo: variantRepository });
+  const cohortService = createCohortService({ cohortRepo: cohortRepository });
+  const auditLogService = createAuditLogService({
+    auditLogRepository,
+    orgMemberRepository,
+  });
+  const webPushService = createWebPushService({
+    repository: pushSubscriptionRepository,
+    vapid: {
+      publicKey: process.env.VAPID_PUBLIC_KEY,
+      privateKey: process.env.VAPID_PRIVATE_KEY,
+      subject: process.env.VAPID_SUBJECT,
+    },
     logger: log,
   });
   const shortCacheTtlMs = normalizePositiveInteger(
@@ -225,7 +316,10 @@ export async function createApp(options = {}) {
   );
   const shortCache = new Map();
   const indexerCursorState = {
-    cursor: /** @type {string | null} */ (options.initialIndexerCursor) ?? process.env.INDEXER_EVENT_CURSOR ?? null,
+    cursor:
+      /** @type {string | null} */ (options.initialIndexerCursor) ??
+      process.env.INDEXER_EVENT_CURSOR ??
+      null,
     updatedAt: new Date().toISOString(),
     source: (options.initialIndexerCursor ?? process.env.INDEXER_EVENT_CURSOR) ? 'env' : 'runtime',
   };
@@ -239,7 +333,24 @@ export async function createApp(options = {}) {
     requestTotal: 0,
     requestErrors: 0,
     routeHits: new Map(),
+    authFailures: 0,
+    authLockouts: 0,
+    // p95 latency histogram — 12 buckets (ms): 50,100,200,500,1000,2000,5000,...
+    latencyBuckets: [50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 30_000, Infinity],
+    latencyCounts: /** @type {number[]} */ ([]),
+    latencyTotal: 0,
+    latencySum: 0,
   };
+  // Initialise bucket counters to 0.
+  metrics.latencyCounts = metrics.latencyBuckets.map(() => 0);
+
+  // Apply global request deadline so every route self-defends against slow
+  // upstreams.  The timeout is configurable via REQUEST_TIMEOUT_MS.
+  const requestTimeoutMs = normalizePositiveInteger(
+    options.requestTimeoutMs ?? process.env.REQUEST_TIMEOUT_MS,
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  app.use(requestTimeout(requestTimeoutMs));
 
   /**
    * Compatibility shim: ?api_version=v0 rewrites v1 routes to legacy patterns
@@ -256,15 +367,56 @@ export async function createApp(options = {}) {
     next();
   });
 
-  const requireApiKey = createApiKeyAuth({
-    apiKeys: /** @type {string} */ (options.apiKeys) ?? /** @type {string} */ (options.apiKey) ?? process.env.TRIVELA_API_KEYS ?? process.env.TRIVELA_API_KEY ?? '',
-    apiKeyRepository: options.apiKeyRepository ?? apiKeyRepository,
-  });
-  const requireMasterKey = createMasterKeyAuth({
-    masterKey: /** @type {string} */ (options.masterKey) ?? process.env.TRIVELA_MASTER_KEY ?? '',
+  // Brute-force / credential-stuffing guard (#588). Runs immediately before the
+  // auth middleware on every protected route; a spike in failures/lockouts is
+  // surfaced via the trivela_auth_* counters and structured warn logs.
+  const authGuard = createAuthLockout({
+    softThreshold: authLockoutSoftThreshold,
+    hardThreshold: authLockoutHardThreshold,
+    baseLockoutMs: authLockoutBaseMs,
+    timeProvider: authLockoutOptions.timeProvider,
+    delayFn: authLockoutOptions.delayFn,
+    store: authLockoutOptions.store,
+    onFailure: ({ key, failures }) => {
+      metrics.authFailures += 1;
+      log.warn({ key, failures }, 'Failed authentication attempt');
+    },
+    onLockout: ({ key, failures, lockoutMs, lockoutCount }) => {
+      metrics.authLockouts += 1;
+      log.warn(
+        { key, failures, lockoutMs, lockoutCount },
+        'Authentication lockout triggered (possible brute-force)',
+      );
+    },
   });
 
+  // Auth middlewares are exposed as [authGuard, requireX] arrays; Express
+  // flattens nested handler arrays, so existing route registrations pick up the
+  // guard with no change. Only auth-bearing routes are guarded, which keeps a
+  // 200 on a public route from ever resetting an attacker's failure counter.
+  const requireApiKey = [
+    authGuard,
+    createApiKeyAuth({
+      apiKeys:
+        /** @type {string} */ (options.apiKeys) ??
+        /** @type {string} */ (options.apiKey) ??
+        process.env.TRIVELA_API_KEYS ??
+        process.env.TRIVELA_API_KEY ??
+        '',
+      apiKeyRepository: options.apiKeyRepository ?? apiKeyRepository,
+      orgMemberRepository: options.orgMemberRepository ?? orgMemberRepository,
+    }),
+  ];
+  const requireMasterKey = [
+    authGuard,
+    createMasterKeyAuth({
+      masterKey: /** @type {string} */ (options.masterKey) ?? process.env.TRIVELA_MASTER_KEY ?? '',
+    }),
+  ];
+  const requireAdminMasterKey = requireMasterKey;
+
   let rateLimitStore = null;
+  let usageRedisClient = null;
   const redisUrl = process.env.REDIS_URL || process.env.REDIS_HOST;
   if (redisUrl && !options.disableRedis) {
     try {
@@ -277,11 +429,64 @@ export async function createApp(options = {}) {
         log.error({ err }, 'Redis connection error');
       });
       rateLimitStore = createRedisStore(redisClient);
-      log.info({ redisUrl: redisUrl.replace(/:[^:@]+@/, ':***@') }, 'Rate limiter using Redis store');
+      usageRedisClient = redisClient;
+      log.info(
+        { redisUrl: redisUrl.replace(/:[^:@]+@/, ':***@') },
+        'Rate limiter using Redis store',
+      );
     } catch (error) {
-      log.warn({ err: error }, 'Failed to connect to Redis, falling back to in-memory rate limiter');
+      log.warn(
+        { err: error },
+        'Failed to connect to Redis, falling back to in-memory rate limiter',
+      );
     }
   }
+
+  // Distributed lock — Redis when available, in-process Map otherwise (#564)
+  const lockTtlMs = normalizePositiveInteger(
+    /** @type {any} */ (options.lockTtlMs) ?? process.env.LOCK_TTL_MS,
+    30_000,
+  );
+  const lockProvider =
+    options.lockProvider ??
+    (usageRedisClient
+      ? createDistributedLock(usageRedisClient, { ttlMs: lockTtlMs })
+      : createInMemoryLock({ ttlMs: lockTtlMs }));
+
+  // Data export job — daily CSV export to object storage (#562)
+  const exportRetentionDays = normalizePositiveInteger(
+    /** @type {any} */ (options.exportRetentionDays) ?? process.env.EXPORT_RETENTION_DAYS,
+    30,
+  );
+  const exportJob = createExportJob({
+    db: dal.db,
+    storage: storageAdapter,
+    logger: log,
+    retentionDays: exportRetentionDays,
+    uploadDir: process.env.UPLOAD_DIR ?? './uploads',
+  });
+
+  const eventIndexer = createEventIndexer({
+    db: dal.db,
+    rpcPool,
+    logger: log,
+    referralBonus: normalizePositiveInteger(
+      /** @type {any} */ (options.referralBonus) ?? process.env.REFERRAL_BONUS,
+      0,
+    ),
+  });
+
+  // Durable job queue store — persistent across restarts (#565)
+  const jobQueueStore = createSqliteJobQueueRepository({ db: dal.db });
+
+  const usageMeteringService = createUsageMeteringService({
+    usageRepository,
+    redisClient: usageRedisClient ?? /** @type {any} */ (options.usageRedisClient) ?? null,
+    timeProvider: /** @type {any} */ (options.usageMeteringService)?.timeProvider,
+  });
+  const stopUsageFlush = usageMeteringService.startFlushInterval();
+
+  const usageMeteringMiddleware = createUsageMeteringMiddleware({ usageMeteringService });
 
   const rateLimiter = createRateLimiter({
     windowMs: rateLimitWindowMs,
@@ -303,42 +508,72 @@ export async function createApp(options = {}) {
   if ((process.env.STORAGE_BACKEND ?? 'local') === 'local') {
     app.use('/uploads', express.static(uploadDir));
   }
-  app.use((/** @type {any} */ err, /** @type {import('express').Request} */ _req, /** @type {import('express').Response} */ res, /** @type {import('express').NextFunction} */ next) => {
-    if (err?.type === 'entity.too.large') {
-      return res.status(413).json({ error: 'Request body too large', code: 'PAYLOAD_TOO_LARGE' });
-    }
-    return next(err);
-  });
-  app.use((/** @type {import('express').Request} */ req, /** @type {import('express').Response} */ res, /** @type {import('express').NextFunction} */ next) => {
-    metrics.requestTotal += 1;
-    res.on('finish', () => {
-      const routeKey = `${req.method} ${req.path}`;
-      metrics.routeHits.set(routeKey, (metrics.routeHits.get(routeKey) ?? 0) + 1);
-      if (res.statusCode >= 400) {
-        metrics.requestErrors += 1;
+  app.use(
+    (
+      /** @type {any} */ err,
+      /** @type {import('express').Request} */ _req,
+      /** @type {import('express').Response} */ res,
+      /** @type {import('express').NextFunction} */ next,
+    ) => {
+      if (err?.type === 'entity.too.large') {
+        return res.status(413).json({ error: 'Request body too large', code: 'PAYLOAD_TOO_LARGE' });
       }
-    });
-    next();
-  });
+      return next(err);
+    },
+  );
+  app.use(
+    (
+      /** @type {import('express').Request} */ req,
+      /** @type {import('express').Response} */ res,
+      /** @type {import('express').NextFunction} */ next,
+    ) => {
+      metrics.requestTotal += 1;
+      const _reqStart = Date.now();
+      res.on('finish', () => {
+        const routeKey = `${req.method} ${req.path}`;
+        metrics.routeHits.set(routeKey, (metrics.routeHits.get(routeKey) ?? 0) + 1);
+        if (res.statusCode >= 400) {
+          metrics.requestErrors += 1;
+        }
+        // Record request duration into the latency histogram.
+        const durationMs = Date.now() - _reqStart;
+        metrics.latencySum += durationMs;
+        metrics.latencyTotal += 1;
+        for (let _bi = 0; _bi < metrics.latencyBuckets.length; _bi++) {
+          if (durationMs <= metrics.latencyBuckets[_bi]) {
+            metrics.latencyCounts[_bi] += 1;
+            break;
+          }
+        }
+      });
+      next();
+    },
+  );
 
   const SCHEMA_VERSION_HEADER = 'X-Trivela-Schema-Version';
   const SCHEMA_VERSION = '1';
 
-  app.use((/** @type {import('express').Request} */ req, /** @type {import('express').Response} */ res, /** @type {import('express').NextFunction} */ next) => {
-    res.setHeader(SCHEMA_VERSION_HEADER, SCHEMA_VERSION);
+  app.use(
+    (
+      /** @type {import('express').Request} */ req,
+      /** @type {import('express').Response} */ res,
+      /** @type {import('express').NextFunction} */ next,
+    ) => {
+      res.setHeader(SCHEMA_VERSION_HEADER, SCHEMA_VERSION);
 
-    const requestedVersion = req.get(SCHEMA_VERSION_HEADER);
-    if (requestedVersion && requestedVersion !== SCHEMA_VERSION) {
-      return res.status(400).json({
-        error: 'Unsupported API schema version',
-        code: 'UNSUPPORTED_SCHEMA_VERSION',
-        supported: SCHEMA_VERSION,
-        requested: requestedVersion,
-      });
-    }
+      const requestedVersion = req.get(SCHEMA_VERSION_HEADER);
+      if (requestedVersion && requestedVersion !== SCHEMA_VERSION) {
+        return res.status(400).json({
+          error: 'Unsupported API schema version',
+          code: 'UNSUPPORTED_SCHEMA_VERSION',
+          supported: SCHEMA_VERSION,
+          requested: requestedVersion,
+        });
+      }
 
-    return next();
-  });
+      return next();
+    },
+  );
 
   const jobMaxAttempts = normalizePositiveInteger(
     /** @type {any} */ (options.jobMaxAttempts) ?? process.env.JOB_MAX_RETRIES,
@@ -372,9 +607,13 @@ export async function createApp(options = {}) {
       async webhook_retry_failed_deliveries() {
         await webhookService.retryFailedDeliveries();
       },
+      async data_export({ date }) {
+        await exportJob.run(date);
+      },
     },
     logger: log,
     deadLetter: failedJobRepository,
+    lockProvider,
     defaultMaxAttempts: jobMaxAttempts,
     defaultBaseDelayMs: jobBaseDelayMs,
     defaultMaxDelayMs: jobMaxDelayMs,
@@ -389,14 +628,34 @@ export async function createApp(options = {}) {
   if (!options.disableJobs) {
     const webhookRetryIntervalMs = 5 * 60 * 1000; // 5 minutes
     jobRunner.enqueue('webhook_retry_failed_deliveries', null);
-    setInterval(() => jobRunner.enqueue('webhook_retry_failed_deliveries', null), webhookRetryIntervalMs).unref?.();
+    setInterval(
+      () => jobRunner.enqueue('webhook_retry_failed_deliveries', null),
+      webhookRetryIntervalMs,
+    ).unref?.();
+  }
+
+  // Daily data export — idempotent, safe to fire on every startup (#562)
+  if (!options.disableJobs) {
+    const doExport = () =>
+      jobRunner.enqueue('data_export', { date: new Date().toISOString().slice(0, 10) });
+    doExport();
+    setInterval(doExport, 24 * 60 * 60 * 1_000).unref?.();
+  }
+
+  // Durable job queue — starts poll loop and recovers stale jobs from prior crashes (#565)
+  const durableJobQueue = createDurableJobQueue({
+    store: jobQueueStore,
+    handlers: {},
+    logger: log,
+    deadLetter: failedJobRepository,
+  });
+  if (!options.disableJobs) {
+    durableJobQueue.start();
   }
 
   async function buildHealthPayload() {
     const rpcUrl = rpcPool.getHealthyRpcUrl();
-    const rpc =
-      rpcHealthCache.payload ??
-      (await checkSorobanRpcHealth({ rpcUrl, fetchImpl }));
+    const rpc = rpcHealthCache.payload ?? (await checkSorobanRpcHealth({ rpcUrl, fetchImpl }));
 
     return {
       status: /** @type {any} */ (rpc).status === 'ok' ? 'ok' : 'degraded',
@@ -428,6 +687,7 @@ export async function createApp(options = {}) {
         entity,
         entityId,
         diff,
+        orgId: req.auth?.orgId || null,
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
@@ -435,10 +695,39 @@ export async function createApp(options = {}) {
     }
   }
 
+  let isShuttingDown = false;
+
   app.get('/health', async (_req, res) => {
     const payload = await buildHealthPayload();
     res.json(payload);
   });
+
+  app.get('/ready', (_req, res) => {
+    if (isShuttingDown) {
+      return res.status(503).json({ status: 'shutting_down', ready: false });
+    }
+    return res.json({ status: 'ok', ready: true });
+  });
+
+  const siteOrigin =
+    process.env.SITE_ORIGIN ?? allowedOrigins.find((origin) => origin !== '*') ?? '';
+
+  // Embed endpoints use a tighter per-IP rate limit (30 req/min) to guard
+  // against scraping while still allowing reasonable widget traffic.
+  const embedRateLimiter = createRateLimiter({
+    windowMs: rateLimitWindowMs,
+    maxRequests: Math.min(30, rateLimitMaxRequests),
+    timeProvider: /** @type {any} */ (options.rateLimit)?.timeProvider,
+    store: rateLimitStore,
+  });
+
+  app.get(
+    '/embed/campaign/:id',
+    embedRateLimiter,
+    createEmbedRoute(campaignRepository, siteOrigin, {
+      embedSecret: process.env.EMBED_ATTRIBUTION_SECRET,
+    }),
+  );
 
   app.get('/health/rpc', async (_req, res) => {
     const rpcUrl = rpcPool.getHealthyRpcUrl();
@@ -452,6 +741,18 @@ export async function createApp(options = {}) {
     });
   });
 
+  app.get('/health/indexer', (_req, res) => {
+    const health = eventIndexer?.getHealth?.() ?? {
+      status: 'unavailable',
+      lastLedger: 0,
+      lagLedgers: 0,
+      eventsTotal: 0,
+      errorsTotal: 0,
+    };
+    const isHealthy = health.status === 'ok' || health.status === 'idle';
+    res.status(isHealthy ? 200 : 503).json(health);
+  });
+
   app.get('/metrics', (_req, res) => {
     const uptimeSeconds = process.uptime();
     const routeLines = [...metrics.routeHits.entries()]
@@ -461,6 +762,18 @@ export async function createApp(options = {}) {
       })
       .join('\n');
 
+    // Latency histogram — cumulative buckets (le = upper bound in ms).
+    const latencyBucketLines = metrics.latencyBuckets
+      .map((le, i) => {
+        const cumulative = metrics.latencyCounts.slice(0, i + 1).reduce((a, b) => a + b, 0);
+        const leLabel = le === Infinity ? '+Inf' : String(le);
+        return `trivela_http_request_duration_ms_bucket{le="${leLabel}"} ${cumulative}`;
+      })
+      .join('\n');
+
+    // RPC pool saturation metrics.
+    const poolStatus = rpcPool.getStatus();
+
     const payload = [
       '# HELP trivela_requests_total Total HTTP requests handled.',
       '# TYPE trivela_requests_total counter',
@@ -468,12 +781,46 @@ export async function createApp(options = {}) {
       '# HELP trivela_request_errors_total Total HTTP requests with status >= 400.',
       '# TYPE trivela_request_errors_total counter',
       `trivela_request_errors_total ${metrics.requestErrors}`,
+      '# HELP trivela_auth_failures_total Total failed authentication attempts on guarded routes.',
+      '# TYPE trivela_auth_failures_total counter',
+      `trivela_auth_failures_total ${metrics.authFailures}`,
+      '# HELP trivela_auth_lockouts_total Total brute-force lockouts triggered on guarded routes.',
+      '# TYPE trivela_auth_lockouts_total counter',
+      `trivela_auth_lockouts_total ${metrics.authLockouts}`,
       '# HELP trivela_process_uptime_seconds Node.js process uptime.',
       '# TYPE trivela_process_uptime_seconds gauge',
       `trivela_process_uptime_seconds ${uptimeSeconds.toFixed(3)}`,
       '# HELP trivela_route_hits_total Route-level request counts.',
       '# TYPE trivela_route_hits_total counter',
       routeLines,
+      // Request latency histogram (issue #650 — p95 latency SLO).
+      '# HELP trivela_http_request_duration_ms HTTP request duration in milliseconds.',
+      '# TYPE trivela_http_request_duration_ms histogram',
+      latencyBucketLines,
+      `trivela_http_request_duration_ms_count ${metrics.latencyTotal}`,
+      `trivela_http_request_duration_ms_sum ${metrics.latencySum}`,
+      // RPC pool saturation (issue #650 — pool saturation safety).
+      '# HELP trivela_rpc_pool_in_use RPC pool slots currently in use.',
+      '# TYPE trivela_rpc_pool_in_use gauge',
+      `trivela_rpc_pool_in_use ${poolStatus.in_use}`,
+      '# HELP trivela_rpc_pool_idle RPC pool slots immediately available.',
+      '# TYPE trivela_rpc_pool_idle gauge',
+      `trivela_rpc_pool_idle ${poolStatus.idle}`,
+      '# HELP trivela_rpc_pool_waiting Callers queued waiting for a pool slot.',
+      '# TYPE trivela_rpc_pool_waiting gauge',
+      `trivela_rpc_pool_waiting ${poolStatus.waiting}`,
+      '# HELP trivela_rpc_pool_healthy Healthy RPC endpoints in the pool.',
+      '# TYPE trivela_rpc_pool_healthy gauge',
+      `trivela_rpc_pool_healthy ${poolStatus.healthy}`,
+      '# HELP trivela_rpc_pool_unhealthy Unhealthy RPC endpoints in the pool.',
+      '# TYPE trivela_rpc_pool_unhealthy gauge',
+      `trivela_rpc_pool_unhealthy ${poolStatus.unhealthy}`,
+      // Indexer metrics (#532).
+      ...Object.entries(eventIndexer?.getMetrics?.() ?? {}).map(([key, value]) => [
+        `# HELP ${key.replace(/_/g, ' ')} Indexer metric.`,
+        `# TYPE ${key} gauge`,
+        `${key} ${value}`,
+      ]).flat(),
     ]
       .filter(Boolean)
       .join('\n');
@@ -493,6 +840,7 @@ export async function createApp(options = {}) {
       prefix: API_V1_PREFIX,
       endpoints: {
         health: 'GET /health',
+        ready: 'GET /ready',
         healthRpc: 'GET /health/rpc',
         metrics: 'GET /metrics',
         info: `GET ${API_V1_PREFIX}`,
@@ -500,16 +848,21 @@ export async function createApp(options = {}) {
         campaignById: `GET ${API_V1_PREFIX}/campaigns/:id`,
         campaignBySlug: `GET ${API_V1_PREFIX}/campaigns/by-slug/:slug`,
         createCampaign: `POST ${API_V1_PREFIX}/campaigns`,
+        cloneCampaign: `POST ${API_V1_PREFIX}/campaigns/:id/clone`,
         updateCampaign: `PUT ${API_V1_PREFIX}/campaigns/:id`,
         deleteCampaign: `DELETE ${API_V1_PREFIX}/campaigns/:id`,
         auditLogs: `GET ${API_V1_PREFIX}/audit-logs`,
+        usage: `GET ${API_V1_PREFIX}/usage`,
+        adminUsage: `GET ${API_V1_PREFIX}/admin/usage`,
+        adminUsageQuotas: `PUT ${API_V1_PREFIX}/admin/usage/quotas`,
         config: `GET ${API_V1_PREFIX}/config`,
         explorer: `GET ${API_V1_PREFIX}/explorer`,
       },
       compatibility: {
         legacyPrefix: LEGACY_API_PREFIX,
         legacyRoutesSupported: true,
-        migrationNote: 'Prefer /api/v1/* routes. Legacy /api/* routes remain available for compatibility.',
+        migrationNote:
+          'Prefer /api/v1/* routes. Legacy /api/* routes remain available for compatibility.',
         usingLegacyPrefix,
       },
       stellar: {
@@ -526,6 +879,12 @@ export async function createApp(options = {}) {
         keying: 'per API key when present, otherwise per IP address',
         windowMs: rateLimitWindowMs,
         maxRequests: rateLimitMaxRequests,
+      },
+      authLockout: {
+        keying: 'per client IP address',
+        softThreshold: authLockoutSoftThreshold,
+        hardThreshold: authLockoutHardThreshold,
+        baseLockoutMs: authLockoutBaseMs,
       },
       body: {
         jsonLimit: jsonBodyLimit,
@@ -564,20 +923,93 @@ export async function createApp(options = {}) {
 
     const activeRaw =
       typeof req.query.active === 'string' ? req.query.active.toLowerCase() : undefined;
-    const activeFilter =
-      activeRaw === 'true' ? true : activeRaw === 'false' ? false : undefined;
+    const activeFilter = activeRaw === 'true' ? true : activeRaw === 'false' ? false : undefined;
     const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
     const sort = typeof req.query.sort === 'string' ? req.query.sort : undefined;
-    const order = req.query.order === 'asc' ? 'asc' : req.query.order === 'desc' ? 'desc' : undefined;
+    const order =
+      req.query.order === 'asc' ? 'asc' : req.query.order === 'desc' ? 'desc' : undefined;
     const category = typeof req.query.category === 'string' ? req.query.category.trim() : undefined;
     const tagsRaw = typeof req.query.tags === 'string' ? req.query.tags.trim() : '';
-    const tags = tagsRaw ? tagsRaw.split(',').map((t) => t.trim()).filter(Boolean) : undefined;
-    const items = campaignRepository.list({ active: activeFilter, q, sort, order, category, tags });
-    const payload = paginateItems(items, req.query);
+    const tags = tagsRaw
+      ? tagsRaw
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean)
+      : undefined;
+
+    // Status filtering (Issue #457)
+    // By default, only show published campaigns to public API
+    // API key holders can request draft/archived/all statuses
+    const statusRaw = typeof req.query.status === 'string' ? req.query.status.trim() : undefined;
+    const hasApiKey = req.context?.apiKeyRecord !== undefined;
+    let status = statusRaw;
+
+    if (statusRaw && ['draft', 'archived', 'all'].includes(statusRaw) && !hasApiKey) {
+      // Require API key for non-published statuses
+      return res.status(401).json({
+        error: 'API key required to access draft, archived, or all campaigns',
+        code: 'UNAUTHORIZED',
+      });
+    }
+
+    // Default to published only for public API
+    if (!status && !hasApiKey) {
+      status = 'published';
+    }
+
+    // Handle urgency sorting separately since it requires application-level logic
+    const isUrgencySort = sort === 'urgency';
+    const dbSort = isUrgencySort ? undefined : sort;
+    const dbOrder = isUrgencySort ? undefined : order;
+
+    const items = campaignRepository.list({
+      active: activeFilter,
+      q,
+      sort: dbSort,
+      order: dbOrder,
+      category,
+      tags,
+      status,
+    });
+
+    // Apply urgency sorting if requested
+    let sortedItems = items;
+    if (isUrgencySort) {
+      const { sortByUrgency } = await import('./utils/urgency.js');
+      sortedItems = sortByUrgency(items);
+    }
+
+    const payload = paginateItems(sortedItems, req.query);
     shortCache.set(cacheKey, {
       expiresAt: Date.now() + shortCacheTtlMs,
       payload,
     });
+    res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
+    return res.set('x-cache', 'MISS').json(payload);
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function getTrendingCampaigns(req, res) {
+    const limitRaw = Number.parseInt(String(req.query.limit ?? '6'), 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 && limitRaw <= 50 ? limitRaw : 6;
+
+    const cacheKey = `trending:${limit}`;
+    const cached = shortCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
+      return res.set('x-cache', 'HIT').json(cached.payload);
+    }
+
+    const all = campaignRepository.list({
+      active: true,
+      sort: 'reward_per_action',
+      order: 'desc',
+    });
+    const data = all.slice(0, limit);
+    const payload = { data, total: data.length };
+
+    shortCache.set(cacheKey, { expiresAt: Date.now() + shortCacheTtlMs, payload });
+    res.set('Cache-Control', 'public, max-age=60, stale-while-revalidate=120');
     return res.set('x-cache', 'MISS').json(payload);
   }
 
@@ -629,8 +1061,22 @@ export async function createApp(options = {}) {
     }
 
     const {
-      name, slug, description, rewardPerAction, referralBonusPoints, startDate, endDate,
-      featured, hidden, hiddenReason, active, contractId, imageUrl, tags, category,
+      name,
+      slug,
+      description,
+      rewardPerAction,
+      referralBonusPoints,
+      startDate,
+      endDate,
+      featured,
+      hidden,
+      hiddenReason,
+      active,
+      contractId,
+      imageUrl,
+      tags,
+      category,
+      status,
     } = result.data;
     try {
       const campaign = campaignRepository.create({
@@ -649,6 +1095,7 @@ export async function createApp(options = {}) {
         imageUrl: imageUrl ?? null,
         tags: tags ?? [],
         category: category ?? null,
+        status: status ?? 'draft',
       });
       recordAuditEntry(req, {
         action: 'create',
@@ -658,20 +1105,34 @@ export async function createApp(options = {}) {
       });
 
       // Dispatch webhook event (Issue #287)
-      webhookService.dispatchEvent({
-        type: WEBHOOK_EVENTS.CAMPAIGN_CREATED,
-        campaignId: campaign.id,
-        data: campaign,
-        timestamp: new Date().toISOString(),
-      }).catch((err) => {
-        log.warn({ err, campaignId: campaign.id }, 'Failed to dispatch campaign.created webhook');
-      });
+      webhookService
+        .dispatchEvent({
+          type: WEBHOOK_EVENTS.CAMPAIGN_CREATED,
+          campaignId: campaign.id,
+          data: campaign,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn({ err, campaignId: campaign.id }, 'Failed to dispatch campaign.created webhook');
+        });
+
+      // Notify WebSocket clients about new campaign (Issue #456)
+      const wsServer = getWebSocketServer();
+      if (wsServer) {
+        wsServer.broadcast('campaigns', {
+          type: 'campaign_created',
+          campaign,
+          timestamp: new Date().toISOString(),
+        });
+      }
 
       shortCache.clear();
       return res.status(201).json(campaign);
     } catch (error) {
-      if (/** @type {any} */ (error).message?.includes('Tag')
-        || /** @type {any} */ (error).message?.includes('Category')) {
+      if (
+        /** @type {any} */ (error).message?.includes('Tag') ||
+        /** @type {any} */ (error).message?.includes('Category')
+      ) {
         return res.status(400).json({
           error: /** @type {Error} */ (error).message,
           code: 'VALIDATION_ERROR',
@@ -700,8 +1161,21 @@ export async function createApp(options = {}) {
     }
 
     const {
-      name, description, active, rewardPerAction, referralBonusPoints, startDate, endDate,
-      featured, hidden, hiddenReason, contractId, imageUrl, tags, category,
+      name,
+      description,
+      active,
+      rewardPerAction,
+      referralBonusPoints,
+      startDate,
+      endDate,
+      featured,
+      hidden,
+      hiddenReason,
+      contractId,
+      imageUrl,
+      tags,
+      category,
+      status,
     } = result.data;
     /** @type {Record<string, unknown>} */
     const updateFields = {};
@@ -719,6 +1193,7 @@ export async function createApp(options = {}) {
     if (imageUrl !== undefined) updateFields.imageUrl = imageUrl;
     if (tags !== undefined) updateFields.tags = tags;
     if (category !== undefined) updateFields.category = category;
+    if (status !== undefined) updateFields.status = status;
 
     const before = campaignRepository.getById(req.params.id);
     if (!before) {
@@ -729,8 +1204,10 @@ export async function createApp(options = {}) {
     try {
       campaign = campaignRepository.update(req.params.id, updateFields);
     } catch (error) {
-      if (/** @type {any} */ (error).message?.includes('Tag')
-        || /** @type {any} */ (error).message?.includes('Category')) {
+      if (
+        /** @type {any} */ (error).message?.includes('Tag') ||
+        /** @type {any} */ (error).message?.includes('Category')
+      ) {
         return res.status(400).json({
           error: /** @type {Error} */ (error).message,
           code: 'VALIDATION_ERROR',
@@ -753,27 +1230,46 @@ export async function createApp(options = {}) {
     // Dispatch webhook events (Issue #290, #352)
     const wasActive = before.active;
     const isNowActive = campaign.active;
-    
+
     if (active !== undefined && wasActive !== isNowActive) {
       // Dispatch activation/deactivation event
-      const eventType = isNowActive ? WEBHOOK_EVENTS.CAMPAIGN_ACTIVATED : WEBHOOK_EVENTS.CAMPAIGN_DEACTIVATED;
-      webhookService.dispatchEvent({
-        type: eventType,
-        campaignId: campaign.id,
-        data: campaign,
-        timestamp: new Date().toISOString(),
-      }).catch((err) => {
-        log.warn({ err, campaignId: campaign.id, eventType }, 'Failed to dispatch campaign activation/deactivation webhook');
-      });
+      const eventType = isNowActive
+        ? WEBHOOK_EVENTS.CAMPAIGN_ACTIVATED
+        : WEBHOOK_EVENTS.CAMPAIGN_DEACTIVATED;
+      webhookService
+        .dispatchEvent({
+          type: eventType,
+          campaignId: campaign.id,
+          data: campaign,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn(
+            { err, campaignId: campaign.id, eventType },
+            'Failed to dispatch campaign activation/deactivation webhook',
+          );
+        });
     } else {
       // Dispatch generic update event
-      webhookService.dispatchEvent({
-        type: WEBHOOK_EVENTS.CAMPAIGN_UPDATED,
-        campaignId: campaign.id,
-        data: campaign,
-        timestamp: new Date().toISOString(),
-      }).catch((err) => {
-        log.warn({ err, campaignId: campaign.id }, 'Failed to dispatch campaign.updated webhook');
+      webhookService
+        .dispatchEvent({
+          type: WEBHOOK_EVENTS.CAMPAIGN_UPDATED,
+          campaignId: campaign.id,
+          data: campaign,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn({ err, campaignId: campaign.id }, 'Failed to dispatch campaign.updated webhook');
+        });
+    }
+
+    // Notify WebSocket clients about campaign update (Issue #456)
+    const wsServer = getWebSocketServer();
+    if (wsServer) {
+      wsServer.notifyCampaignUpdate(campaign.id, {
+        campaign,
+        changes,
+        before,
       });
     }
 
@@ -797,18 +1293,144 @@ export async function createApp(options = {}) {
 
     // Dispatch webhook event (Issue #285)
     if (before) {
-      webhookService.dispatchEvent({
-        type: WEBHOOK_EVENTS.CAMPAIGN_DELETED,
-        campaignId: req.params.id,
-        data: before,
-        timestamp: new Date().toISOString(),
-      }).catch((err) => {
-        log.warn({ err, campaignId: req.params.id }, 'Failed to dispatch campaign.deleted webhook');
-      });
+      webhookService
+        .dispatchEvent({
+          type: WEBHOOK_EVENTS.CAMPAIGN_DELETED,
+          campaignId: req.params.id,
+          data: before,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn(
+            { err, campaignId: req.params.id },
+            'Failed to dispatch campaign.deleted webhook',
+          );
+        });
     }
 
     shortCache.clear();
     return res.status(204).end();
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function cloneCampaign(req, res) {
+    const sourceId = req.params.id;
+    const source = campaignRepository.getById(sourceId);
+
+    if (!source) {
+      return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+    }
+
+    const overrides = req.body?.overrides || {};
+
+    try {
+      const clonedCampaign = campaignRepository.clone(sourceId, overrides);
+
+      if (!clonedCampaign) {
+        return res.status(500).json({ error: 'Failed to clone campaign', code: 'CLONE_FAILED' });
+      }
+
+      recordAuditEntry(req, {
+        action: 'clone',
+        entity: 'campaign',
+        entityId: clonedCampaign.id,
+        diff: { cloned_from: sourceId, overrides },
+      });
+
+      shortCache.clear();
+      return res.status(201).json(clonedCampaign);
+    } catch (error) {
+      if (/** @type {any} */ (error).message?.includes('UNIQUE constraint failed')) {
+        return res.status(409).json({
+          error: 'Slug already exists',
+          code: 'SLUG_CONFLICT',
+          details: ['A campaign with this slug already exists'],
+        });
+      }
+      throw error;
+    }
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function publishCampaign(req, res) {
+    const before = campaignRepository.getById(req.params.id);
+    if (!before) {
+      return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+    }
+
+    try {
+      const campaign = campaignRepository.publish(req.params.id);
+      recordAuditEntry(req, {
+        action: 'publish',
+        entity: 'campaign',
+        entityId: campaign.id,
+        diff: { before, after: campaign },
+      });
+
+      // Dispatch webhook event (Issue #457)
+      webhookService
+        .dispatchEvent({
+          type: 'campaign.published',
+          campaignId: campaign.id,
+          data: campaign,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn(
+            { err, campaignId: campaign.id },
+            'Failed to dispatch campaign.published webhook',
+          );
+        });
+
+      shortCache.clear();
+      return res.json(campaign);
+    } catch (error) {
+      return res.status(400).json({
+        error: /** @type {Error} */ (error).message,
+        code: 'PUBLISH_FAILED',
+      });
+    }
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function archiveCampaign(req, res) {
+    const before = campaignRepository.getById(req.params.id);
+    if (!before) {
+      return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+    }
+
+    try {
+      const campaign = campaignRepository.archive(req.params.id);
+      recordAuditEntry(req, {
+        action: 'archive',
+        entity: 'campaign',
+        entityId: campaign.id,
+        diff: { before, after: campaign },
+      });
+
+      // Dispatch webhook event (Issue #457)
+      webhookService
+        .dispatchEvent({
+          type: 'campaign.archived',
+          campaignId: campaign.id,
+          data: campaign,
+          timestamp: new Date().toISOString(),
+        })
+        .catch((err) => {
+          log.warn(
+            { err, campaignId: campaign.id },
+            'Failed to dispatch campaign.archived webhook',
+          );
+        });
+
+      shortCache.clear();
+      return res.json(campaign);
+    } catch (error) {
+      return res.status(400).json({
+        error: /** @type {Error} */ (error).message,
+        code: 'ARCHIVE_FAILED',
+      });
+    }
   }
 
   /** @param {import('express').Request} req @param {import('express').Response} res */
@@ -822,6 +1444,12 @@ export async function createApp(options = {}) {
       action: action || undefined,
     });
     return res.json(paginateItems(items, req.query));
+  }
+
+  /** @param {import('express').Request} _req @param {import('express').Response} res */
+  function verifyAuditChain(_req, res) {
+    const result = auditLogRepository.verify();
+    return res.status(result.valid ? 200 : 409).json(result);
   }
 
   /** @param {import('express').Request} _req @param {import('express').Response} res */
@@ -863,6 +1491,98 @@ export async function createApp(options = {}) {
   function listTags(_req, res) {
     const tags = campaignRepository.listTags?.() ?? [];
     return res.json({ data: tags });
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  async function getAdminDashboard(req, res) {
+    const cacheKey = 'admin:dashboard';
+    const cached = shortCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return res.set('x-cache', 'HIT').json(cached.payload);
+    }
+
+    // Campaign stats
+    const allCampaigns = campaignRepository.list({ includeHidden: true });
+    const totalCampaigns = allCampaigns.length;
+    const now = new Date();
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const campaignsByStatus = {
+      draft: allCampaigns.filter((c) => !c.active && c.hidden).length,
+      published: allCampaigns.filter((c) => c.active && !c.hidden).length,
+      archived: allCampaigns.filter((c) => !c.active && !c.hidden).length,
+    };
+
+    const campaignsCreatedLast7Days = allCampaigns.filter(
+      (c) => new Date(c.createdAt) >= sevenDaysAgo,
+    ).length;
+    const campaignsCreatedLast30Days = allCampaigns.filter(
+      (c) => new Date(c.createdAt) >= thirtyDaysAgo,
+    ).length;
+
+    // Participants (unique wallets from referrals)
+    const allReferrals = referralRepository.listAll?.() ?? [];
+    const uniqueParticipants = new Set();
+    for (const referral of allReferrals) {
+      uniqueParticipants.add(referral.refereeAddress);
+      uniqueParticipants.add(referral.referrerAddress);
+    }
+    const totalParticipants = uniqueParticipants.size;
+
+    // Rewards stats (placeholder - would need indexer event DB integration)
+    const rewards = {
+      totalPointsCredited: 0,
+      totalClaimed: 0,
+      redemptionRate: 0,
+    };
+
+    // Activity: registrations per day (last 30 days)
+    const activity = [];
+    for (let i = 29; i >= 0; i--) {
+      const date = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+      const dateStr = date.toISOString().split('T')[0];
+      const dayReferrals = allReferrals.filter((r) => r.createdAt.startsWith(dateStr)).length;
+      activity.push({ date: dateStr, registrations: dayReferrals });
+    }
+
+    // Errors from metrics (last 24h would need time-series tracking, using current total)
+    const errors = {
+      last24h: metrics.requestErrors,
+    };
+
+    // RPC pool status
+    const rpc = rpcPool.getStatus();
+
+    const payload = {
+      campaigns: {
+        total: totalCampaigns,
+        byStatus: campaignsByStatus,
+        createdLast7Days: campaignsCreatedLast7Days,
+        createdLast30Days: campaignsCreatedLast30Days,
+      },
+      participants: {
+        total: totalParticipants,
+      },
+      rewards,
+      activity,
+      errors,
+      rpc,
+      timestamp: now.toISOString(),
+    };
+
+    shortCache.set(cacheKey, {
+      expiresAt: Date.now() + 60000, // 60 seconds
+      payload,
+    });
+
+    return res.set('x-cache', 'MISS').json(payload);
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function listAdminCampaigns(req, res) {
+    const allCampaigns = campaignRepository.list({ includeHidden: true });
+    return res.json(paginateItems(allCampaigns, req.query));
   }
 
   /** @param {import('express').Request} req @param {import('express').Response} res */
@@ -927,6 +1647,8 @@ export async function createApp(options = {}) {
     const created = apiKeyRepository.create({
       label: result.data.label ?? '',
       expiresAt: result.data.expiresAt ?? null,
+      orgId: result.data.orgId ?? null,
+      scopes: result.data.scopes ?? undefined,
     });
 
     recordAuditEntry(req, {
@@ -970,7 +1692,9 @@ export async function createApp(options = {}) {
   function rotateApiKeyHandler(req, res) {
     const rotated = apiKeyRepository.rotate(req.params.id);
     if (!rotated) {
-      return res.status(404).json({ error: 'API key not found or already revoked', code: 'API_KEY_NOT_FOUND' });
+      return res
+        .status(404)
+        .json({ error: 'API key not found or already revoked', code: 'API_KEY_NOT_FOUND' });
     }
 
     recordAuditEntry(req, {
@@ -1006,9 +1730,7 @@ export async function createApp(options = {}) {
   function retryFailedJobHandler(req, res) {
     const entry = failedJobRepository.getById(req.params.id);
     if (!entry) {
-      return res
-        .status(404)
-        .json({ error: 'Failed job not found', code: 'FAILED_JOB_NOT_FOUND' });
+      return res.status(404).json({ error: 'Failed job not found', code: 'FAILED_JOB_NOT_FOUND' });
     }
 
     jobRunner.enqueue(entry.type, entry.payload);
@@ -1029,52 +1751,133 @@ export async function createApp(options = {}) {
 
   /** @param {string} prefix */
   function registerApiRoutes(prefix) {
+    // Shorthand: auth + per-tenant api_calls metering in one step.
+    const guard = [requireApiKey, usageMeteringMiddleware];
+
     app.get(prefix, rateLimiter, apiInfo);
     app.get(`${prefix}/config`, rateLimiter, getPublicConfig);
     app.get(`${prefix}/explorer`, rateLimiter, getExplorerLinks);
     app.get(`${prefix}/campaigns`, rateLimiter, listCampaigns);
     app.get(`${prefix}/categories`, rateLimiter, listCategories);
     app.get(`${prefix}/tags`, rateLimiter, listTags);
+    app.get(`${prefix}/campaigns/trending`, rateLimiter, getTrendingCampaigns);
     app.get(`${prefix}/campaigns/by-slug/:slug`, rateLimiter, getCampaignBySlug);
     app.get(`${prefix}/campaigns/:id`, rateLimiter, getCampaignById);
     app.get(`${prefix}/campaigns/:id/stats`, rateLimiter, getCampaignStats);
     app.use(prefix, createCampaignExportRoute({ db: dal.db, campaignRepository, auditLogRepository, requireApiKey }));
     app.get(`${prefix}/deprecations`, rateLimiter, (_req, res) => res.json({ deprecations: DEPRECATION_REGISTRY }));
-    app.get(`${prefix}/audit-logs`, rateLimiter, requireApiKey, listAuditLogs);
+    app.get(`${prefix}/audit-logs`, rateLimiter, ...guard, listAuditLogs);
+    app.get(`${prefix}/admin/audit/verify`, rateLimiter, requireMasterKey, verifyAuditChain);
     app.get(`${prefix}/indexer/cursor`, rateLimiter, getIndexerCursorState);
-    app.post(`${prefix}/indexer/cursor`, rateLimiter, requireApiKey, setIndexerCursorState);
-    app.post(`${prefix}/campaigns`, rateLimiter, requireApiKey, createCampaign);
-    app.post(
-      `${prefix}/campaigns/:id/image`,
-      rateLimiter,
-      requireApiKey,
-      (req, res, next) => {
-        imageUpload.single('image')(req, res, (err) => {
-          if (err?.code === 'LIMIT_FILE_SIZE') {
-            return res.status(400).json({
-              error: 'Image must be 5MB or smaller',
-              code: 'FILE_TOO_LARGE',
-            });
-          }
-          if (err) return next(err);
-          return uploadCampaignImageHandler(req, res);
-        });
-      },
-    );
-    app.put(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, updateCampaign);
+    app.post(`${prefix}/indexer/cursor`, rateLimiter, ...guard, setIndexerCursorState);
+    app.post(`${prefix}/campaigns`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), createCampaign);
+    app.post(`${prefix}/campaigns/:id/clone`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), cloneCampaign);
+    app.post(`${prefix}/campaigns/:id/image`, rateLimiter, ...guard, requireScope('campaigns:write'), (req, res, next) => {
+      imageUpload.single('image')(req, res, (err) => {
+        if (err?.code === 'LIMIT_FILE_SIZE') {
+          return res.status(400).json({
+            error: 'Image must be 5MB or smaller',
+            code: 'FILE_TOO_LARGE',
+          });
+        }
+        if (err) return next(err);
+        return uploadCampaignImageHandler(req, res);
+      });
+    });
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, ...guard, requireScope('campaigns:write'), updateCampaign);
+    app.delete(`${prefix}/campaigns/:id`, rateLimiter, ...guard, requireScope('campaigns:write'), deleteCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, requireApiKey, updateCampaign);
+    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, idempotencyMiddleware, requireApiKey, publishCampaign);
+    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, idempotencyMiddleware, requireApiKey, archiveCampaign);
     app.delete(`${prefix}/campaigns/:id`, rateLimiter, requireApiKey, deleteCampaign);
+    app.put(`${prefix}/campaigns/:id`, rateLimiter, idempotencyMiddleware, ...guard, updateCampaign);
+    app.put(`${prefix}/campaigns/:id/publish`, rateLimiter, idempotencyMiddleware, ...guard, publishCampaign);
+    app.put(`${prefix}/campaigns/:id/archive`, rateLimiter, idempotencyMiddleware, ...guard, archiveCampaign);
+    app.delete(`${prefix}/campaigns/:id`, rateLimiter, ...guard, deleteCampaign);
 
-    app.post(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, createApiKeyHandler);
+    app.post(`${prefix}/admin/api-keys`, rateLimiter, idempotencyMiddleware, requireMasterKey, createApiKeyHandler);
     app.get(`${prefix}/admin/api-keys`, rateLimiter, requireMasterKey, listApiKeysHandler);
     app.delete(`${prefix}/admin/api-keys/:id`, rateLimiter, requireMasterKey, revokeApiKeyHandler);
-    app.put(`${prefix}/admin/api-keys/:id/rotate`, rateLimiter, requireMasterKey, rotateApiKeyHandler);
+    app.put(
+      `${prefix}/admin/api-keys/:id/rotate`,
+      rateLimiter,
+      idempotencyMiddleware,
+      requireMasterKey,
+      rotateApiKeyHandler,
+    );
+
+    // Admin dashboard and campaign management (Issue #467)
+    app.get(`${prefix}/admin/dashboard`, rateLimiter, requireMasterKey, getAdminDashboard);
+    app.get(`${prefix}/admin/campaigns`, rateLimiter, requireMasterKey, listAdminCampaigns);
+
+    // Tenant usage metering (Issue #574)
+    app.get(`${prefix}/usage`, rateLimiter, ...guard, (req, res) => {
+      const orgId = req.auth?.orgId;
+      if (!orgId) {
+        return res.status(403).json({
+          error: 'Usage data is scoped to org-linked API keys.',
+          code: 'NO_ORG_CONTEXT',
+        });
+      }
+      const usage = usageMeteringService.getOrgUsage(orgId);
+      return res.json({ orgId, usage });
+    });
+
+    app.get(`${prefix}/admin/usage`, rateLimiter, requireMasterKey, (_req, res) => {
+      const rows = usageMeteringService.adminExport();
+      return res.json({ usage: rows });
+    });
+
+    app.put(`${prefix}/admin/usage/quotas`, rateLimiter, requireMasterKey, (req, res) => {
+      const {
+        orgId,
+        resource,
+        softLimit = null,
+        hardLimit = null,
+        windowSeconds = 3600,
+      } = req.body ?? {};
+      if (!orgId || !resource) {
+        return res.status(400).json({
+          error: 'orgId and resource are required',
+          code: 'VALIDATION_ERROR',
+        });
+      }
+      const quota = usageRepository.upsertQuota({
+        orgId,
+        resource,
+        softLimit,
+        hardLimit,
+        windowSeconds,
+      });
+      return res.json(quota);
+    });
 
     // Job dead-letter inspection / requeue (Issue #286)
-    app.get(`${prefix}/jobs/failed`, rateLimiter, requireApiKey, listFailedJobsHandler);
-    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, requireApiKey, retryFailedJobHandler);
+    app.get(`${prefix}/jobs/failed`, rateLimiter, ...guard, listFailedJobsHandler);
+    app.post(`${prefix}/jobs/retry/:id`, rateLimiter, idempotencyMiddleware, ...guard, retryFailedJobHandler);
+
+    // Durable job queue DLQ admin — inspect and replay dead jobs (#565)
+    app.get(`${prefix}/admin/jobs/dlq`, rateLimiter, requireMasterKey, (req, res) => {
+      const limit = Math.min(parseInt(/** @type {any} */ (req.query.limit)) || 100, 500);
+      const offset = Math.max(parseInt(/** @type {any} */ (req.query.offset)) || 0, 0);
+      const items = jobQueueStore.listDead({ limit, offset });
+      const total = jobQueueStore.countDead();
+      return res.json({ data: items, pagination: { total, count: items.length, limit, offset } });
+    });
+
+    app.post(`${prefix}/admin/jobs/:id/replay`, rateLimiter, idempotencyMiddleware, requireMasterKey, async (req, res) => {
+      const job = jobQueueStore.getById(req.params.id);
+      if (!job) {
+        return res.status(404).json({ error: 'Job not found', code: 'JOB_NOT_FOUND' });
+      }
+      durableJobQueue.enqueue(job.type, job.payload);
+      jobQueueStore.removeById(job.id);
+      recordAuditEntry(req, { action: 'replay', entity: 'durableJob', entityId: job.id });
+      return res.status(202).json({ requeued: true, job: { id: job.id, type: job.type } });
+    });
 
     // Webhook routes (Issue #287)
-    app.post(`${prefix}/webhooks`, rateLimiter, requireApiKey, (req, res) => {
+    app.post(`${prefix}/webhooks`, rateLimiter, idempotencyMiddleware, ...guard, (req, res) => {
       const { url, events, secret } = req.body;
       if (!url || !Array.isArray(events) || events.length === 0) {
         return res.status(400).json({
@@ -1093,12 +1896,12 @@ export async function createApp(options = {}) {
       return res.status(201).json(webhook);
     });
 
-    app.get(`${prefix}/webhooks`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks`, rateLimiter, ...guard, (req, res) => {
       const webhooks = webhookRepository.list();
       return res.json(paginateItems(webhooks, req.query));
     });
 
-    app.get(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
       const webhook = webhookRepository.getById(req.params.id);
       if (!webhook) {
         return res.status(404).json({ error: 'Webhook not found', code: 'WEBHOOK_NOT_FOUND' });
@@ -1106,7 +1909,7 @@ export async function createApp(options = {}) {
       return res.json(webhook);
     });
 
-    app.put(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.put(`${prefix}/webhooks/:id`, rateLimiter, idempotencyMiddleware, ...guard, (req, res) => {
       const { url, events, active } = req.body;
       const before = webhookRepository.getById(req.params.id);
       if (!before) {
@@ -1126,7 +1929,7 @@ export async function createApp(options = {}) {
       return res.json(webhook);
     });
 
-    app.delete(`${prefix}/webhooks/:id`, rateLimiter, requireApiKey, (req, res) => {
+    app.delete(`${prefix}/webhooks/:id`, rateLimiter, ...guard, (req, res) => {
       const before = webhookRepository.getById(req.params.id);
       const deleted = webhookRepository.delete(req.params.id);
       if (!deleted) {
@@ -1141,7 +1944,7 @@ export async function createApp(options = {}) {
       return res.status(204).end();
     });
 
-    app.get(`${prefix}/webhooks/:id/deliveries`, rateLimiter, requireApiKey, (req, res) => {
+    app.get(`${prefix}/webhooks/:id/deliveries`, rateLimiter, ...guard, (req, res) => {
       const webhook = webhookRepository.getById(req.params.id);
       if (!webhook) {
         return res.status(404).json({ error: 'Webhook not found', code: 'WEBHOOK_NOT_FOUND' });
@@ -1161,13 +1964,20 @@ export async function createApp(options = {}) {
 
       const { referrerAddress, refereeAddress } = req.body ?? {};
       if (!referrerAddress || typeof referrerAddress !== 'string') {
-        return res.status(400).json({ error: 'referrerAddress is required', code: 'VALIDATION_ERROR' });
+        return res
+          .status(400)
+          .json({ error: 'referrerAddress is required', code: 'VALIDATION_ERROR' });
       }
       if (!refereeAddress || typeof refereeAddress !== 'string') {
-        return res.status(400).json({ error: 'refereeAddress is required', code: 'VALIDATION_ERROR' });
+        return res
+          .status(400)
+          .json({ error: 'refereeAddress is required', code: 'VALIDATION_ERROR' });
       }
       if (referrerAddress === refereeAddress) {
-        return res.status(400).json({ error: 'referrerAddress and refereeAddress must be different', code: 'VALIDATION_ERROR' });
+        return res.status(400).json({
+          error: 'referrerAddress and refereeAddress must be different',
+          code: 'VALIDATION_ERROR',
+        });
       }
 
       const referral = referralRepository.create({
@@ -1177,7 +1987,10 @@ export async function createApp(options = {}) {
       });
 
       if (!referral) {
-        return res.status(409).json({ error: 'Referee already attributed to a referrer for this campaign', code: 'REFERRAL_DUPLICATE' });
+        return res.status(409).json({
+          error: 'Referee already attributed to a referrer for this campaign',
+          code: 'REFERRAL_DUPLICATE',
+        });
       }
 
       return res.status(201).json(referral);
@@ -1201,13 +2014,230 @@ export async function createApp(options = {}) {
         bonusEarned,
       });
     });
+
+    // Allowlist CSV import + proof routes (Issue #514)
+    const csvUpload = multer({
+      storage: multer.memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 /* 5 MB */ },
+    });
+
+    app.post(
+      `${prefix}/campaigns/:id/allowlist/import`,
+      rateLimiter,
+      ...guard,
+      requireScope('campaigns:write'),
+      csvUpload.single('file'),
+      async (req, res) => {
+        const campaign = campaignRepository.getById(req.params.id);
+        if (!campaign) {
+          return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+        }
+        if (!req.file && !req.body.csv) {
+          return res.status(400).json({ error: 'No CSV data provided', code: 'MISSING_CSV' });
+        }
+        const raw = req.file ? req.file.buffer.toString('utf8') : String(req.body.csv);
+        const { rows } = parseAllowlistCsv(raw);
+        if (rows.length === 0) {
+          return res.status(400).json({ error: 'CSV contains no addresses', code: 'EMPTY_CSV' });
+        }
+        if (rows.length > MAX_ALLOWLIST_ROWS) {
+          return res.status(400).json({
+            error: `CSV exceeds maximum of ${MAX_ALLOWLIST_ROWS} rows`,
+            code: 'CSV_TOO_LARGE',
+          });
+        }
+        const invalid = rows.filter((r) => !validateGAddress(r.address));
+        if (invalid.length > 0) {
+          return res.status(400).json({
+            error: 'CSV contains invalid Stellar addresses',
+            code: 'INVALID_ADDRESSES',
+            details: invalid.slice(0, 20).map((r) => ({ row: r.row, address: r.address })),
+          });
+        }
+        try {
+          const addresses = rows.map((r) => r.address);
+          const { root, proofs } = await generateAllowlist(addresses);
+          const addressEntries = rows.map((r) => ({
+            address: r.address,
+            label: r.label,
+            bonus_points: r.bonus_points ? Number(r.bonus_points) : undefined,
+            proof: proofs[r.address],
+          }));
+          allowlistRepository.upsertAllowlistEntries({ campaignId: req.params.id, addressEntries, merkleRootHex: root });
+          return res.status(201).json({
+            campaignId: String(req.params.id),
+            merkleRoot: root,
+            count: rows.length,
+          });
+        } catch (err) {
+          log.error({ err, campaignId: req.params.id }, 'Allowlist import failed');
+          return res.status(500).json({ error: 'Failed to generate allowlist', code: 'ALLOWLIST_ERROR' });
+        }
+      },
+    );
+
+    app.get(`${prefix}/campaigns/:id/allowlist`, rateLimiter, ...guard, (req, res) => {
+      const campaign = campaignRepository.getById(req.params.id);
+      if (!campaign) {
+        return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+      }
+      const entries = allowlistRepository.listAllowlist(req.params.id);
+      const merkleRoot = entries[0]?.merkleRoot ?? null;
+      return res.json({ campaignId: String(req.params.id), merkleRoot, count: entries.length, entries });
+    });
+
+    app.get(`${prefix}/campaigns/:id/allowlist/:address/proof`, rateLimiter, (req, res) => {
+      const campaign = campaignRepository.getById(req.params.id);
+      if (!campaign) {
+        return res.status(404).json({ error: 'Campaign not found', code: 'CAMPAIGN_NOT_FOUND' });
+      }
+      const address = req.params.address.trim();
+      if (!validateGAddress(address)) {
+        return res.status(400).json({ error: 'Invalid Stellar address', code: 'INVALID_ADDRESS' });
+      }
+      const row = allowlistRepository.getProof(req.params.id, address);
+      if (!row) {
+        return res.status(404).json({ error: 'Address not in allowlist', code: 'NOT_IN_ALLOWLIST' });
+      }
+      const proof = row.merkle_proof ? JSON.parse(row.merkle_proof) : null;
+      return res.json({ campaignId: String(req.params.id), address, merkleRoot: row.merkle_root, proof });
+    });
+
+    // Org + RBAC member management routes (Issue #608)
+    // Registered BEFORE the app.use(prefix, requireApiKey, ...) mounts so that
+    // master-key-only routes (POST /orgs) are not intercepted by the API-key
+    // guard that the variant/cohort/push routers apply at the prefix level.
+    const orgRouter = createOrgRoutes({
+      orgMemberRepository,
+      requireMasterKey,
+      requireApiKey,
+    });
+    app.use(prefix, rateLimiter, orgRouter);
+
+    // Audit log routes for organization-scoped audit logging and activity feeds (Issue #612)
+    const auditRouter = createAuditRouter({
+      auditLogService,
+      requireApiKey,
+    });
+    app.use(prefix, rateLimiter, auditRouter);
+
+    // Variant routes for A/B testing (Issue #624)
+    const variantRouter = createVariantRoutes({
+      variantRepo: variantRepository,
+      variantService,
+      campaignRepo: campaignRepository,
+    });
+    app.use(prefix, rateLimiter, ...guard, variantRouter);
+
+    // Cohort and retention analysis routes (Issue #623)
+    const cohortRouter = createCohortRoutes({
+      cohortService,
+      campaignRepo: campaignRepository,
+    });
+    app.use(prefix, rateLimiter, ...guard, cohortRouter);
+
+    // Web Push subscription routes (Issue #619)
+    const pushRouter = createPushRoutes({
+      repository: pushSubscriptionRepository,
+      service: webPushService,
+    });
+    app.use(prefix, rateLimiter, requireApiKey, pushRouter);
+
+    // Organization and team member invitation routes (Issue #609)
+    const organizationRouter = createOrganizationRoutes(dal);
+    app.use(`${prefix}/organizations`, rateLimiter, requireApiKey, organizationRouter);
+    app.use(prefix, rateLimiter, ...guard, pushRouter);
+
+    // Feature flag system routes (Issue #625)
+    const featureFlagService = createFeatureFlagService({ featureFlagRepository: dal.featureFlags });
+    const featureFlagRouter = createFeatureFlagRoutes({ featureFlagService });
+    app.use(`${prefix}/feature-flags`, rateLimiter, featureFlagRouter);
+
+    // #560 — Public read API over indexed data (cursor-paginated, ETag cached)
+    const indexReadRouter = createIndexReadRoutes({ dal, campaignRepository });
+    app.use(`${prefix}/index`, rateLimiter, indexReadRouter);
+
+    // #556 — Sponsored account creation + CAP-33 reserve sponsorship
+    const sponsoredAccountRouter = createSponsoredAccountRoutes({
+      dal,
+      stellarConfig,
+      env: process.env,
+    });
+    app.use(`${prefix}/sponsored-accounts`, rateLimiter, ...guard, sponsoredAccountRouter);
+
+    // #548 — Claimable balances for unclaimed/expired rewards
+    const claimableBalancesRouter = createClaimableBalancesRoutes({
+      dal,
+      campaignRepository,
+      stellarConfig,
+      env: process.env,
+      logger: log,
+    });
+    app.use(prefix, rateLimiter, ...guard, claimableBalancesRouter);
   }
+
+  // #551 — SEP-1 stellar.toml (public, no auth, correct content-type + CORS)
+  const stellarTomlRouter = createStellarTomlRoute({ env: process.env });
+  app.use(stellarTomlRouter);
+
+  // #547 — SEP-10 Stellar Web Authentication
+  const sep10Router = createSep10Routes({
+    serverSecret: process.env.STELLAR_SECRET_KEY,
+    networkPassphrase: process.env.STELLAR_NETWORK,
+    jwtSecret: process.env.TRIVELA_JWT_SECRET,
+  });
+  app.use(rateLimiter, sep10Router);
+
+  // Expose requireWalletAuth for routes that need wallet-based auth
+  const requireWalletAuth = createRequireWalletAuth({
+    jwtSecret: process.env.TRIVELA_JWT_SECRET,
+    serverSecret: process.env.STELLAR_SECRET_KEY,
+  });
+
+  // #543 — ZK proving inputs (public, no auth — secrets never leave the device)
+  const zkInputsRouter = createZkInputsRoutes({ campaignRepository });
+  app.use(API_V1_PREFIX, rateLimiter, zkInputsRouter);
 
   registerApiRoutes(API_V1_PREFIX);
   registerApiRoutes(LEGACY_API_PREFIX);
 
+  // Dynamic sitemap.xml for SEO — lists all public (non-hidden, active) campaign pages
+  app.get('/sitemap.xml', rateLimiter, (req, res) => {
+    const siteUrl =
+      (process.env.SITE_URL || '').replace(/\/+$/, '') || `${req.protocol}://${req.get('host')}`;
+
+    const staticPaths = ['/', '/explore', '/about'];
+    const campaigns = campaignRepository.list({ active: true });
+
+    const urlEntries = [
+      ...staticPaths.map(
+        (p) =>
+          `<url><loc>${siteUrl}${p}</loc><changefreq>daily</changefreq><priority>${p === '/' || p === '/explore' ? '1.0' : '0.7'}</priority></url>`,
+      ),
+      ...campaigns.map(
+        (c) =>
+          `<url><loc>${siteUrl}/campaign/${encodeURIComponent(c.id)}</loc><lastmod>${c.updatedAt ? new Date(c.updatedAt).toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10)}</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>`,
+      ),
+    ];
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlEntries.join('\n')}\n</urlset>`;
+
+    res
+      .set('Content-Type', 'application/xml; charset=utf-8')
+      .set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
+      .send(xml);
+  });
+
   // Central error handler — must be registered after all routes
   app.use(errorHandler);
+
+  app._close = () => {
+    isShuttingDown = true;
+    try { dal.db.close(); } catch (_) {}
+  };
+
+  // Expose wallet auth middleware for use by routes and tests
+  app._requireWalletAuth = requireWalletAuth;
 
   return app;
 }
@@ -1221,9 +2251,55 @@ export async function startServer(options = {}) {
   const app = await createApp(options);
   const port = options.port ?? process.env.PORT ?? DEFAULT_PORT;
 
-  return app.listen(port, () => {
+  const server = app.listen(port, () => {
     log.info({ port }, 'Trivela API running');
   });
+
+  // Initialize WebSocket server if not disabled
+  if (!options.disableWebSocket && process.env.ENABLE_WEBSOCKET !== 'false') {
+    try {
+      initializeWebSocket(server, {
+        path: process.env.WEBSOCKET_PATH || '/ws',
+      });
+      log.info('WebSocket server initialized on /ws');
+    } catch (error) {
+      log.error({ error }, 'Failed to initialize WebSocket server');
+    }
+  }
+
+  // ── Graceful shutdown (issue #650) ─────────────────────────────────────────
+  const SHUTDOWN_GRACE_MS = normalizePositiveInteger(process.env.SHUTDOWN_GRACE_MS, 15_000);
+
+  let shuttingDown = false;
+
+  async function gracefulShutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    app._close?.();
+    log.info({ signal, graceMs: SHUTDOWN_GRACE_MS }, 'graceful shutdown started');
+
+    const forceTimer = setTimeout(() => {
+      log.error('graceful shutdown timed out — forcing exit');
+      process.exit(1);
+    }, SHUTDOWN_GRACE_MS);
+    if (typeof forceTimer.unref === 'function') forceTimer.unref();
+
+    await new Promise((resolve) => server.close(resolve));
+
+    stopUsageFlush();
+    await usageMeteringService.flushToDb().catch((err) => log.warn({ err }, 'usage flush warning'));
+
+    await shutdownTracing().catch((err) => log.warn({ err }, 'OTel shutdown warning'));
+
+    log.info('graceful shutdown complete');
+    clearTimeout(forceTimer);
+    process.exit(0);
+  }
+
+  process.once('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.once('SIGINT', () => gracefulShutdown('SIGINT'));
+
+  return server;
 }
 
 const isExecutedDirectly =

--- a/backend/src/middleware/deprecationNotice.js
+++ b/backend/src/middleware/deprecationNotice.js
@@ -1,0 +1,66 @@
+// @ts-check
+import { DEPRECATION_REGISTRY } from '../deprecations.js';
+
+/**
+ * Match a request path+method against the deprecation registry.
+ * Registry keys are like "GET /api/v1/campaigns/:id/stats"; path segments
+ * starting with ":" are treated as wildcards.
+ *
+ * @param {string} method  e.g. "GET"
+ * @param {string} path    e.g. "/api/v1/campaigns/42/stats"
+ * @returns {import('../deprecations.js').DeprecationEntry | null}
+ */
+function matchDeprecation(method, path) {
+  for (const [pattern, entry] of Object.entries(DEPRECATION_REGISTRY)) {
+    const [patternMethod, ...rest] = pattern.split(' ');
+    const patternPath = rest.join(' ');
+
+    if (patternMethod.toUpperCase() !== method.toUpperCase()) continue;
+
+    const patternParts = patternPath.split('/');
+    const pathParts = path.split('/');
+
+    if (patternParts.length !== pathParts.length) continue;
+
+    const matched = patternParts.every(
+      (seg, i) => seg.startsWith(':') || seg === pathParts[i],
+    );
+
+    if (matched) return entry;
+  }
+  return null;
+}
+
+/**
+ * Express middleware that injects RFC 8594 deprecation headers for
+ * any route registered in the deprecation registry, and WARN-logs usage
+ * so operators know which deprecated endpoints are still being hit.
+ *
+ * @param {{ log?: { warn?: Function } }} [options]
+ * @returns {import('express').RequestHandler}
+ */
+export function createDeprecationMiddleware({ log = console } = {}) {
+  return function deprecationNotice(req, res, next) {
+    const entry = matchDeprecation(req.method, req.path);
+
+    if (entry) {
+      const deprecationDate = new Date(entry.deprecatedAt).toUTCString();
+      const sunsetDate = new Date(entry.removedAt).toUTCString();
+
+      res.setHeader('Deprecation', deprecationDate);
+      res.setHeader('Sunset', sunsetDate);
+      res.setHeader(
+        'Link',
+        `<${entry.replacement}>; rel="successor-version"`,
+      );
+
+      log.warn?.(
+        `deprecated_endpoint_hit method=${req.method} path=${req.path} ` +
+        `deprecated_at=${entry.deprecatedAt} removed_at=${entry.removedAt} ` +
+        `replacement=${entry.replacement}`,
+      );
+    }
+
+    next();
+  };
+}

--- a/backend/src/routes/campaignExport.js
+++ b/backend/src/routes/campaignExport.js
@@ -1,0 +1,172 @@
+// @ts-check
+import { Router } from 'express';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const EXPORT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const EXPORT_RATE_LIMIT_MAX = 5;
+
+/** @type {Map<string, { count: number, resetAt: number }>} */
+const _exportBuckets = new Map();
+
+function checkExportRateLimit(campaignId, actorKey) {
+  const key = `${campaignId}:${actorKey}`;
+  const now = Date.now();
+  const bucket = _exportBuckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    _exportBuckets.set(key, { count: 1, resetAt: now + EXPORT_RATE_LIMIT_WINDOW_MS });
+    return { allowed: true, remaining: EXPORT_RATE_LIMIT_MAX - 1, resetAt: now + EXPORT_RATE_LIMIT_WINDOW_MS };
+  }
+  if (bucket.count >= EXPORT_RATE_LIMIT_MAX) {
+    return { allowed: false, remaining: 0, resetAt: bucket.resetAt };
+  }
+  bucket.count += 1;
+  return { allowed: true, remaining: EXPORT_RATE_LIMIT_MAX - bucket.count, resetAt: bucket.resetAt };
+}
+
+/**
+ * RFC 4180-compliant CSV serializer.
+ * @param {string[]} columns
+ * @param {Record<string, unknown>[]} rows
+ */
+function buildCsv(columns, rows) {
+  const escape = (v) => {
+    const s = v === null || v === undefined ? '' : String(v);
+    return s.includes(',') || s.includes('"') || s.includes('\n') || s.includes('\r')
+      ? '"' + s.replace(/"/g, '""') + '"'
+      : s;
+  };
+  const lines = [columns.join(',')];
+  for (const row of rows) lines.push(columns.map((c) => escape(row[c])).join(','));
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * @param {{
+ *   db: import('better-sqlite3').Database,
+ *   campaignRepository: import('../dal/campaignRepository.js').CampaignRepository,
+ *   auditLogRepository: import('../dal/auditLogRepository.js').AuditLogRepository,
+ *   requireApiKey: import('express').RequestHandler,
+ * }} options
+ */
+export function createCampaignExportRoute({ db, campaignRepository, auditLogRepository, requireApiKey }) {
+  const router = Router();
+
+  router.get('/campaigns/:id/export', requireApiKey, async (req, res) => {
+    const { id } = req.params;
+    const format = String(req.query.format ?? 'csv').toLowerCase();
+    const fromDate = typeof req.query.from === 'string' ? req.query.from : null;
+    const toDate = typeof req.query.to === 'string' ? req.query.to : null;
+
+    if (format !== 'csv' && format !== 'json') {
+      return res.status(400).json({ error: 'Invalid format. Use ?format=csv or ?format=json', code: 'INVALID_FORMAT' });
+    }
+
+    const campaign = campaignRepository.getById(id);
+    if (!campaign) {
+      return res.status(404).json({ error: 'Campaign not found', code: 'NOT_FOUND' });
+    }
+
+    const actorKey = String(req.headers['x-api-key'] ?? req.query.api_key ?? req.ip ?? 'anon');
+    const { allowed, remaining, resetAt } = checkExportRateLimit(id, actorKey);
+    res.setHeader('X-RateLimit-Limit', String(EXPORT_RATE_LIMIT_MAX));
+    res.setHeader('X-RateLimit-Remaining', String(remaining));
+
+    if (!allowed) {
+      res.setHeader('Retry-After', String(Math.ceil((resetAt - Date.now()) / 1000)));
+      return res.status(429).json({
+        error: 'Export rate limit exceeded. Max 5 exports per campaign per hour.',
+        code: 'EXPORT_RATE_LIMIT_EXCEEDED',
+      });
+    }
+
+    const hasCreditEvents = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='credit_events'").get();
+    const hasClaimEvents = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='claim_events'").get();
+
+    let participants = [];
+
+    if (hasCreditEvents) {
+      const dateFilters = [];
+      const vals = [String(id)];
+      if (fromDate) { dateFilters.push("r.created_at >= ?"); vals.push(fromDate); }
+      if (toDate) { dateFilters.push("r.created_at <= ?"); vals.push(toDate); }
+      const dateWhere = dateFilters.length ? `AND ${dateFilters.join(' AND ')}` : '';
+
+      participants = db.prepare(`
+        WITH participants AS (
+          SELECT DISTINCT user FROM credit_events
+        ),
+        credited AS (
+          SELECT user, SUM(CAST(amount AS INTEGER)) AS total FROM credit_events GROUP BY user
+        ),
+        claimed AS (
+          SELECT user, SUM(CAST(amount AS INTEGER)) AS total FROM claim_events GROUP BY user
+        )
+        SELECT
+          p.user                                       AS participantAddress,
+          r.created_at                                 AS registeredAt,
+          COALESCE(cr.total, 0)                        AS pointsCredited,
+          COALESCE(cl.total, 0)                        AS pointsClaimed,
+          COALESCE(cr.total, 0) - COALESCE(cl.total, 0) AS netPoints,
+          ref.referrer_address                         AS referredBy
+        FROM participants p
+        LEFT JOIN referrals r
+          ON r.referee_address = p.user AND r.campaign_id = ? ${dateWhere}
+        LEFT JOIN credited cr ON cr.user = p.user
+        LEFT JOIN ${hasClaimEvents ? 'claimed' : '(SELECT NULL AS user, 0 AS total) dummy_cl'} cl ON cl.user = p.user
+        LEFT JOIN referrals ref
+          ON ref.referee_address = p.user AND ref.campaign_id = ?
+      `).all(...vals, String(id));
+    } else {
+      // Fall back to referrals-only when event tables haven't been created yet
+      const dateFilters = [];
+      const vals = [String(id)];
+      if (fromDate) { dateFilters.push("created_at >= ?"); vals.push(fromDate); }
+      if (toDate) { dateFilters.push("created_at <= ?"); vals.push(toDate); }
+      const dateWhere = dateFilters.length ? `AND ${dateFilters.join(' AND ')}` : '';
+
+      const rows = db.prepare(`
+        SELECT referee_address, referrer_address, created_at
+        FROM referrals
+        WHERE campaign_id = ? ${dateWhere}
+        ORDER BY created_at ASC
+      `).all(...vals);
+
+      participants = rows.map((row) => ({
+        participantAddress: row.referee_address,
+        registeredAt: row.created_at,
+        pointsCredited: 0,
+        pointsClaimed: 0,
+        netPoints: 0,
+        referredBy: row.referrer_address ?? null,
+      }));
+    }
+
+    try {
+      auditLogRepository.create({
+        actor: actorKey,
+        action: 'campaign.export',
+        entity: 'campaign',
+        entityId: id,
+        diff: { format, fromDate, toDate, rowCount: participants.length },
+      });
+    } catch (_err) { /* non-fatal */ }
+
+    const filename = `campaign-${id}-export.${format}`;
+
+    if (format === 'csv') {
+      const columns = ['participantAddress', 'registeredAt', 'pointsCredited', 'pointsClaimed', 'netPoints', 'referredBy'];
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      await pipeline(Readable.from([buildCsv(columns, participants)]), res);
+    } else {
+      const payload = JSON.stringify({ campaign: { id: campaign.id, name: campaign.name }, participants }, null, 2);
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      await pipeline(Readable.from([payload]), res);
+    }
+  });
+
+  return router;
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,56 @@
+# Trivela Runbook
+
+Operational procedures for the Trivela backend and infrastructure.
+
+---
+
+## Secret Rotation Procedure
+
+If a private key, API key, or other secret is accidentally committed to the repository, follow these steps immediately.
+
+### 1. Assess the exposure
+
+- Determine what was committed: Stellar secret key, Trivela API key, environment variable, or third-party credential.
+- Check if the commit reached GitHub (even briefly) — assume it did and treat it as compromised.
+
+### 2. Revoke / rotate the secret immediately
+
+| Secret type | Rotation action |
+|---|---|
+| Stellar secret key | Generate a new keypair. If the key held on-chain funds, sweep them to a new address first. |
+| Trivela API key | Call `DELETE /api/v1/admin/api-keys/:id` to revoke the old key, then create a new one. |
+| Third-party credential | Follow the provider's key rotation procedure. |
+
+Do **not** wait until the commit is removed before revoking — assume the secret is already exploited.
+
+### 3. Remove the secret from git history
+
+Use `git filter-repo` (preferred) or BFG Repo Cleaner to rewrite history:
+
+```bash
+# Install: pip install git-filter-repo
+git filter-repo --path-regex '.*' --replace-text <(echo 'COMPROMISED_VALUE==>REDACTED')
+```
+
+Then force-push all branches and tags. Coordinate with other contributors to re-clone.
+
+### 4. Request a GitHub secret scan review
+
+Open a GitHub support ticket to purge cached views of the exposed commit, and enable [GitHub's secret scanning alerts](https://docs.github.com/en/code-security/secret-scanning) if not already on.
+
+### 5. Post-incident
+
+- Add a custom rule to `.gitleaks.toml` for the leaked pattern if it is not already covered.
+- Update `scripts/dev-setup.sh` if a `git-secrets` pattern needs to be added locally.
+- Write a brief incident summary and share it with the team.
+
+---
+
+## Gitleaks CI Failures
+
+If the `Secrets Scanning` CI workflow fails on a PR:
+
+1. **Do not merge** until the finding is resolved.
+2. Read the workflow output to see which file/line triggered the rule (the secret value itself is not printed).
+3. If it is a **false positive**, add an `[allowlist]` entry in `.gitleaks.toml` for that path or pattern, and explain why in the PR.
+4. If it is a **real secret**, follow the rotation procedure above before amending the commit.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import CampaignLeaderboard from './CampaignLeaderboard';
 import CampaignAnalytics from './CampaignAnalytics';
 import AdminCampaigns from './AdminCampaigns';
 import About from './About';
+import UserProfile from './pages/UserProfile';
 import PageMeta from './components/PageMeta';
 import TransactionHistory from './TransactionHistory';
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
@@ -244,6 +245,23 @@ export default function App() {
         path="/about"
         element={
           <About
+            theme={theme}
+            onToggleTheme={toggleTheme}
+            stellarNetwork={runtimeConfig.stellar.network}
+            onChangeStellarNetwork={handleChangeStellarNetwork}
+            walletAddress={walletAddress}
+            walletBalance={walletBalance}
+            isWalletLoading={isWalletLoading}
+            isWalletBalanceLoading={isWalletBalanceLoading}
+            onConnectWallet={connectWallet}
+            onDisconnectWallet={disconnectWallet}
+          />
+        }
+      />
+      <Route
+        path="/profile"
+        element={
+          <UserProfile
             theme={theme}
             onToggleTheme={toggleTheme}
             stellarNetwork={runtimeConfig.stellar.network}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,18 +1,33 @@
-import { useEffect, useState } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { lazy, Suspense, useEffect, useState } from 'react';
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import Landing from './Landing';
 import CampaignDetail from './CampaignDetail';
-import CampaignLeaderboard from './CampaignLeaderboard';
-import CampaignAnalytics from './CampaignAnalytics';
 import AdminCampaigns from './AdminCampaigns';
 import About from './About';
-import UserProfile from './pages/UserProfile';
+import CampaignAnalytics from './CampaignAnalytics';
+import NotificationSettings from './NotificationSettings';
+import CreateCampaign from './CreateCampaign';
 import PageMeta from './components/PageMeta';
-import TransactionHistory from './TransactionHistory';
+import WalletModal from './components/WalletModal';
+import RequireAdmin from './components/RequireAdmin';
+
+// Route-level lazy loading — each chunk is fetched only when the user
+// navigates to that route, keeping the initial bundle small.
+const Explore = lazy(() => import('./Explore'));
+const CampaignDetail = lazy(() => import('./CampaignDetail'));
+const CampaignLeaderboard = lazy(() => import('./CampaignLeaderboard'));
+const CampaignAnalytics = lazy(() => import('./CampaignAnalytics'));
+const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
+const About = lazy(() => import('./About'));
+const TransactionHistory = lazy(() => import('./TransactionHistory'));
+const EmbedCampaign = lazy(() => import('./pages/EmbedCampaign'));
+const PublicProfile = lazy(() => import('./pages/PublicProfile'));
+const UserProfile = lazy(() => import('./pages/UserProfile'));
 import { applyTheme, getPreferredTheme, THEME_STORAGE_KEY } from './theme';
 import { getRuntimeConfig, initializeRuntimeConfig, setRuntimeStellarNetwork } from './config';
 import {
-  getWalletAddress,
+  connectWallet as connectWalletProvider,
   fetchWalletBalance,
   formatWalletBalance,
   fetchRewardsBalance,
@@ -31,6 +46,8 @@ export default function App() {
   const [isWalletBalanceLoading, setIsWalletBalanceLoading] = useState(false);
   const [isRewardsPointsLoading, setIsRewardsPointsLoading] = useState(false);
   const [walletError, setWalletError] = useState('');
+  const [showWalletModal, setShowWalletModal] = useState(false);
+  const { showHelpModal, setShowHelpModal, announcement } = useKeyboardShortcuts(true);
 
   useEffect(() => {
     applyTheme(theme);
@@ -74,7 +91,6 @@ export default function App() {
     setIsWalletBalanceLoading(true);
     setIsRewardsPointsLoading(true);
 
-    // 1. Load native XLM balance (Horizon)
     try {
       const balance = await fetchWalletBalance(address);
       setWalletBalance(formatWalletBalance(balance));
@@ -84,33 +100,38 @@ export default function App() {
       setIsWalletBalanceLoading(false);
     }
 
-    // 2. Load rewards points (Soroban RPC)
     try {
       const points = await fetchRewardsBalance(address);
       setRewardsPoints(formatPoints(points));
     } catch (error) {
       console.error('Failed to load rewards points:', error);
-      // We rely on normalizeError in components if they want more detail,
-      // but here we just mark it as unavailable for the global state.
       setRewardsPoints('Unavailable');
     } finally {
       setIsRewardsPointsLoading(false);
     }
   };
 
-  const connectWallet = async () => {
+  const openWalletModal = () => {
+    setWalletError('');
+    setShowWalletModal(true);
+  };
+
+  const handleWalletSelect = async (providerName) => {
+    setShowWalletModal(false);
     setIsWalletLoading(true);
     setWalletError('');
 
     try {
-      const address = await getWalletAddress();
+      const { address } = await connectWalletProvider(providerName);
       setWalletAddress(address);
-      logSafeEvent('wallet_connected');
+      logSafeEvent('wallet_connected', { provider: providerName });
       await loadWalletBalance(address);
     } catch (error) {
       setWalletAddress('');
       setWalletBalance('');
-      setWalletError(normalizeError(error));
+      const msg = normalizeError(error);
+      setWalletError(msg);
+      setShowWalletModal(true);
     } finally {
       setIsWalletLoading(false);
     }
@@ -139,76 +160,225 @@ export default function App() {
   };
 
   const location = useLocation();
+  const navigate = useNavigate();
   const defaultPath = location.pathname || '/';
 
   return (
     <>
       <PageMeta path={defaultPath} />
-      <Routes>
-      <Route
-        path="/"
-        element={
-          <Landing
-            runtimeConfig={runtimeConfig}
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            rewardsPoints={rewardsPoints}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            isRewardsPointsLoading={isRewardsPointsLoading}
-            walletError={walletError}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-            onRefreshPoints={() => loadWalletBalance(walletAddress)}
-          />
+      <Suspense
+        fallback={
+          <div className="route-loading" aria-live="polite">
+            Loading…
+          </div>
         }
+      >
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <Landing
+                runtimeConfig={runtimeConfig}
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                rewardsPoints={rewardsPoints}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                isRewardsPointsLoading={isRewardsPointsLoading}
+                walletError={walletError}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+                onRefreshPoints={() => loadWalletBalance(walletAddress)}
+              />
+            }
+          />
+          <Route
+            path="/explore"
+            element={
+              <Explore
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+          <Route
+            path="/campaign/:id"
+            element={
+              <CampaignDetail
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                rewardsPoints={rewardsPoints}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                isRewardsPointsLoading={isRewardsPointsLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+                onRefreshPoints={() => loadWalletBalance(walletAddress)}
+              />
+            }
+          />
+          <Route
+            path="/campaign/:id/leaderboard"
+            element={
+              <CampaignLeaderboard
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                rewardsPoints={rewardsPoints}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                isRewardsPointsLoading={isRewardsPointsLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+                onRefreshPoints={() => loadWalletBalance(walletAddress)}
+              />
+            }
+          />
+          <Route
+            path="/admin/campaigns/:id/analytics"
+            element={
+              <RequireAdmin
+                walletAddress={walletAddress}
+                onConnectWallet={openWalletModal}
+                isWalletLoading={isWalletLoading}
+              >
+                <CampaignAnalytics
+                  theme={theme}
+                  onToggleTheme={toggleTheme}
+                  stellarNetwork={runtimeConfig.stellar.network}
+                  onChangeStellarNetwork={handleChangeStellarNetwork}
+                  walletAddress={walletAddress}
+                  walletBalance={walletBalance}
+                  isWalletLoading={isWalletLoading}
+                  isWalletBalanceLoading={isWalletBalanceLoading}
+                  onConnectWallet={openWalletModal}
+                  onDisconnectWallet={disconnectWallet}
+                />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <RequireAdmin
+                walletAddress={walletAddress}
+                onConnectWallet={openWalletModal}
+                isWalletLoading={isWalletLoading}
+              >
+                <AdminCampaigns
+                  theme={theme}
+                  onToggleTheme={toggleTheme}
+                  stellarNetwork={runtimeConfig.stellar.network}
+                  onChangeStellarNetwork={handleChangeStellarNetwork}
+                  walletAddress={walletAddress}
+                  walletBalance={walletBalance}
+                  isWalletLoading={isWalletLoading}
+                  isWalletBalanceLoading={isWalletBalanceLoading}
+                  onConnectWallet={openWalletModal}
+                  onDisconnectWallet={disconnectWallet}
+                />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/campaigns/new"
+            element={
+              <RequireAdmin
+                walletAddress={walletAddress}
+                onConnectWallet={openWalletModal}
+                isWalletLoading={isWalletLoading}
+              >
+                <CreateCampaign
+                  standalone
+                  campaigns={[]}
+                  onCampaignCreated={(c) => navigate(`/campaign/${c.id}`)}
+                />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/about"
+            element={
+              <About
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+          <Route
+            path="/history"
+            element={
+              <TransactionHistory
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+          <Route path="/embed/campaign/:id" element={<EmbedCampaign />} />
+          <Route path="/u/:address" element={<PublicProfile />} />
+          <Route
+            path="/profile"
+            element={
+              <UserProfile
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+        </Routes>
+      </Suspense>
+      <WalletModal
+        isOpen={showWalletModal}
+        onClose={() => setShowWalletModal(false)}
+        onConnect={handleWalletSelect}
+        isLoading={isWalletLoading}
+        error={walletError}
       />
       <Route
-        path="/campaign/:id"
-        element={
-          <CampaignDetail
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            rewardsPoints={rewardsPoints}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            isRewardsPointsLoading={isRewardsPointsLoading}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-            onRefreshPoints={() => loadWalletBalance(walletAddress)}
-          />
-        }
-      />
-      <Route
-        path="/campaign/:id/leaderboard"
-        element={
-          <CampaignLeaderboard
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            rewardsPoints={rewardsPoints}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            isRewardsPointsLoading={isRewardsPointsLoading}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-            onRefreshPoints={() => loadWalletBalance(walletAddress)}
-          />
-        }
-      />
-      <Route
-        path="/admin/campaigns/:id/analytics"
+        path="/analytics"
         element={
           <CampaignAnalytics
             theme={theme}
@@ -225,65 +395,9 @@ export default function App() {
         }
       />
       <Route
-        path="/admin"
+        path="/notification-settings"
         element={
-          <AdminCampaigns
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-          />
-        }
-      />
-      <Route
-        path="/about"
-        element={
-          <About
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-          />
-        }
-      />
-      <Route
-        path="/profile"
-        element={
-          <UserProfile
-            theme={theme}
-            onToggleTheme={toggleTheme}
-            stellarNetwork={runtimeConfig.stellar.network}
-            onChangeStellarNetwork={handleChangeStellarNetwork}
-            walletAddress={walletAddress}
-            walletBalance={walletBalance}
-            isWalletLoading={isWalletLoading}
-            isWalletBalanceLoading={isWalletBalanceLoading}
-            onConnectWallet={connectWallet}
-            onDisconnectWallet={disconnectWallet}
-          />
-        }
-      />
-      </Routes>
-    </>
-      {/* #295 — Per-wallet transaction history. Renders empty / loading
-          / error states inline so the page never depends on the caller
-          to wrap. */}
-      <Route
-        path="/history"
-        element={
-          <TransactionHistory
+          <NotificationSettings
             theme={theme}
             onToggleTheme={toggleTheme}
             stellarNetwork={runtimeConfig.stellar.network}
@@ -298,5 +412,56 @@ export default function App() {
         }
       />
     </Routes>
+      <div className="sr-only" aria-live="assertive" style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', border: 0 }}>
+        {announcement}
+      </div>
+      {showHelpModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="shortcuts-modal-title"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.75)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={() => setShowHelpModal(false)}
+        >
+          <div
+            style={{
+              backgroundColor: 'var(--color-surface, #1e293b)',
+              padding: '24px',
+              borderRadius: '8px',
+              border: '1px solid var(--color-border, #334155)',
+              width: '100%',
+              maxWidth: '450px',
+              boxShadow: '0 10px 25px rgba(0,0,0,0.5)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="shortcuts-modal-title" style={{ margin: '0 0 16px', fontSize: '1.25rem' }}>Keyboard Shortcuts</h2>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 20px', textAlign: 'left', lineHeight: '2' }}>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>/</kbd> : Focus search bar</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>n</kbd> : New campaign</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>g</kbd> then <kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>h</kbd> : Go home</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>g</kbd> then <kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>p</kbd> : Go to profile</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>g</kbd> then <kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>a</kbd> : Go to admin dashboard</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>Esc</kbd> : Close open modals</li>
+              <li><kbd style={{ background: '#334155', padding: '2px 6px', borderRadius: '4px', marginRight: '8px' }}>?</kbd> : Open this help menu</li>
+            </ul>
+            <button type="button" className="btn btn-secondary" style={{ width: '100%' }} onClick={() => setShowHelpModal(false)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -52,6 +52,9 @@ export default function Header({
 
         <div className="nav-actions">
           <div className="nav-links">
+            {walletAddress && (
+              <a href="/profile">Profile</a>
+            )}
             {/* #295 — only show the history link when a wallet is
                 connected; the page itself is per-wallet. */}
             {walletAddress && (

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,4 +1,8 @@
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import DevNetworkSwitcher from './DevNetworkSwitcher';
+import NotificationCenter from './NotificationCenter';
+import { apiUrl } from '../config';
 
 function truncateWalletAddress(walletAddress) {
   if (!walletAddress) return '';
@@ -7,22 +11,14 @@ function truncateWalletAddress(walletAddress) {
 }
 
 const NAV_LINKS = [
-  {
-    href: '/api-docs.html',
-    label: 'API Docs',
-  },
-  {
-    href: 'https://github.com/FinesseStudioLab/Trivela',
-    label: 'GitHub',
-  },
-  {
-    href: 'https://github.com/FinesseStudioLab/Trivela/issues',
-    label: 'Contribute',
-  },
-  {
-    href: 'https://developers.stellar.org/docs',
-    label: 'Stellar',
-  },
+  { href: '/analytics', label: 'Analytics' },
+  { href: '/notification-settings', label: 'Notifications' },
+  { href: 'https://github.com/FinesseStudioLab/Trivela', label: 'GitHub' },
+  { href: 'https://developers.stellar.org/docs', label: 'Stellar' },
+  { href: '/', label: 'Campaigns' },
+  { href: '/explore', label: 'Explore' },
+  { href: '/about', label: 'About' },
+  { href: '/admin', label: 'Admin' },
 ];
 
 export default function Header({
@@ -39,35 +35,239 @@ export default function Header({
 }) {
   const nextTheme = theme === 'dark' ? 'light' : 'dark';
   const balanceLabel = `${stellarNetwork === 'mainnet' ? 'Mainnet' : 'Testnet'} balance`;
+  const { pathname } = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const [latency, setLatency] = useState(null);
+  const [statusColor, setStatusColor] = useState('red');
+  const [showPanel, setShowPanel] = useState(false);
+  const [latencyHistory, setLatencyHistory] = useState(() => {
+    try {
+      const stored = localStorage.getItem('rpc_latency_history');
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    const checkHealth = async () => {
+      const startTime = Date.now();
+      try {
+        const res = await fetch(apiUrl('/health/rpc'));
+        const endTime = Date.now();
+        const duration = endTime - startTime;
+        
+        if (res.ok) {
+          setLatency(duration);
+          let color = 'green';
+          if (duration >= 2000) {
+            color = 'red';
+          } else if (duration >= 500) {
+            color = 'yellow';
+          }
+          setStatusColor(color);
+          
+          setLatencyHistory(prev => {
+            const next = [...prev.slice(-4), duration];
+            localStorage.setItem('rpc_latency_history', JSON.stringify(next));
+            return next;
+          });
+        } else {
+          setLatency(null);
+          setStatusColor('red');
+          setLatencyHistory(prev => {
+            const next = [...prev.slice(-4), 0];
+            localStorage.setItem('rpc_latency_history', JSON.stringify(next));
+            return next;
+          });
+        }
+      } catch (err) {
+        setLatency(null);
+        setStatusColor('red');
+        setLatencyHistory(prev => {
+          const next = [...prev.slice(-4), 0];
+          localStorage.setItem('rpc_latency_history', JSON.stringify(next));
+          return next;
+        });
+      }
+    };
+
+    checkHealth();
+    const interval = setInterval(checkHealth, 30000);
+    return () => clearInterval(interval);
+  }, [stellarNetwork]);
+
+  const rpcUrl = stellarNetwork === 'mainnet' ? 'https://soroban-mainnet.stellar.org' : 'https://soroban-testnet.stellar.org';
+  const tooltipText = latency !== null ? `RPC Latency: ${latency}ms — ${stellarNetwork === 'mainnet' ? 'Mainnet' : 'Testnet'}` : `RPC Offline — ${stellarNetwork === 'mainnet' ? 'Mainnet' : 'Testnet'}`;
+
+  const toggleMenu = () => setMenuOpen((prev) => !prev);
+  const closeMenu = () => setMenuOpen(false);
 
   return (
     <header className="site-header">
       <nav className="nav" aria-label="Primary">
-        <a href="/" className="nav-logo" aria-label="Trivela home">
-          <span className="nav-logo-icon" aria-hidden="true">
-            ◇
-          </span>
-          Trivela
-        </a>
+        <div className="nav-top-row">
+          <a href="/" className="nav-logo" aria-label="Trivela home" onClick={closeMenu}>
+            <span className="nav-logo-icon" aria-hidden="true">
+              ◇
+            </span>
+            Trivela
+          </a>
 
-        <div className="nav-actions">
+          <button
+            type="button"
+            className="nav-hamburger"
+            onClick={toggleMenu}
+            aria-expanded={menuOpen}
+            aria-controls="nav-mobile-menu"
+            aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+          >
+            <span className="nav-hamburger-bar" aria-hidden="true" />
+            <span className="nav-hamburger-bar" aria-hidden="true" />
+            <span className="nav-hamburger-bar" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div
+          id="nav-mobile-menu"
+          className={`nav-actions${menuOpen ? ' nav-actions--open' : ''}`}
+        >
           <div className="nav-links">
-            {walletAddress && (
-              <a href="/profile">Profile</a>
-            )}
-            {/* #295 — only show the history link when a wallet is
-                connected; the page itself is per-wallet. */}
-            {walletAddress && (
-              <a href="/history">Transaction History</a>
-            )}
+            {NAV_LINKS.map((link) => {
+              const isExternal = link.href.startsWith('http');
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                >
+                  {link.label}
+                </a>
+              );
+            })}
             {NAV_LINKS.map((link) => (
-              <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer">
+              <a
+                key={link.href}
+                href={link.href}
+                className={pathname === link.href ? 'nav-link-active' : undefined}
+                aria-current={pathname === link.href ? 'page' : undefined}
+                onClick={closeMenu}
+              >
                 {link.label}
               </a>
             ))}
+            {walletAddress && (
+              <a
+                href="/profile"
+                className={pathname === '/profile' ? 'nav-link-active' : undefined}
+                aria-current={pathname === '/profile' ? 'page' : undefined}
+                onClick={closeMenu}
+              >
+                Profile
+              </a>
+            )}
+            {walletAddress && (
+              <a
+                href="/history"
+                className={pathname === '/history' ? 'nav-link-active' : undefined}
+                aria-current={pathname === '/history' ? 'page' : undefined}
+                onClick={closeMenu}
+              >
+                History
+              </a>
+            )}
           </div>
 
           <div className="nav-utilities">
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', position: 'relative' }}>
+              <button
+                type="button"
+                onClick={() => setShowPanel(!showPanel)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: '4px',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                }}
+                title={tooltipText}
+              >
+                <span
+                  style={{
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '50%',
+                    backgroundColor: statusColor === 'green' ? '#10b981' : statusColor === 'yellow' ? '#f59e0b' : '#ef4444',
+                    display: 'inline-block',
+                  }}
+                />
+                {latency !== null && (
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-secondary, #94a3b8)' }}>
+                    {latency}ms
+                  </span>
+                )}
+              </button>
+
+              {showPanel && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: '100%',
+                    right: 0,
+                    backgroundColor: 'var(--color-surface, #1e293b)',
+                    border: '1px solid var(--color-border, #334155)',
+                    borderRadius: '8px',
+                    padding: '16px',
+                    zIndex: 100,
+                    width: '260px',
+                    textAlign: 'left',
+                    boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+                  }}
+                >
+                  <h4 style={{ margin: '0 0 8px 0', fontSize: '0.875rem', fontWeight: 600, color: 'var(--color-text, #f8fafc)' }}>Soroban RPC Status</h4>
+                  <p style={{ margin: '0 0 12px 0', fontSize: '0.75rem', color: 'var(--color-text-secondary, #94a3b8)', wordBreak: 'break-all' }}>
+                    <strong>URL:</strong> {rpcUrl}
+                  </p>
+                  
+                  <div style={{ marginBottom: '12px' }}>
+                    <p style={{ margin: '0 0 4px 0', fontSize: '0.75rem', fontWeight: 600, color: 'var(--color-text, #f8fafc)' }}>Latency Sparkline (last 5):</p>
+                    <div style={{ display: 'flex', alignItems: 'flex-end', gap: '4px', height: '30px', background: 'rgba(0,0,0,0.2)', padding: '4px', borderRadius: '4px' }}>
+                      {latencyHistory.map((h, i) => {
+                        const maxVal = Math.max(...latencyHistory, 500);
+                        const heightPct = h > 0 ? (h / maxVal) * 100 : 5;
+                        const barColor = h === 0 ? '#ef4444' : h < 500 ? '#10b981' : h < 2000 ? '#f59e0b' : '#ef4444';
+                        return (
+                          <div
+                            key={i}
+                            style={{
+                              flex: 1,
+                              height: `${heightPct}%`,
+                              backgroundColor: barColor,
+                              borderRadius: '2px',
+                            }}
+                            title={h > 0 ? `${h}ms` : 'Failed/Error'}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                  
+                  <a
+                    href="https://stellar.org/status"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ fontSize: '0.75rem', color: '#38bdf8', textDecoration: 'underline' }}
+                  >
+                    Stellar Network Status
+                  </a>
+                </div>
+              )}
+            </div>
+
+            <NotificationCenter />
             <DevNetworkSwitcher network={stellarNetwork} onChange={onChangeStellarNetwork} />
 
             {walletAddress && (
@@ -94,7 +294,13 @@ export default function Header({
                 disabled={isWalletLoading}
                 aria-label={walletAddress ? 'Disconnect wallet' : 'Connect wallet'}
               >
-                {isWalletLoading ? 'Connecting…' : walletAddress ? 'Disconnect' : 'Connect wallet'}
+                {isWalletLoading
+                  ? 'Connecting…'
+                  : walletAddress
+                    ? 'Disconnect'
+                    : statusColor === 'red'
+                      ? 'Connect wallet (Network degraded)'
+                      : 'Connect wallet'}
               </button>
             )}
 

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -1,0 +1,223 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiUrl } from '../config';
+import PageMeta from '../components/PageMeta';
+import Header from '../components/Header';
+
+function truncateAddress(addr) {
+  if (!addr || addr.length <= 14) return addr ?? '';
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function StatCard({ label, value }) {
+  return (
+    <div className="profile-stat-card">
+      <span className="profile-stat-value">{value}</span>
+      <span className="profile-stat-label">{label}</span>
+    </div>
+  );
+}
+
+function Skeleton({ width = '100%', height = '1.2em' }) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width,
+        height,
+        background: 'var(--color-skeleton, #334155)',
+        borderRadius: '4px',
+        animation: 'pulse 1.5s ease-in-out infinite',
+      }}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Private profile page for the connected wallet.
+ * Redirects to wallet connect if no wallet is connected.
+ */
+export default function UserProfile({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!walletAddress && !isWalletLoading) {
+      navigate('/', { replace: true });
+    }
+  }, [walletAddress, isWalletLoading, navigate]);
+
+  const fetchProfile = useCallback(async () => {
+    if (!walletAddress) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch(apiUrl(`/participants/${walletAddress}/profile`));
+      if (res.status === 404) {
+        setProfile({ empty: true });
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setProfile(data);
+    } catch (err) {
+      setError('Failed to load profile. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [walletAddress]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const copyPublicUrl = () => {
+    const url = `${window.location.origin}/u/${walletAddress}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  if (!walletAddress) return null;
+
+  return (
+    <>
+      <PageMeta path="/profile" />
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletLoading={isWalletLoading}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+
+      <main className="profile-page" style={{ maxWidth: '800px', margin: '0 auto', padding: '2rem 1rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
+          <div>
+            <h1 style={{ margin: 0, fontSize: '1.5rem' }}>My Profile</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '6px' }}>
+              <code
+                title={walletAddress}
+                style={{ fontSize: '0.875rem', color: 'var(--color-text-secondary, #94a3b8)', cursor: 'pointer' }}
+                onClick={() => navigator.clipboard.writeText(walletAddress)}
+              >
+                {truncateAddress(walletAddress)}
+              </code>
+              <span style={{ fontSize: '0.75rem', color: 'var(--color-text-muted, #64748b)' }}>
+                (click to copy)
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={copyPublicUrl}
+            aria-label="Copy public profile link"
+          >
+            {copied ? 'Copied!' : 'Share Profile'}
+          </button>
+        </div>
+
+        {error && (
+          <p role="alert" style={{ color: 'var(--color-error, #ef4444)', marginBottom: '1.5rem' }}>
+            {error}
+          </p>
+        )}
+
+        <section aria-label="Stats" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+          {loading ? (
+            Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="profile-stat-card">
+                <Skeleton width="60%" height="2rem" />
+                <Skeleton width="80%" height="1rem" />
+              </div>
+            ))
+          ) : (
+            <>
+              <StatCard label="Campaigns joined" value={profile?.campaignCount ?? 0} />
+              <StatCard label="Points earned" value={profile?.totalPointsEarned ?? 0} />
+              <StatCard label="Points claimed" value={profile?.totalPointsClaimed ?? 0} />
+              <StatCard label="Net balance" value={profile?.netPoints ?? 0} />
+            </>
+          )}
+        </section>
+
+        <section aria-label="Recent activity" style={{ marginBottom: '2rem' }}>
+          <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Recent Activity</h2>
+          {loading ? (
+            Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} style={{ padding: '12px 0', borderBottom: '1px solid var(--color-border, #334155)' }}>
+                <Skeleton width="70%" />
+              </div>
+            ))
+          ) : !profile?.recentActivity?.length ? (
+            <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No activity yet.</p>
+          ) : (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {profile.recentActivity.map((event, i) => (
+                <li
+                  key={i}
+                  style={{ padding: '10px 0', borderBottom: '1px solid var(--color-border, #334155)', display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}
+                >
+                  <span>{event.description ?? event.action}</span>
+                  <time dateTime={event.timestamp} style={{ color: 'var(--color-text-secondary, #94a3b8)', fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
+                    {new Date(event.timestamp).toLocaleDateString()}
+                  </time>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section aria-label="Campaigns participated">
+          <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Campaigns</h2>
+          {loading ? (
+            <Skeleton width="100%" height="3rem" />
+          ) : !profile?.campaigns?.length ? (
+            <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No campaigns yet.</p>
+          ) : (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {profile.campaigns.map((c) => (
+                <li key={c.id}>
+                  <a href={`/campaign/${c.id}`} style={{ color: 'var(--color-primary, #38bdf8)' }}>
+                    {c.name}
+                  </a>
+                  <span style={{ marginLeft: '8px', fontSize: '0.875rem', color: 'var(--color-text-secondary, #94a3b8)' }}>
+                    {c.pointsEarned} pts
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {profile?.joinedDate && (
+          <p style={{ marginTop: '2rem', fontSize: '0.875rem', color: 'var(--color-text-muted, #64748b)' }}>
+            Member since {new Date(profile.joinedDate).toLocaleDateString()}
+          </p>
+        )}
+      </main>
+    </>
+  );
+}

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Trivela local dev setup script.
+# Run once after cloning to configure git hooks and tooling.
+
+set -euo pipefail
+
+echo "==> Setting up Trivela dev environment"
+
+# ── Node / npm ────────────────────────────────────────────────────────────────
+if ! command -v node &>/dev/null; then
+  echo "ERROR: Node.js is required. Install it from https://nodejs.org" >&2
+  exit 1
+fi
+
+echo "==> Installing npm dependencies"
+npm install
+
+# ── git-secrets pre-commit hook ───────────────────────────────────────────────
+# Scans staged files for secret patterns before each commit, mirroring the
+# gitleaks CI check locally. Requires git-secrets to be installed.
+# Install: https://github.com/awslabs/git-secrets#installing-git-secrets
+if command -v git-secrets &>/dev/null; then
+  echo "==> Configuring git-secrets"
+  git secrets --install --force
+  git secrets --register-aws
+  # Stellar secret key pattern: S[A-Z2-7]{55}
+  git secrets --add 'S[A-Z2-7]{55}'
+  # Trivela API key pattern
+  git secrets --add 'tvl_[a-zA-Z0-9]{32,}'
+  # Allow .env.example and fixture paths
+  git secrets --add-provider -- echo '.env.example test/fixtures docs/'
+  echo "  git-secrets configured. Staged secrets will be blocked pre-commit."
+else
+  echo "  WARN: git-secrets not found. Install it to enable local secret scanning."
+  echo "        https://github.com/awslabs/git-secrets#installing-git-secrets"
+fi
+
+echo ""
+echo "Dev setup complete. Start the backend with: npm run dev"


### PR DESCRIPTION
Closes #466

---

Closes #463

---

Closes #473

---

Closes #485

---

Addresses #463, #466, #473, #485.

## #463 — Campaign metrics CSV/JSON export

- `backend/src/routes/campaignExport.js` — new route: `GET /api/v1/campaigns/:id/export?format=csv|json` (API key required)
- CSV columns: `participantAddress`, `registeredAt`, `pointsCredited`, `pointsClaimed`, `netPoints`, `referredBy`
- JSON: `{ campaign, participants }` structure
- Streaming via Node.js `pipeline()` — dataset not buffered in memory
- Date range filter: `?from` / `?to`
- Rate limit: 5 exports per campaign per hour (per API key / IP)
- Audit log entry on every export

## #466 — API versioning and deprecation notices

- `backend/src/deprecations.js` — registry mapping route patterns to `{ deprecatedAt, removedAt, replacement, message }`
- `backend/src/middleware/deprecationNotice.js` — injects RFC 8594 headers (`Deprecation`, `Sunset`, `Link`) and WARN-logs each hit
- `GET /api/v1/deprecations` — returns full registry as JSON
- `backend/README.md` — documents 90-day notice policy and content negotiation

## #473 — User profile page

- `frontend/src/pages/UserProfile.jsx` — `/profile` route; shows stats (campaigns joined, points earned/claimed/net), recent activity list, campaign list, joined date, share button
- Redirects to home if wallet not connected
- Loading skeletons while data fetches
- `frontend/src/App.jsx` — adds `/profile` route
- `frontend/src/components/Header.jsx` — adds Profile link in nav when wallet is connected

## #485 — Secrets scanning CI

- `.github/workflows/secrets-scan.yml` — gitleaks on every push and PR
- `.gitleaks.toml` — custom rules for Stellar secret keys and Trivela API key patterns; excludes `.env.example`, `test/fixtures/`, `docs/`
- `scripts/dev-setup.sh` — installs `git-secrets` pre-commit hook locally
- `docs/RUNBOOK.md` — secret rotation procedure
- `README.md` — adds secrets scanning badge