### PR TITLE
Add amount token formatter component

### DIFF
--- a/frontend/src/components/AmountFormatter.css
+++ b/frontend/src/components/AmountFormatter.css
@@ -1,0 +1,30 @@
+.amount-formatter {
+  display: inline-flex;
+  align-items: baseline;
+  max-width: 100%;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.amount-formatter-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.amount-formatter--default {
+  color: inherit;
+}
+
+.amount-formatter--accent {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.amount-formatter--muted {
+  color: var(--text-muted);
+}
+
+.amount-formatter--success {
+  color: var(--success);
+  font-weight: 700;
+}

--- a/frontend/src/components/AmountFormatter.jsx
+++ b/frontend/src/components/AmountFormatter.jsx
@@ -1,0 +1,38 @@
+import './AmountFormatter.css';
+import { formatTokenAmount } from '../lib/amountFormatter';
+
+export default function AmountFormatter({
+  value,
+  locale = 'en-US',
+  tokenSymbol = 'pts',
+  tokenDecimals = 0,
+  minimumFractionDigits = 0,
+  maximumFractionDigits = 2,
+  compact = false,
+  signDisplay = 'auto',
+  fallback = '—',
+  tone = 'default',
+  className = '',
+  ariaLabel,
+}) {
+  const label = formatTokenAmount(value, {
+    locale,
+    tokenSymbol,
+    tokenDecimals,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    compact,
+    signDisplay,
+    fallback,
+  });
+
+  const classes = ['amount-formatter', `amount-formatter--${tone}`, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={classes} aria-label={ariaLabel || label}>
+      <span className="amount-formatter-value">{label}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/AmountFormatter.test.jsx
+++ b/frontend/src/components/AmountFormatter.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { formatTokenAmount } from '../lib/amountFormatter';
+import AmountFormatter from './AmountFormatter';
+
+describe('formatTokenAmount', () => {
+  it('formats locale-aware token values with fractional digits', () => {
+    expect(formatTokenAmount(1234.567, { tokenSymbol: 'pts' })).toBe('1,234.57 pts');
+    expect(formatTokenAmount(25, { tokenSymbol: 'pts' })).toBe('25 pts');
+  });
+
+  it('scales raw integer token amounts when tokenDecimals is provided', () => {
+    expect(
+      formatTokenAmount('1234567', {
+        tokenSymbol: 'USDC',
+        tokenDecimals: 6,
+        maximumFractionDigits: 4,
+      }),
+    ).toBe('1.2346 USDC');
+  });
+
+  it('supports compact notation and explicit sign display', () => {
+    expect(
+      formatTokenAmount(1500000, {
+        tokenSymbol: 'XLM',
+        compact: true,
+        signDisplay: 'always',
+      }),
+    ).toBe('+1.5M XLM');
+  });
+
+  it('returns a fallback for empty or invalid values', () => {
+    expect(formatTokenAmount(null)).toBe('—');
+    expect(formatTokenAmount('not-a-number', { fallback: 'n/a' })).toBe('n/a');
+  });
+});
+
+describe('AmountFormatter', () => {
+  it('renders an accessible formatted amount', () => {
+    render(<AmountFormatter value={42} tokenSymbol="pts" ariaLabel="Campaign reward" />);
+
+    expect(screen.getByLabelText('Campaign reward').textContent).toBe('42 pts');
+  });
+
+  it('applies tone classes for design-system usage', () => {
+    render(<AmountFormatter value={12} tokenSymbol="XLM" tone="accent" />);
+
+    expect(screen.getByLabelText('12 XLM').classList.contains('amount-formatter--accent')).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/src/components/CampaignCard.jsx
+++ b/frontend/src/components/CampaignCard.jsx
@@ -1,5 +1,6 @@
 import { useId } from 'react';
 import { Link } from 'react-router-dom';
+import AmountFormatter from './AmountFormatter';
 import StatusBadge from './StatusBadge';
 import UrgencyBadge from './UrgencyBadge';
 
@@ -45,7 +46,9 @@ export default function CampaignCard({ campaign }) {
         <dl className="campaign-card-metadata">
           <div className="campaign-card-metadata-item">
             <dt>Reward</dt>
-            <dd>{rewardPerAction} pts</dd>
+            <dd>
+              <AmountFormatter value={rewardPerAction} tokenSymbol="pts" maximumFractionDigits={2} />
+            </dd>
           </div>
 
           {formattedDate && (

--- a/frontend/src/lib/amountFormatter.js
+++ b/frontend/src/lib/amountFormatter.js
@@ -1,0 +1,58 @@
+const DEFAULT_TOKEN_SYMBOL = 'pts';
+const DEFAULT_FALLBACK = '—';
+
+function clampFractionDigits(value, fallback) {
+  if (value == null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return fallback;
+  return Math.min(Math.max(parsed, 0), 20);
+}
+
+function normalizeAmount(value, tokenDecimals) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+
+  const scale = clampFractionDigits(tokenDecimals, 0);
+  return scale > 0 ? amount / 10 ** scale : amount;
+}
+
+export function formatTokenAmount(
+  value,
+  {
+    locale = 'en-US',
+    tokenSymbol = DEFAULT_TOKEN_SYMBOL,
+    tokenDecimals = 0,
+    minimumFractionDigits = 0,
+    maximumFractionDigits = 2,
+    compact = false,
+    signDisplay = 'auto',
+    fallback = DEFAULT_FALLBACK,
+  } = {},
+) {
+  const amount = normalizeAmount(value, tokenDecimals);
+  if (amount === null) {
+    return fallback;
+  }
+
+  const minFractionDigits = clampFractionDigits(minimumFractionDigits, 0);
+  const maxFractionDigits = Math.max(
+    minFractionDigits,
+    clampFractionDigits(maximumFractionDigits, 2),
+  );
+
+  const formatter = new Intl.NumberFormat(locale, {
+    notation: compact ? 'compact' : 'standard',
+    minimumFractionDigits: minFractionDigits,
+    maximumFractionDigits: maxFractionDigits,
+    signDisplay,
+  });
+
+  const formattedAmount = formatter.format(amount);
+  return tokenSymbol ? `${formattedAmount} ${tokenSymbol}` : formattedAmount;
+}

--- a/frontend/src/stories/AmountFormatter.stories.jsx
+++ b/frontend/src/stories/AmountFormatter.stories.jsx
@@ -1,0 +1,69 @@
+import AmountFormatter from '../components/AmountFormatter.jsx';
+
+export default {
+  title: 'Components/AmountFormatter',
+  component: AmountFormatter,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'number' },
+    locale: { control: 'text' },
+    tokenSymbol: { control: 'text' },
+    tokenDecimals: { control: 'number' },
+    minimumFractionDigits: { control: 'number' },
+    maximumFractionDigits: { control: 'number' },
+    compact: { control: 'boolean' },
+    signDisplay: {
+      control: 'select',
+      options: ['auto', 'always', 'exceptZero', 'negative', 'never'],
+    },
+    tone: {
+      control: 'select',
+      options: ['default', 'accent', 'muted', 'success'],
+    },
+  },
+};
+
+export const Points = {
+  args: {
+    value: 1234.567,
+    tokenSymbol: 'pts',
+    maximumFractionDigits: 2,
+    tone: 'accent',
+  },
+};
+
+export const StellarLumens = {
+  args: {
+    value: 98765.4321,
+    tokenSymbol: 'XLM',
+    maximumFractionDigits: 4,
+  },
+};
+
+export const RawUsdcAmount = {
+  args: {
+    value: 1234567,
+    tokenSymbol: 'USDC',
+    tokenDecimals: 6,
+    maximumFractionDigits: 4,
+    tone: 'success',
+  },
+};
+
+export const CompactSigned = {
+  args: {
+    value: 1500000,
+    tokenSymbol: 'XLM',
+    compact: true,
+    signDisplay: 'always',
+  },
+};
+
+export const MissingValue = {
+  args: {
+    value: null,
+    tokenSymbol: 'pts',
+    fallback: 'Not available',
+    tone: 'muted',
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable `AmountFormatter` design-system component
- support locale-aware number formatting, token symbols, raw token scaling, compact notation, signed values, empty-value fallbacks, and tone classes
- wire `CampaignCard` reward display through the formatter
- add Vitest coverage and Storybook stories for the component

## Validation
- `node node_modules/vitest/vitest.mjs run src/components/AmountFormatter.test.jsx --config vitest.no-setup.config.mjs` (temporary no-setup config; 6 tests passed)
- `node node_modules/eslint/bin/eslint.js src/components/AmountFormatter.jsx src/components/AmountFormatter.test.jsx src/components/CampaignCard.jsx src/stories/AmountFormatter.stories.jsx src/lib/amountFormatter.js`
- `git diff --check`

## Notes
The repository's default frontend Vitest setup currently imports `@testing-library/jest-dom`, but that package is not declared in `frontend/package.json`. The main Vite/Storybook builds are also blocked by existing dependency/build configuration issues (`workbox-window` / PWA plugin resolution). This PR keeps the component scope focused and does not change unrelated dependencies.

Closes #977
