### PR TITLE
feat: in-app notification center, SMS/WhatsApp preferences, bug bount…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in Trivela, please report it responsibly by emailing **security@trivela.io** instead of using the public issue tracker.
+
+**Please include:**
+- A description of the vulnerability
+- Steps to reproduce (if applicable)
+- Potential impact assessment
+- Any proof-of-concept (POC) code (optional but helpful)
+
+We will acknowledge your report within 48 hours and work with you to understand and resolve the issue.
+
+## Security Standards
+
+Trivela follows these security practices:
+
+- **Smart Contracts**: Deployed on Stellar Testnet with formal verification where possible
+- **API Security**: Rate limiting, API key authentication, and CORS protection
+- **Data Protection**: PII is minimized; sensitive operations require authentication
+- **Dependencies**: Regular updates and vulnerability scanning via automated tools
+
+## Scope
+
+### In Scope
+
+- Smart contract vulnerabilities (integer overflow, access control, logic flaws)
+- API vulnerabilities (authentication bypass, authorization flaws, injection attacks)
+- Cryptographic weaknesses
+- Information disclosure issues
+- Denial-of-service vulnerabilities with high impact
+
+### Out of Scope
+
+- Vulnerabilities in third-party dependencies (report to upstream maintainers)
+- Social engineering or phishing attacks
+- Issues requiring access to private infrastructure
+- Minor UI/UX issues or styling inconsistencies
+- Already disclosed vulnerabilities
+
+## Rewards
+
+While Trivela is an open-source project, we recognize the value of security research:
+
+- Critical vulnerabilities: $5,000+ (negotiable based on impact)
+- High severity: $1,000 - $5,000
+- Medium severity: $500 - $1,000
+- Low severity: $100 - $500
+
+Rewards are offered at our discretion based on:
+- Severity and exploitability
+- Clarity and quality of the report
+- Cooperation in resolution
+
+## Responsible Disclosure Timeline
+
+1. **Day 0**: Initial report received
+2. **Day 1-2**: Triage and acknowledgment
+3. **Day 30**: Expected patch/mitigation (varies by severity)
+4. **Day 90**: Public disclosure permitted (unless active exploit)
+
+We request a **90-day responsible disclosure window** before public disclosure, allowing time for fixes and deployment.
+
+## Safe Harbor
+
+We will not pursue legal action against researchers who:
+- Report vulnerabilities in good faith
+- Avoid accessing data beyond what's necessary to demonstrate the vulnerability
+- Do not disrupt or degrade services
+- Do not demand ransom or compensation
+- Follow responsible disclosure practices
+
+## Out-of-Band Communication
+
+For particularly sensitive issues, researchers may request verification of their identity before disclosure. We use standard OpenPGP keys for encrypted communication (keys available upon request).
+
+## Security Contact
+
+- **Email**: security@trivela.io
+- **GitHub Security Advisories**: [Create a private security advisory](https://github.com/FinesseStudioLab/Trivela/security/advisories)
+
+---
+
+**Last Updated**: 2025-07-25

--- a/backend/src/dal/index.js
+++ b/backend/src/dal/index.js
@@ -22,6 +22,8 @@ import { createSqliteOrgMemberRepository } from './sqliteOrgMemberRepository.js'
 import { createSqliteUsageRepository } from './sqliteUsageRepository.js';
 import { createSqliteFeatureFlagRepository } from './sqliteFeatureFlagRepository.js';
 import { createSqliteIdempotencyRepository } from './sqliteIdempotencyRepository.js';
+import { createSqliteNotificationRepository } from './sqliteNotificationRepository.js';
+import { createSqliteNotificationPreferencesRepository } from './sqliteNotificationPreferencesRepository.js';
 
 import { runPgMigrations } from './pg/migrate.js';
 import { createPgCampaignRepository } from './pg/pgCampaignRepository.js';
@@ -96,6 +98,8 @@ export async function createDal({
     usage: createSqliteUsageRepository({ db }),
     featureFlags: createSqliteFeatureFlagRepository({ db }),
     idempotency: createSqliteIdempotencyRepository({ db }),
+    notifications: createSqliteNotificationRepository({ db }),
+    notificationPreferences: createSqliteNotificationPreferencesRepository({ db }),
     db,
     pgPool,
   };

--- a/backend/src/dal/sqliteNotificationPreferencesRepository.js
+++ b/backend/src/dal/sqliteNotificationPreferencesRepository.js
@@ -1,0 +1,38 @@
+export function createSqliteNotificationPreferencesRepository({ db }) {
+  return {
+    getOrCreate(userId) {
+      let prefs = this.get(userId);
+      if (!prefs) {
+        const stmt = db.prepare(`
+          INSERT OR IGNORE INTO notification_preferences (user_id)
+          VALUES (?)
+        `);
+        stmt.run(userId);
+        prefs = this.get(userId);
+      }
+      return prefs;
+    },
+
+    get(userId) {
+      const stmt = db.prepare(`
+        SELECT id, user_id, email_enabled, sms_enabled, whatsapp_enabled, phone_number, created_at, updated_at
+        FROM notification_preferences
+        WHERE user_id = ?
+      `);
+      return stmt.get(userId);
+    },
+
+    update({ userId, emailEnabled, smsEnabled, whatsappEnabled, phoneNumber }) {
+      const stmt = db.prepare(`
+        UPDATE notification_preferences
+        SET email_enabled = COALESCE(?, email_enabled),
+            sms_enabled = COALESCE(?, sms_enabled),
+            whatsapp_enabled = COALESCE(?, whatsapp_enabled),
+            phone_number = COALESCE(?, phone_number),
+            updated_at = datetime('now')
+        WHERE user_id = ?
+      `);
+      stmt.run(emailEnabled, smsEnabled, whatsappEnabled, phoneNumber, userId);
+    },
+  };
+}

--- a/backend/src/dal/sqliteNotificationRepository.js
+++ b/backend/src/dal/sqliteNotificationRepository.js
@@ -1,0 +1,58 @@
+export function createSqliteNotificationRepository({ db }) {
+  return {
+    create({ userId, campaignId, title, message, type = 'reward' }) {
+      const stmt = db.prepare(`
+        INSERT INTO notifications (user_id, campaign_id, title, message, type)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      const result = stmt.run(userId, campaignId, title, message, type);
+      return { id: result.lastInsertRowid };
+    },
+
+    listByUserId({ userId, limit = 50, offset = 0 }) {
+      const stmt = db.prepare(`
+        SELECT id, user_id, campaign_id, title, message, type, read, created_at, read_at
+        FROM notifications
+        WHERE user_id = ?
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+      `);
+      return stmt.all(userId, limit, offset);
+    },
+
+    getUnreadCount(userId) {
+      const stmt = db.prepare(`
+        SELECT COUNT(*) as count
+        FROM notifications
+        WHERE user_id = ? AND read = 0
+      `);
+      return stmt.get(userId)?.count ?? 0;
+    },
+
+    markAsRead(notificationId) {
+      const stmt = db.prepare(`
+        UPDATE notifications
+        SET read = 1, read_at = datetime('now')
+        WHERE id = ?
+      `);
+      stmt.run(notificationId);
+    },
+
+    markAllAsRead(userId) {
+      const stmt = db.prepare(`
+        UPDATE notifications
+        SET read = 1, read_at = datetime('now')
+        WHERE user_id = ? AND read = 0
+      `);
+      stmt.run(userId);
+    },
+
+    deleteOlderThan(days) {
+      const stmt = db.prepare(`
+        DELETE FROM notifications
+        WHERE created_at < datetime('now', '-' || ? || ' days')
+      `);
+      stmt.run(days);
+    },
+  };
+}

--- a/backend/src/db/migrations/025_notifications.js
+++ b/backend/src/db/migrations/025_notifications.js
@@ -1,0 +1,23 @@
+export const version = 25;
+export const description = 'Notifications table with read/unread state for in-app inbox (#1027)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS notifications (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id           TEXT NOT NULL,
+      campaign_id       INTEGER,
+      title             TEXT NOT NULL,
+      message           TEXT NOT NULL,
+      type              TEXT NOT NULL DEFAULT 'reward',
+      read              INTEGER NOT NULL DEFAULT 0,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      read_at           TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+    CREATE INDEX IF NOT EXISTS idx_notifications_read ON notifications(read);
+    CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at);
+    CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications(user_id, read);
+  `);
+}

--- a/backend/src/db/migrations/026_notification_preferences.js
+++ b/backend/src/db/migrations/026_notification_preferences.js
@@ -1,0 +1,19 @@
+export const version = 26;
+export const description = 'User notification preferences for SMS/WhatsApp opt-in (#1028)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS notification_preferences (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id           TEXT NOT NULL UNIQUE,
+      email_enabled     INTEGER NOT NULL DEFAULT 1,
+      sms_enabled       INTEGER NOT NULL DEFAULT 0,
+      whatsapp_enabled  INTEGER NOT NULL DEFAULT 0,
+      phone_number      TEXT,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_notification_preferences_user_id ON notification_preferences(user_id);
+  `);
+}

--- a/backend/src/db/migrations/027_pruning_state.js
+++ b/backend/src/db/migrations/027_pruning_state.js
@@ -1,0 +1,16 @@
+export const version = 27;
+export const description = 'Pruning state tracking for expired nonces, snapshots, and stale indices (#1029)';
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pruning_state (
+      id                INTEGER PRIMARY KEY AUTOINCREMENT,
+      resource_type     TEXT NOT NULL UNIQUE,
+      last_pruned_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      last_cursor       TEXT,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pruning_state_resource_type ON pruning_state(resource_type);
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -88,7 +88,9 @@ import { createPathPaymentRoutes } from './routes/pathPayment.js';
 import { createIndexReadRoutes } from './routes/indexRead.js';
 import { createSep10Routes, createRequireWalletAuth } from './routes/sep10.js';
 import { createZkInputsRoutes } from './routes/zkInputs.js';
+import { createNotificationRoutes, createNotificationPreferencesRoutes } from './routes/notifications.js';
 import { createOperatorBalanceJob } from './jobs/operatorBalanceJob.js';
+import { createPruningJob } from './jobs/pruningJob.js';
 import { createModerationService } from './moderation/moderationService.js';
 import { createContentModerationMiddleware } from './middleware/contentModeration.js';
 import createFaucetRoutes from './routes/faucet.js';
@@ -667,6 +669,8 @@ export async function createApp(options = {}) {
     30_000,
   );
 
+  const pruningJob = createPruningJob({ dal });
+
   const jobRunner = createJobRunner({
     handlers: {
       async rpc_health_poll() {
@@ -689,6 +693,9 @@ export async function createApp(options = {}) {
       async data_export({ date }) {
         await exportJob.run(date);
       },
+      async storage_pruning() {
+        await pruningJob();
+      },
     },
     logger: log,
     deadLetter: failedJobRepository,
@@ -710,6 +717,16 @@ export async function createApp(options = {}) {
     setInterval(
       () => jobRunner.enqueue('webhook_retry_failed_deliveries', null),
       webhookRetryIntervalMs,
+    ).unref?.();
+  }
+
+  // Daily storage pruning (#1029)
+  if (!options.disableJobs) {
+    const pruningIntervalMs = 24 * 60 * 60 * 1000; // 24 hours
+    jobRunner.enqueue('storage_pruning', null);
+    setInterval(
+      () => jobRunner.enqueue('storage_pruning', null),
+      pruningIntervalMs,
     ).unref?.();
   }
 
@@ -2672,6 +2689,14 @@ export async function createApp(options = {}) {
   // #543 — ZK proving inputs (public, no auth — secrets never leave the device)
   const zkInputsRouter = createZkInputsRoutes({ campaignRepository });
   app.use(API_V1_PREFIX, rateLimiter, zkInputsRouter);
+
+  // #1027 — In-app notification center with read/unread state
+  const notificationRouter = createNotificationRoutes({ dal });
+  app.use(API_V1_PREFIX, rateLimiter, notificationRouter);
+
+  // #1028 — SMS/WhatsApp notification preferences
+  const notificationPreferencesRouter = createNotificationPreferencesRoutes({ dal });
+  app.use(API_V1_PREFIX, rateLimiter, notificationPreferencesRouter);
 
   // #808 — In-app testnet faucet/funding helper
   app.use(`${API_V1_PREFIX}/faucet`, createFaucetRoutes);

--- a/backend/src/integration/notifications.test.js
+++ b/backend/src/integration/notifications.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../db/migrate.js';
+import { createSqliteNotificationRepository } from '../dal/sqliteNotificationRepository.js';
+import { createSqliteNotificationPreferencesRepository } from '../dal/sqliteNotificationPreferencesRepository.js';
+
+describe('Notifications', () => {
+  let db;
+  let notificationRepo;
+  let preferencesRepo;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    notificationRepo = createSqliteNotificationRepository({ db });
+    preferencesRepo = createSqliteNotificationPreferencesRepository({ db });
+  });
+
+  describe('Notifications Repository', () => {
+    it('should create a notification', () => {
+      const result = notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 1,
+        title: 'Test Notification',
+        message: 'This is a test',
+        type: 'reward',
+      });
+
+      expect(result.id).toBeDefined();
+    });
+
+    it('should list notifications for a user', () => {
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 1,
+        title: 'Test 1',
+        message: 'Message 1',
+      });
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 2,
+        title: 'Test 2',
+        message: 'Message 2',
+      });
+
+      const notifications = notificationRepo.listByUserId({ userId: 'user-1' });
+      expect(notifications).toHaveLength(2);
+    });
+
+    it('should get unread count', () => {
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 1,
+        title: 'Test 1',
+        message: 'Message 1',
+      });
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 2,
+        title: 'Test 2',
+        message: 'Message 2',
+      });
+
+      const count = notificationRepo.getUnreadCount('user-1');
+      expect(count).toBe(2);
+    });
+
+    it('should mark notification as read', () => {
+      const { id } = notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 1,
+        title: 'Test',
+        message: 'Message',
+      });
+
+      notificationRepo.markAsRead(id);
+
+      const count = notificationRepo.getUnreadCount('user-1');
+      expect(count).toBe(0);
+    });
+
+    it('should mark all notifications as read', () => {
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 1,
+        title: 'Test 1',
+        message: 'Message 1',
+      });
+      notificationRepo.create({
+        userId: 'user-1',
+        campaignId: 2,
+        title: 'Test 2',
+        message: 'Message 2',
+      });
+
+      notificationRepo.markAllAsRead('user-1');
+
+      const count = notificationRepo.getUnreadCount('user-1');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('Notification Preferences Repository', () => {
+    it('should create or get user preferences', () => {
+      const prefs = preferencesRepo.getOrCreate('user-1');
+      expect(prefs).toBeDefined();
+      expect(prefs.user_id).toBe('user-1');
+      expect(prefs.email_enabled).toBe(1);
+      expect(prefs.sms_enabled).toBe(0);
+    });
+
+    it('should update preferences', () => {
+      preferencesRepo.getOrCreate('user-1');
+      preferencesRepo.update({
+        userId: 'user-1',
+        emailEnabled: 0,
+        smsEnabled: 1,
+        whatsappEnabled: 1,
+        phoneNumber: '+1234567890',
+      });
+
+      const prefs = preferencesRepo.get('user-1');
+      expect(prefs.email_enabled).toBe(0);
+      expect(prefs.sms_enabled).toBe(1);
+      expect(prefs.whatsapp_enabled).toBe(1);
+      expect(prefs.phone_number).toBe('+1234567890');
+    });
+  });
+});

--- a/backend/src/jobs/pruningJob.js
+++ b/backend/src/jobs/pruningJob.js
@@ -1,0 +1,39 @@
+import { log } from '../middleware/logger.js';
+
+const RETENTION_DAYS = {
+  notifications: 90,
+  indexedEvents: 180,
+};
+
+export function createPruningJob({ dal }) {
+  return async function prune() {
+    try {
+      // Prune old notifications
+      if (dal.notifications) {
+        dal.notifications.deleteOlderThan(RETENTION_DAYS.notifications);
+        log.info(`[pruning] Deleted notifications older than ${RETENTION_DAYS.notifications} days`);
+      }
+
+      // Prune old indexed events
+      const pruneStmt = dal.db.prepare(`
+        DELETE FROM indexed_events
+        WHERE created_at < datetime('now', '-' || ? || ' days')
+      `);
+      pruneStmt.run(RETENTION_DAYS.indexedEvents);
+      log.info(`[pruning] Deleted indexed events older than ${RETENTION_DAYS.indexedEvents} days`);
+
+      // Update pruning state
+      const updateStmt = dal.db.prepare(`
+        INSERT OR REPLACE INTO pruning_state (resource_type, last_pruned_at)
+        VALUES (?, datetime('now'))
+      `);
+      updateStmt.run('notifications');
+      updateStmt.run('indexedEvents');
+
+      log.info('[pruning] Pruning job completed successfully');
+    } catch (error) {
+      log.error('[pruning] Job failed:', error);
+      throw error;
+    }
+  };
+}

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -1,0 +1,104 @@
+import express from 'express';
+
+export function createNotificationRoutes({ dal }) {
+  const router = express.Router();
+
+  router.get('/notifications', (req, res) => {
+    try {
+      const userId = req.headers['x-user-id'];
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const limit = parseInt(req.query.limit) || 50;
+      const offset = parseInt(req.query.offset) || 0;
+
+      const notifications = dal.notifications.listByUserId({ userId, limit, offset });
+      const unreadCount = dal.notifications.getUnreadCount(userId);
+
+      res.json({
+        data: notifications,
+        unreadCount,
+        limit,
+        offset,
+      });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  router.post('/notifications/:id/read', (req, res) => {
+    try {
+      const userId = req.headers['x-user-id'];
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      dal.notifications.markAsRead(parseInt(req.params.id));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  router.post('/notifications/mark-all-read', (req, res) => {
+    try {
+      const userId = req.headers['x-user-id'];
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      dal.notifications.markAllAsRead(userId);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  return router;
+}
+
+export function createNotificationPreferencesRoutes({ dal }) {
+  const router = express.Router();
+
+  router.get('/notification-preferences', (req, res) => {
+    try {
+      const userId = req.headers['x-user-id'];
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const prefs = dal.notificationPreferences.getOrCreate(userId);
+      res.json(prefs);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  router.put('/notification-preferences', (req, res) => {
+    try {
+      const userId = req.headers['x-user-id'];
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { emailEnabled, smsEnabled, whatsappEnabled, phoneNumber } = req.body;
+
+      dal.notificationPreferences.getOrCreate(userId);
+      dal.notificationPreferences.update({
+        userId,
+        emailEnabled,
+        smsEnabled,
+        whatsappEnabled,
+        phoneNumber,
+      });
+
+      const updated = dal.notificationPreferences.get(userId);
+      res.json(updated);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
…y, and storage pruning (#1027, #1028, #1029, #1030)

- Closes #1027: In-app notification center with read/unread state
  - Added notifications table with user tracking
  - Created repository methods for CRUD and bulk operations
  - Added REST API endpoints to list, mark read, and mark all read

- Closes #1028: SMS/WhatsApp notification preferences (opt-in)
  - Added notification_preferences table with per-user channel toggles
  - Email enabled by default, SMS/WhatsApp disabled by default
  - REST API endpoints to get and update preferences

- Closes #1029: Storage pruning jobs for expired data
  - Added pruning_state table to track cleanup progress
  - Created pruning job that removes old notifications (90-day TTL) and indexed events (180-day TTL)
  - Integrated into job runner to execute daily

- Closes #1030: Public bug-bounty program setup
  - Created SECURITY.md with responsible disclosure policy
  - Defined vulnerability scope, severity levels, and reward tiers
  - Includes safe harbor clause and 90-day disclosure timeline