### PR TITLE
feat: export tests, deprecation registry, profile UX, and gitleaks patterns

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,10 +15,35 @@ description = "Trivela API key pattern"
 regex = '''tvl_[a-zA-Z0-9]{32,}'''
 tags = ["trivela", "api-key"]
 
+[[rules]]
+id = "pem-private-key"
+description = "PEM-encoded private key block"
+regex = '''-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----'''
+tags = ["pem", "private-key"]
+
+[[rules]]
+id = "jwt-secret-env"
+description = "JWT_SECRET value assignment in env files or shell"
+regex = '''JWT_SECRET\s*=\s*['"]?[A-Za-z0-9+/=\-_]{16,}['"]?'''
+tags = ["jwt", "secret"]
+
+[[rules]]
+id = "generic-high-entropy-secret"
+description = "Assignment to variables named *_SECRET or *_PRIVATE_KEY with high-entropy values"
+regex = '''(?i)(secret|private_key)\s*[:=]\s*['"]?[A-Za-z0-9+/]{32,}['"]?'''
+tags = ["generic", "secret"]
+
+[[rules]]
+id = "keeper-secret-key"
+description = "KEEPER_SECRET_KEY Stellar value"
+regex = '''KEEPER_SECRET_KEY\s*=\s*['"]?S[A-Z2-7]{55}['"]?'''
+tags = ["stellar", "keeper"]
+
 [allowlist]
 description = "Safe paths — example files, test fixtures, docs"
 paths = [
   '''.env\.example''',
   '''test[s]?/fixtures/''',
   '''docs/''',
+  '''\.gitleaks\.toml''',
 ]

--- a/backend/src/deprecations.js
+++ b/backend/src/deprecations.js
@@ -1,17 +1,60 @@
 // @ts-check
 
 /**
+ * @typedef {{ deprecatedAt: string, removedAt: string, replacement: string, message: string }} DeprecationEntry
+ */
+
+/**
  * Deprecation registry — maps route patterns to lifecycle metadata.
- * Add entries here before removing or replacing any endpoint.
  *
- * @type {Record<string, { deprecatedAt: string, removedAt: string, replacement: string, message: string }>}
+ * All legacy /api/* routes are deprecated in favour of their /api/v1/* equivalents.
+ * A minimum 90-day notice period applies. Add entries here before removing or
+ * replacing any endpoint; the deprecationNotice middleware reads this map at
+ * runtime and injects RFC 8594 Deprecation / Sunset / Link headers automatically.
+ *
+ * @type {Record<string, DeprecationEntry>}
  */
 export const DEPRECATION_REGISTRY = {
-  // Example — uncomment when real deprecations land:
-  // 'GET /api/v1/campaigns/:id/stats': {
-  //   deprecatedAt: '2024-09-01',
-  //   removedAt: '2024-12-01',
-  //   replacement: '/api/v1/campaigns/:id/analytics',
-  //   message: 'Use the /analytics endpoint for richer campaign stats.',
-  // },
+  'GET /api/campaigns': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns',
+    message: 'Use GET /api/v1/campaigns for the versioned campaign list.',
+  },
+  'GET /api/campaigns/:id': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns/:id',
+    message: 'Use GET /api/v1/campaigns/:id for the versioned campaign detail.',
+  },
+  'POST /api/campaigns': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns',
+    message: 'Use POST /api/v1/campaigns to create campaigns.',
+  },
+  'PUT /api/campaigns/:id': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns/:id',
+    message: 'Use PUT /api/v1/campaigns/:id to update campaigns.',
+  },
+  'DELETE /api/campaigns/:id': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns/:id',
+    message: 'Use DELETE /api/v1/campaigns/:id to delete campaigns.',
+  },
+  'GET /api/campaigns/:id/stats': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns/:id/stats',
+    message: 'Use GET /api/v1/campaigns/:id/stats for the versioned stats endpoint.',
+  },
+  'GET /api/campaigns/:id/export': {
+    deprecatedAt: '2026-06-01',
+    removedAt: '2026-09-01',
+    replacement: '/api/v1/campaigns/:id/export',
+    message: 'Use GET /api/v1/campaigns/:id/export for the versioned export endpoint.',
+  },
 };

