### PR TITLE
feat: contributor reward attribution + GrantFox leaderboard link (#885)

### DIFF
--- a/docs/CONTRIBUTOR_REWARD_ATTRIBUTION.md
+++ b/docs/CONTRIBUTOR_REWARD_ATTRIBUTION.md
@@ -1,0 +1,46 @@
+# Contributor reward attribution and leaderboard
+
+Issue: [#885](https://github.com/FinesseStudioLab/Trivela/issues/885)
+
+## Purpose
+
+Make contributor impact **transparent** and connect the live campaign leaderboard to reward eligibility (including GrantFox OSS campaigns).
+
+## What the leaderboard shows
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| Rank | `GET /api/v1/campaigns/:id/leaderboard` | Ordered by points |
+| Wallet | Same API | Truncated in UI; full address available via search |
+| Points | Campaign scoring | Earned via participation / claims per campaign rules |
+| Claimed / net | API row fields | Shown when backend provides them |
+
+UI: `frontend/src/CampaignLeaderboard.jsx` (route `/campaign/:id/leaderboard`).
+
+## Attribution rules (transparent)
+
+1. **On-campaign score** is authoritative for the in-app leaderboard and is not hand-edited.
+2. **GrantFox rewards** require a merged PR that references an issue labeled for GrantFox (or an official campaign issue). Ranking high on the leaderboard alone does not auto-pay GrantFox.
+3. **Dual credit is allowed** when the same work is both campaign-eligible and GrantFox-eligible; each rail has its own payout process.
+4. **Disputes** use campaign admin tools + issue comments; scores refresh from the API on load/search.
+
+## GrantFox integration
+
+- Document campaign issues with GrantFox labels when a Trivela OSS bounty is funded.
+- Link PRs with `Fixes #N` so attribution is recoverable from GitHub + leaderboard wallet identity.
+- Prefer publishing the public receive wallet on the contributor profile for settlement.
+
+## Updating the leaderboard
+
+- Backend aggregation: campaign leaderboard endpoints (pagination, search `q`).
+- Frontend: debounced search, infinite scroll / load more, connected-wallet rank banner.
+- E2E: `frontend/tests/e2e/leaderboard.spec.js`.
+
+## Acceptance map (#885)
+
+| Criterion | Status |
+| --- | --- |
+| Leaderboard live and updated | Live via campaign API + UI |
+| Attribution transparent | This doc + in-UI attribution panel |
+| Link to reward eligibility | GrantFox rules section above |
+

--- a/frontend/src/CampaignLeaderboard.css
+++ b/frontend/src/CampaignLeaderboard.css
@@ -403,3 +403,39 @@
     display: none;
   }
 }
+
+/* Reward attribution panel (#885) */
+.lb-attribution {
+  margin: 0 0 1.25rem;
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.55);
+}
+.lb-attribution-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+.lb-attribution-body {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+.lb-attribution-body a {
+  color: #38bdf8;
+}
+.lb-attribution-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  line-height: 1.55;
+}
+.lb-attribution-list code {
+  font-size: 0.8em;
+}

--- a/frontend/src/CampaignLeaderboard.jsx
+++ b/frontend/src/CampaignLeaderboard.jsx
@@ -236,6 +236,30 @@ export default function CampaignLeaderboard({
             <p className="lb-subtitle">Participants ranked by reward points earned</p>
           </header>
 
+          {/* Transparent reward attribution (GrantFox / issue #885) */}
+          <aside className="lb-attribution" aria-label="Reward attribution">
+            <h2 className="lb-attribution-title">Reward attribution</h2>
+            <p className="lb-attribution-body">
+              Rankings reflect on-campaign reward points from merged contributions and claims.
+              GrantFox OSS eligibility is separate: only work accepted under an open GrantFox
+              campaign issue qualifies for GrantFox payouts. See{' '}
+              <a href="/docs/CONTRIBUTOR_REWARD_ATTRIBUTION.md">contributor reward attribution</a>{' '}
+              for the transparent scoring rules.
+            </p>
+            <ul className="lb-attribution-list">
+              <li>
+                <strong>Leaderboard score:</strong> campaign points API (
+                <code>/api/v1/campaigns/:id/leaderboard</code>)
+              </li>
+              <li>
+                <strong>GrantFox eligibility:</strong> merged PR linked to a GrantFox-labeled issue
+              </li>
+              <li>
+                <strong>Payout rail:</strong> campaign rewards contract + optional GrantFox USDC/XLM
+              </li>
+            </ul>
+          </aside>
+
           {/* Connected wallet rank banner */}
           {walletAddress && myRank && (
             <div className="lb-my-rank-banner" role="status">


### PR DESCRIPTION
## Summary
Implements [#885](https://github.com/FinesseStudioLab/Trivela/issues/885).

## Changes
- In-UI **Reward attribution** panel on campaign leaderboard
- `docs/CONTRIBUTOR_REWARD_ATTRIBUTION.md` — transparent scoring rules + GrantFox eligibility link
- Existing live leaderboard remains the update surface (`/api/v1/campaigns/:id/leaderboard`)

## Acceptance
- [x] Leaderboard live (existing API/UI)
- [x] Attribution transparent (doc + panel)
- [x] Link to reward eligibility (GrantFox section)

Fixes #885