--- a/backend/src/middleware/deprecationNotice.js
+++ b/backend/src/middleware/deprecationNotice.js
@@ -2,16 +2,21 @@
 import { DEPRECATION_REGISTRY } from '../deprecations.js';
 
 /**
- * Match a request path+method against the deprecation registry.
+ * @typedef {{ deprecatedAt: string, removedAt: string, replacement: string, message: string }} DeprecationEntry
+ */
+
+/**
+ * Match a request path+method against a deprecation registry.
  * Registry keys are like "GET /api/v1/campaigns/:id/stats"; path segments
  * starting with ":" are treated as wildcards.
  *
  * @param {string} method  e.g. "GET"
  * @param {string} path    e.g. "/api/v1/campaigns/42/stats"
- * @returns {import('../deprecations.js').DeprecationEntry | null}
+ * @param {Record<string, DeprecationEntry>} registry
+ * @returns {DeprecationEntry | null}
  */
-function matchDeprecation(method, path) {
-  for (const [pattern, entry] of Object.entries(DEPRECATION_REGISTRY)) {
+function matchDeprecation(method, path, registry) {
+  for (const [pattern, entry] of Object.entries(registry)) {
     const [patternMethod, ...rest] = pattern.split(' ');
     const patternPath = rest.join(' ');
 
@@ -36,12 +41,12 @@ function matchDeprecation(method, path) {
  * any route registered in the deprecation registry, and WARN-logs usage
  * so operators know which deprecated endpoints are still being hit.
  *
- * @param {{ log?: { warn?: Function } }} [options]
+ * @param {{ log?: { warn?: Function }, registry?: Record<string, DeprecationEntry> }} [options]
  * @returns {import('express').RequestHandler}
  */
-export function createDeprecationMiddleware({ log = console } = {}) {
+export function createDeprecationMiddleware({ log = console, registry = DEPRECATION_REGISTRY } = {}) {
   return function deprecationNotice(req, res, next) {
-    const entry = matchDeprecation(req.method, req.path);
+    const entry = matchDeprecation(req.method, req.path, registry);
 
     if (entry) {
       const deprecationDate = new Date(entry.deprecatedAt).toUTCString();

--- a/backend/src/middleware/deprecationNotice.test.js
+++ b/backend/src/middleware/deprecationNotice.test.js
@@ -1,0 +1,159 @@
+// @ts-check
+/**
+ * Unit tests for the deprecation notice middleware.
+ * Run with: node --test src/middleware/deprecationNotice.test.js
+ */
+
+import test, { describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDeprecationMiddleware } from './deprecationNotice.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReqRes({ method = 'GET', path = '/api/v1/campaigns' } = {}) {
+  const req = { method, path };
+  const headers = {};
+  const res = {
+    setHeader(k, v) { headers[k] = v; },
+    getHeaders: () => headers,
+    _headers: headers,
+  };
+  return { req, res, headers };
+}
+
+function makeLogger() {
+  const warns = [];
+  return {
+    warn: (...args) => warns.push(args.join(' ')),
+    warns,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createDeprecationMiddleware', () => {
+  test('calls next() even when no deprecation matches', (_, done) => {
+    const mw = createDeprecationMiddleware({});
+    const { req, res } = makeReqRes({ path: '/api/v1/campaigns' });
+    mw(req, res, () => done());
+  });
+
+  test('does not set headers when route is not deprecated', () => {
+    const mw = createDeprecationMiddleware({});
+    const { req, res, headers } = makeReqRes({ path: '/api/v1/campaigns' });
+    mw(req, res, () => {});
+    assert.ok(!headers['Deprecation'], 'should not set Deprecation header');
+    assert.ok(!headers['Sunset'], 'should not set Sunset header');
+    assert.ok(!headers['Link'], 'should not set Link header');
+  });
+
+  test('sets Deprecation, Sunset, and Link headers for a registered route', () => {
+    const registry = {
+      'GET /api/campaigns': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns',
+        message: 'Use /api/v1/campaigns instead.',
+      },
+    };
+    const mw = createDeprecationMiddleware({ registry });
+    const { req, res, headers } = makeReqRes({ method: 'GET', path: '/api/campaigns' });
+    mw(req, res, () => {});
+    assert.ok(headers['Deprecation'], 'missing Deprecation header');
+    assert.ok(headers['Sunset'], 'missing Sunset header');
+    assert.ok(headers['Link'], 'missing Link header');
+    assert.ok(headers['Link'].includes('/api/v1/campaigns'), 'Link should point to replacement');
+  });
+
+  test('matches parameterized segments — /api/campaigns/:id', () => {
+    const registry = {
+      'GET /api/campaigns/:id': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns/:id',
+        message: 'Use /api/v1/campaigns/:id instead.',
+      },
+    };
+    const mw = createDeprecationMiddleware({ registry });
+    const { req, res, headers } = makeReqRes({ method: 'GET', path: '/api/campaigns/abc123' });
+    mw(req, res, () => {});
+    assert.ok(headers['Deprecation'], 'parameterized path should match');
+  });
+
+  test('does not match wrong HTTP method', () => {
+    const registry = {
+      'GET /api/campaigns': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns',
+        message: '',
+      },
+    };
+    const mw = createDeprecationMiddleware({ registry });
+    const { req, res, headers } = makeReqRes({ method: 'POST', path: '/api/campaigns' });
+    mw(req, res, () => {});
+    assert.ok(!headers['Deprecation'], 'should not match a different HTTP method');
+  });
+
+  test('does not match a path with a different segment count', () => {
+    const registry = {
+      'GET /api/campaigns': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns',
+        message: '',
+      },
+    };
+    const mw = createDeprecationMiddleware({ registry });
+    const { req, res, headers } = makeReqRes({ method: 'GET', path: '/api/campaigns/extra/segment' });
+    mw(req, res, () => {});
+    assert.ok(!headers['Deprecation'], 'should not match paths with extra segments');
+  });
+
+  test('WARN-logs on deprecated endpoint hit', () => {
+    const registry = {
+      'GET /api/campaigns': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns',
+        message: 'Legacy route.',
+      },
+    };
+    const log = makeLogger();
+    const mw = createDeprecationMiddleware({ log, registry });
+    const { req, res } = makeReqRes({ method: 'GET', path: '/api/campaigns' });
+    mw(req, res, () => {});
+    assert.equal(log.warns.length, 1);
+    assert.ok(log.warns[0].includes('deprecated_endpoint_hit'));
+    assert.ok(log.warns[0].includes('/api/campaigns'));
+  });
+
+  test('does not WARN-log for non-deprecated routes', () => {
+    const log = makeLogger();
+    const mw = createDeprecationMiddleware({ log, registry: {} });
+    const { req, res } = makeReqRes({ path: '/api/v1/campaigns' });
+    mw(req, res, () => {});
+    assert.equal(log.warns.length, 0);
+  });
+
+  test('Deprecation header value is a valid HTTP date string', () => {
+    const registry = {
+      'GET /api/campaigns': {
+        deprecatedAt: '2026-01-01',
+        removedAt: '2026-12-31',
+        replacement: '/api/v1/campaigns',
+        message: '',
+      },
+    };
+    const mw = createDeprecationMiddleware({ registry });
+    const { req, res, headers } = makeReqRes({ method: 'GET', path: '/api/campaigns' });
+    mw(req, res, () => {});
+    assert.ok(!isNaN(Date.parse(headers['Deprecation'])), 'Deprecation header should be a parseable date');
+  });
+
+  test('handles an empty registry without errors', () => {
+    const mw = createDeprecationMiddleware({ registry: {} });
+    const { req, res } = makeReqRes({ path: '/api/v1/anything' });
+    assert.doesNotThrow(() => mw(req, res, () => {}));
+  });
+});

--- a/backend/src/routes/campaignExport.test.js
+++ b/backend/src/routes/campaignExport.test.js
@@ -1,0 +1,506 @@
+// @ts-check
+/**
+ * Unit tests for the campaign export route.
+ * Run with: node --test src/routes/campaignExport.test.js
+ */
+
+import test, { describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCampaignExportRoute } from './campaignExport.js';
+
+// ── Fakes ─────────────────────────────────────────────────────────────────────
+
+function makeDb(rows = [], { hasCreditEvents = true, hasClaimEvents = true } = {}) {
+  return {
+    prepare(sql) {
+      if (sql.includes("sqlite_master") && sql.includes("credit_events")) {
+        return { get: () => hasCreditEvents ? { name: 'credit_events' } : undefined };
+      }
+      if (sql.includes("sqlite_master") && sql.includes("claim_events")) {
+        return { get: () => hasClaimEvents ? { name: 'claim_events' } : undefined };
+      }
+      return { all: (..._args) => rows, get: () => undefined };
+    },
+  };
+}
+
+function makeCampaignRepo(campaign = null) {
+  return { getById: (id) => campaign ?? (id === 'camp1' ? { id: 'camp1', name: 'Test Campaign' } : null) };
+}
+
+function makeAuditRepo() {
+  const calls = [];
+  return {
+    create: (entry) => calls.push(entry),
+    calls,
+  };
+}
+
+function makeRequireApiKey(req, res, next) {
+  next();
+}
+
+function makeReq({ params = {}, query = {}, headers = {}, ip = '1.2.3.4' } = {}) {
+  return { params, query, headers, ip, path: '/campaigns/' + (params.id ?? 'x') + '/export' };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _headers: {},
+    _body: null,
+    status(code) { this._status = code; return this; },
+    setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+    json(body) { this._body = body; return this; },
+  };
+  return res;
+}
+
+// Wraps pipeline streaming into a buffer we can assert against
+function makeStreamRes() {
+  const res = makeRes();
+  const chunks = [];
+  res.write = (chunk) => chunks.push(chunk);
+  res.end = () => {};
+  res.on = (event, cb) => { if (event === 'drain') {} };
+  res.once = () => res;
+  res.emit = () => false;
+  res.writable = true;
+  res.writableEnded = false;
+  res.writableFinished = false;
+  res._getBody = () => chunks.join('');
+  return res;
+}
+
+async function callExport(handler, req, res) {
+  return new Promise((resolve) => {
+    handler(req, res, resolve);
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getRouter(opts = {}) {
+  const db = opts.db ?? makeDb(opts.rows ?? []);
+  const campaignRepository = opts.campaignRepo ?? makeCampaignRepo();
+  const auditLogRepository = opts.auditRepo ?? makeAuditRepo();
+  const requireApiKey = opts.requireApiKey ?? makeRequireApiKey;
+  return createCampaignExportRoute({ db, campaignRepository, auditLogRepository, requireApiKey });
+}
+
+function routeHandler(router) {
+  // Extract the GET handler from the Express router stack
+  const layer = router.stack.find((l) => l.route?.path === '/campaigns/:id/export');
+  if (!layer) throw new Error('Route not found');
+  const handlers = layer.route.stack.map((s) => s.handle);
+  return async (req, res) => {
+    let i = 0;
+    const next = () => { i++; if (i < handlers.length) return handlers[i](req, res, next); };
+    return handlers[0](req, res, next);
+  };
+}
+
+// ── Tests: validation ────────────────────────────────────────────────────────
+
+describe('campaignExport — validation', () => {
+  test('returns 400 for invalid format', async () => {
+    const router = getRouter();
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: 'camp1' }, query: { format: 'xml' } });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    assert.equal(res._status, 400);
+    assert.equal(res._body?.code, 'INVALID_FORMAT');
+  });
+
+  test('returns 404 when campaign does not exist', async () => {
+    const router = getRouter({ campaignRepo: { getById: () => null } });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: 'nonexistent' }, query: { format: 'csv' } });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    assert.equal(res._status, 404);
+    assert.equal(res._body?.code, 'NOT_FOUND');
+  });
+});
+
+// ── Tests: rate limiting ─────────────────────────────────────────────────────
+
+describe('campaignExport — rate limiting', () => {
+  test('sets X-RateLimit-Limit and X-RateLimit-Remaining headers', async () => {
+    // Use a unique campaign ID to avoid state leakage from other tests
+    const uniqueId = `rl-headers-${Date.now()}`;
+    const router = getRouter({
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'RL Test' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': 'key-rl-1' } });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    assert.equal(res._headers['x-ratelimit-limit'], '5');
+    assert.ok(res._headers['x-ratelimit-remaining'] !== undefined);
+  });
+
+  test('returns 429 after exceeding 5 exports per campaign per actor', async () => {
+    const uniqueId = `rl-throttle-${Date.now()}`;
+    const router = getRouter({
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'RL Throttle' } : null },
+    });
+    const handler = routeHandler(router);
+
+    // Exhaust 5 allowed exports
+    for (let i = 0; i < 5; i++) {
+      const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': 'key-rl-throttle' } });
+      const res = makeRes();
+      await handler(req, res);
+    }
+
+    // 6th should be rate-limited
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': 'key-rl-throttle' } });
+    const res = makeRes();
+    await handler(req, res);
+
+    assert.equal(res._status, 429);
+    assert.equal(res._body?.code, 'EXPORT_RATE_LIMIT_EXCEEDED');
+    assert.ok(res._headers['retry-after']);
+  });
+
+  test('different API keys have independent rate limit buckets', async () => {
+    const uniqueId = `rl-keys-${Date.now()}`;
+    const router = getRouter({
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'RL Keys' } : null },
+    });
+    const handler = routeHandler(router);
+
+    // Exhaust key-A
+    for (let i = 0; i < 5; i++) {
+      const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': 'key-A-isolated' } });
+      const res = makeRes();
+      await handler(req, res);
+    }
+
+    // key-B should still be allowed
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': 'key-B-isolated' } });
+    const res = makeRes();
+    await handler(req, res);
+
+    assert.notEqual(res._status, 429);
+  });
+});
+
+// ── Tests: CSV format ────────────────────────────────────────────────────────
+
+describe('campaignExport — CSV format', () => {
+  const PARTICIPANT_ROWS = [
+    { participantAddress: 'GABC', registeredAt: '2026-01-01', pointsCredited: 100, pointsClaimed: 50, netPoints: 50, referredBy: 'GXYZ' },
+    { participantAddress: 'GDEF', registeredAt: '2026-01-02', pointsCredited: 200, pointsClaimed: 0, netPoints: 200, referredBy: null },
+  ];
+
+  test('sets Content-Type text/csv and Content-Disposition attachment', async () => {
+    const uniqueId = `csv-headers-${Date.now()}`;
+    const router = getRouter({
+      rows: PARTICIPANT_ROWS,
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'CSV' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': `k-${uniqueId}` } });
+    const res = makeRes();
+
+    await handler(req, res);
+
+    assert.ok(res._headers['content-type']?.includes('text/csv'));
+    assert.ok(res._headers['content-disposition']?.includes('attachment'));
+    assert.ok(res._headers['content-disposition']?.includes('.csv'));
+  });
+
+  test('CSV header row contains all required columns', async () => {
+    const uniqueId = `csv-cols-${Date.now()}`;
+    const auditRepo = makeAuditRepo();
+    const router = getRouter({
+      rows: PARTICIPANT_ROWS,
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'CSV Cols' } : null },
+      auditRepo,
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': `k-${uniqueId}` } });
+
+    // Capture streamed output by intercepting the underlying stream pipeline
+    let csvBody = '';
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write(chunk) { csvBody += chunk; },
+      end() {},
+      on(e, cb) { return this; },
+      once(e, cb) { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    const firstLine = csvBody.split('\n')[0] ?? '';
+    assert.ok(firstLine.includes('participantAddress'), 'missing participantAddress');
+    assert.ok(firstLine.includes('registeredAt'), 'missing registeredAt');
+    assert.ok(firstLine.includes('pointsCredited'), 'missing pointsCredited');
+    assert.ok(firstLine.includes('pointsClaimed'), 'missing pointsClaimed');
+    assert.ok(firstLine.includes('netPoints'), 'missing netPoints');
+    assert.ok(firstLine.includes('referredBy'), 'missing referredBy');
+  });
+
+  test('CSV escapes values containing commas', async () => {
+    const { buildCsv } = await import('./campaignExport.js').catch(() => ({}));
+    if (!buildCsv) return; // not exported — skip
+
+    const columns = ['a', 'b'];
+    const rows = [{ a: 'hello, world', b: 'normal' }];
+    const csv = buildCsv(columns, rows);
+    assert.ok(csv.includes('"hello, world"'));
+  });
+});
+
+// ── Tests: JSON format ───────────────────────────────────────────────────────
+
+describe('campaignExport — JSON format', () => {
+  test('sets Content-Type application/json and Content-Disposition attachment', async () => {
+    const uniqueId = `json-headers-${Date.now()}`;
+    const router = getRouter({
+      rows: [],
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'JSON Test' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'json' }, headers: { 'x-api-key': `k-${uniqueId}` } });
+
+    let body = '';
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write(chunk) { body += chunk; },
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    assert.ok(res._headers['content-type']?.includes('application/json'));
+    assert.ok(res._headers['content-disposition']?.includes('attachment'));
+    assert.ok(res._headers['content-disposition']?.includes('.json'));
+  });
+
+  test('JSON export includes campaign metadata and participants array', async () => {
+    const uniqueId = `json-shape-${Date.now()}`;
+    const router = getRouter({
+      rows: [{ participantAddress: 'GABC', registeredAt: '2026-01-01', pointsCredited: 10, pointsClaimed: 0, netPoints: 10, referredBy: null }],
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'Shape Test' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'json' }, headers: { 'x-api-key': `k-${uniqueId}` } });
+
+    let body = '';
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write(chunk) { body += chunk; },
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    const parsed = JSON.parse(body);
+    assert.ok('campaign' in parsed, 'missing campaign key');
+    assert.ok('participants' in parsed, 'missing participants key');
+    assert.ok(Array.isArray(parsed.participants));
+    assert.equal(parsed.campaign.id, uniqueId);
+    assert.equal(parsed.campaign.name, 'Shape Test');
+  });
+});
+
+// ── Tests: date range filter ─────────────────────────────────────────────────
+
+describe('campaignExport — date range filter', () => {
+  test('accepts ?from and ?to without error when credit_events table is absent', async () => {
+    const uniqueId = `date-filter-${Date.now()}`;
+    const router = getRouter({
+      rows: [],
+      db: makeDb([], { hasCreditEvents: false }),
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'Date Test' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({
+      params: { id: uniqueId },
+      query: { format: 'csv', from: '2026-01-01', to: '2026-06-01' },
+      headers: { 'x-api-key': `k-${uniqueId}` },
+    });
+
+    let body = '';
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write(chunk) { body += chunk; },
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    assert.notEqual(res._status, 400);
+    assert.notEqual(res._status, 500);
+  });
+});
+
+// ── Tests: audit log ─────────────────────────────────────────────────────────
+
+describe('campaignExport — audit log', () => {
+  test('creates an audit log entry on every successful export', async () => {
+    const uniqueId = `audit-${Date.now()}`;
+    const auditRepo = makeAuditRepo();
+    const router = getRouter({
+      rows: [],
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'Audit Test' } : null },
+      auditRepo,
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': `k-audit-${uniqueId}` } });
+
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write() {},
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    assert.equal(auditRepo.calls.length, 1);
+    const entry = auditRepo.calls[0];
+    assert.equal(entry.action, 'campaign.export');
+    assert.equal(entry.entity, 'campaign');
+    assert.equal(entry.entityId, uniqueId);
+    assert.equal(entry.diff.format, 'csv');
+  });
+
+  test('does not fail if audit log throws', async () => {
+    const uniqueId = `audit-fail-${Date.now()}`;
+    const failingAuditRepo = { create: () => { throw new Error('audit DB down'); } };
+    const router = getRouter({
+      rows: [],
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'Audit Fail' } : null },
+      auditRepo: failingAuditRepo,
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'csv' }, headers: { 'x-api-key': `k-af-${uniqueId}` } });
+
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write() {},
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await assert.doesNotReject(() => handler(req, res));
+  });
+});
+
+// ── Tests: referrals-only fallback ───────────────────────────────────────────
+
+describe('campaignExport — referrals-only fallback', () => {
+  test('falls back to referrals when credit_events table does not exist', async () => {
+    const uniqueId = `fallback-${Date.now()}`;
+    const referralRows = [
+      { referee_address: 'GABC', referrer_address: 'GXYZ', created_at: '2026-01-01' },
+    ];
+    const router = getRouter({
+      db: makeDb(referralRows, { hasCreditEvents: false }),
+      campaignRepo: { getById: (id) => id === uniqueId ? { id: uniqueId, name: 'Fallback Test' } : null },
+    });
+    const handler = routeHandler(router);
+    const req = makeReq({ params: { id: uniqueId }, query: { format: 'json' }, headers: { 'x-api-key': `k-fb-${uniqueId}` } });
+
+    let body = '';
+    const res = {
+      _status: 200,
+      _headers: {},
+      status(c) { this._status = c; return this; },
+      setHeader(k, v) { this._headers[k.toLowerCase()] = v; },
+      json(b) { this._body = b; return this; },
+      write(chunk) { body += chunk; },
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      writable: true,
+      writableEnded: false,
+      writableFinished: false,
+      destroy() {},
+    };
+
+    await handler(req, res);
+
+    const parsed = JSON.parse(body);
+    assert.equal(parsed.participants.length, 1);
+    assert.equal(parsed.participants[0].participantAddress, 'GABC');
+    assert.equal(parsed.participants[0].referredBy, 'GXYZ');
+    assert.equal(parsed.participants[0].pointsCredited, 0);
+    assert.equal(parsed.participants[0].pointsClaimed, 0);
+  });
+});

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -36,7 +36,7 @@ function Skeleton({ width = '100%', height = '1.2em' }) {
 
 /**
  * Private profile page for the connected wallet.
- * Redirects to wallet connect if no wallet is connected.
+ * Redirects home if no wallet is connected.
  */
 export default function UserProfile({
   theme,
@@ -129,93 +129,132 @@ export default function UserProfile({
               </span>
             </div>
           </div>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={copyPublicUrl}
-            aria-label="Copy public profile link"
-          >
-            {copied ? 'Copied!' : 'Share Profile'}
-          </button>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={fetchProfile}
+              disabled={loading}
+              aria-label="Refresh profile data"
+            >
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={copyPublicUrl}
+              aria-label="Copy public profile link"
+            >
+              {copied ? 'Copied!' : 'Share Profile'}
+            </button>
+          </div>
         </div>
 
         {error && (
-          <p role="alert" style={{ color: 'var(--color-error, #ef4444)', marginBottom: '1.5rem' }}>
-            {error}
-          </p>
+          <div
+            role="alert"
+            style={{ display: 'flex', alignItems: 'center', gap: '12px', color: 'var(--color-error, #ef4444)', marginBottom: '1.5rem', padding: '12px 16px', background: 'rgba(239,68,68,0.08)', borderRadius: '8px', border: '1px solid rgba(239,68,68,0.2)' }}
+          >
+            <span style={{ flex: 1 }}>{error}</span>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              style={{ fontSize: '0.8125rem', padding: '4px 12px' }}
+              onClick={fetchProfile}
+            >
+              Retry
+            </button>
+          </div>
         )}
 
-        <section aria-label="Stats" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
-          {loading ? (
-            Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="profile-stat-card">
-                <Skeleton width="60%" height="2rem" />
-                <Skeleton width="80%" height="1rem" />
-              </div>
-            ))
-          ) : (
-            <>
-              <StatCard label="Campaigns joined" value={profile?.campaignCount ?? 0} />
-              <StatCard label="Points earned" value={profile?.totalPointsEarned ?? 0} />
-              <StatCard label="Points claimed" value={profile?.totalPointsClaimed ?? 0} />
-              <StatCard label="Net balance" value={profile?.netPoints ?? 0} />
-            </>
-          )}
-        </section>
+        {!loading && profile?.empty && (
+          <div
+            role="status"
+            style={{ textAlign: 'center', padding: '3rem 1rem', color: 'var(--color-text-secondary, #94a3b8)' }}
+          >
+            <p style={{ fontSize: '1.125rem', marginBottom: '0.5rem' }}>No activity yet</p>
+            <p style={{ fontSize: '0.875rem' }}>
+              Join a campaign to start earning rewards.{' '}
+              <a href="/" style={{ color: 'var(--color-primary, #38bdf8)' }}>Browse campaigns →</a>
+            </p>
+          </div>
+        )}
 
-        <section aria-label="Recent activity" style={{ marginBottom: '2rem' }}>
-          <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Recent Activity</h2>
-          {loading ? (
-            Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} style={{ padding: '12px 0', borderBottom: '1px solid var(--color-border, #334155)' }}>
-                <Skeleton width="70%" />
-              </div>
-            ))
-          ) : !profile?.recentActivity?.length ? (
-            <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No activity yet.</p>
-          ) : (
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {profile.recentActivity.map((event, i) => (
-                <li
-                  key={i}
-                  style={{ padding: '10px 0', borderBottom: '1px solid var(--color-border, #334155)', display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}
-                >
-                  <span>{event.description ?? event.action}</span>
-                  <time dateTime={event.timestamp} style={{ color: 'var(--color-text-secondary, #94a3b8)', fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
-                    {new Date(event.timestamp).toLocaleDateString()}
-                  </time>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
+        {(loading || !profile?.empty) && (
+          <>
+            <section aria-label="Stats" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '2rem' }}>
+              {loading ? (
+                Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="profile-stat-card">
+                    <Skeleton width="60%" height="2rem" />
+                    <Skeleton width="80%" height="1rem" />
+                  </div>
+                ))
+              ) : (
+                <>
+                  <StatCard label="Campaigns joined" value={profile?.campaignCount ?? 0} />
+                  <StatCard label="Points earned" value={profile?.totalPointsEarned ?? 0} />
+                  <StatCard label="Points claimed" value={profile?.totalPointsClaimed ?? 0} />
+                  <StatCard label="Net balance" value={profile?.netPoints ?? 0} />
+                </>
+              )}
+            </section>
 
-        <section aria-label="Campaigns participated">
-          <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Campaigns</h2>
-          {loading ? (
-            <Skeleton width="100%" height="3rem" />
-          ) : !profile?.campaigns?.length ? (
-            <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No campaigns yet.</p>
-          ) : (
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              {profile.campaigns.map((c) => (
-                <li key={c.id}>
-                  <a href={`/campaign/${c.id}`} style={{ color: 'var(--color-primary, #38bdf8)' }}>
-                    {c.name}
-                  </a>
-                  <span style={{ marginLeft: '8px', fontSize: '0.875rem', color: 'var(--color-text-secondary, #94a3b8)' }}>
-                    {c.pointsEarned} pts
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
+            <section aria-label="Recent activity" style={{ marginBottom: '2rem' }}>
+              <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Recent Activity</h2>
+              {loading ? (
+                Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} style={{ padding: '12px 0', borderBottom: '1px solid var(--color-border, #334155)' }}>
+                    <Skeleton width="70%" />
+                  </div>
+                ))
+              ) : !profile?.recentActivity?.length ? (
+                <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No activity yet.</p>
+              ) : (
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                  {profile.recentActivity.map((event, i) => (
+                    <li
+                      key={i}
+                      style={{ padding: '10px 0', borderBottom: '1px solid var(--color-border, #334155)', display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}
+                    >
+                      <span>{event.description ?? event.action}</span>
+                      <time dateTime={event.timestamp} style={{ color: 'var(--color-text-secondary, #94a3b8)', fontSize: '0.875rem', whiteSpace: 'nowrap' }}>
+                        {new Date(event.timestamp).toLocaleDateString()}
+                      </time>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
 
-        {profile?.joinedDate && (
-          <p style={{ marginTop: '2rem', fontSize: '0.875rem', color: 'var(--color-text-muted, #64748b)' }}>
-            Member since {new Date(profile.joinedDate).toLocaleDateString()}
-          </p>
+            <section aria-label="Campaigns participated">
+              <h2 style={{ fontSize: '1.125rem', marginBottom: '1rem' }}>Campaigns</h2>
+              {loading ? (
+                <Skeleton width="100%" height="3rem" />
+              ) : !profile?.campaigns?.length ? (
+                <p style={{ color: 'var(--color-text-secondary, #94a3b8)' }}>No campaigns yet.</p>
+              ) : (
+                <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  {profile.campaigns.map((c) => (
+                    <li key={c.id}>
+                      <a href={`/campaign/${c.id}`} style={{ color: 'var(--color-primary, #38bdf8)' }}>
+                        {c.name}
+                      </a>
+                      <span style={{ marginLeft: '8px', fontSize: '0.875rem', color: 'var(--color-text-secondary, #94a3b8)' }}>
+                        {c.pointsEarned} pts
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {profile?.joinedDate && (
+              <p style={{ marginTop: '2rem', fontSize: '0.875rem', color: 'var(--color-text-muted, #64748b)' }}>
+                Member since {new Date(profile.joinedDate).toLocaleDateString()}
+              </p>
+            )}
+          </>
         )}
       </main>
     </>


### PR DESCRIPTION
Closes #463

---

Closes #473

---

Closes #466

---

Closes #485

---

## Summary

- **Campaign export unit tests** — covers CSV headers/columns, JSON shape, rate limiting (429 + Retry-After, per-actor isolation), date range filter, audit log creation, non-fatal audit errors, and referrals-only fallback (#463)
- **Deprecation middleware: injectable registry** — `createDeprecationMiddleware` now accepts an optional `registry` parameter (defaults to `DEPRECATION_REGISTRY`), enabling isolated unit tests without module mocking (#466)
- **Deprecation middleware tests** — 9 tests: header injection, parameterised path matching, method mismatch, segment-count mismatch, WARN logging, log silence for non-deprecated routes, valid HTTP date format, empty registry safety (#466)
- **Populated deprecation registry** — all legacy `/api/` campaign routes now have 90-day sunset entries pointing to their `/api/v1/` successors (`campaigns`, `campaigns/:id`, stats, export — GET/POST/PUT/DELETE) (#466)
- **User profile: retry + empty-state UX** — added inline Retry button inside the error alert, a standalone Refresh button next to Share Profile, and a dedicated empty-state panel with a "Browse campaigns →" link for new wallets with no activity (#473)
- **Gitleaks: additional secret patterns** — PEM private key blocks, `JWT_SECRET` env assignments, generic `*_SECRET`/`*_PRIVATE_KEY` high-entropy values, and `KEEPER_SECRET_KEY` Stellar assignments (#485)

## Changes

| File | Type | Issue |
|------|------|-------|
| `backend/src/routes/campaignExport.test.js` | NEW | #463 |
| `backend/src/middleware/deprecationNotice.js` | UPDATED | #466 |
| `backend/src/middleware/deprecationNotice.test.js` | NEW | #466 |
| `backend/src/deprecations.js` | UPDATED | #466 |
| `frontend/src/pages/UserProfile.jsx` | UPDATED | #473 |
| `.gitleaks.toml` | UPDATED | #485 |

## Test plan

- [ ] `npm run test:backend` — all export and deprecation tests pass
- [ ] Hit `GET /api/campaigns` — response includes `Deprecation`, `Sunset`, `Link` headers
- [ ] Hit `GET /api/v1/campaigns` — no deprecation headers
- [ ] Hit `/profile` with a brand-new wallet — empty-state panel appears instead of blank sections
- [ ] Hit `/profile` with a network error — error alert shows Retry button; clicking it re-fetches
- [ ] Gitleaks scan passes on a file containing a known-safe Stellar pubkey (`G...`) and fails on a secret key (`S...`)