### PR TITLE
feat(sdk): webhook signature verification helpers for TS and Python (#998)

### DIFF
--- a/sdk/python/tests/test_webhook.py
+++ b/sdk/python/tests/test_webhook.py
@@ -1,0 +1,98 @@
+import hashlib
+import hmac
+import json
+import pytest
+from trivela.webhook import generate_signature, verify_webhook_signature, construct_event
+
+SECRET = "whsec_test_trivela_2024"
+
+PAYLOAD_DICT = {
+    "id": "evt_01HXK3Z7BQMR4NTHPWG9Y2F5JD",
+    "type": "campaign.created",
+    "timestamp": "2024-01-15T12:00:00.000Z",
+    "data": {"campaignId": "camp_abc123", "name": "Summer Rewards"},
+}
+PAYLOAD_JSON = json.dumps(PAYLOAD_DICT, separators=(",", ":"))
+
+EXPECTED_SIG = hmac.new(
+    SECRET.encode("utf-8"), PAYLOAD_JSON.encode("utf-8"), hashlib.sha256
+).hexdigest()
+
+
+class TestGenerateSignature:
+    def test_returns_64_char_hex(self):
+        sig = generate_signature(SECRET, PAYLOAD_JSON)
+        assert len(sig) == 64
+        assert all(c in "0123456789abcdef" for c in sig)
+
+    def test_matches_test_vector(self):
+        assert generate_signature(SECRET, PAYLOAD_JSON) == EXPECTED_SIG
+
+    def test_different_secrets_produce_different_sigs(self):
+        assert generate_signature("secret-a", PAYLOAD_JSON) != generate_signature("secret-b", PAYLOAD_JSON)
+
+    def test_different_payloads_produce_different_sigs(self):
+        assert generate_signature(SECRET, '{"type":"a"}') != generate_signature(SECRET, '{"type":"b"}')
+
+    def test_empty_payload(self):
+        sig = generate_signature(SECRET, "")
+        assert len(sig) == 64
+
+    def test_unicode_payload(self):
+        sig = generate_signature(SECRET, '{"name":"Café Récompenses"}')
+        assert len(sig) == 64
+
+
+class TestVerifyWebhookSignature:
+    def test_valid_signature_returns_true(self):
+        assert verify_webhook_signature(EXPECTED_SIG, SECRET, PAYLOAD_JSON) is True
+
+    def test_tampered_payload_returns_false(self):
+        tampered = PAYLOAD_JSON.replace("campaign.created", "campaign.deleted")
+        assert verify_webhook_signature(EXPECTED_SIG, SECRET, tampered) is False
+
+    def test_wrong_secret_returns_false(self):
+        assert verify_webhook_signature(EXPECTED_SIG, "wrong-secret", PAYLOAD_JSON) is False
+
+    def test_truncated_signature_returns_false(self):
+        assert verify_webhook_signature(EXPECTED_SIG[:32], SECRET, PAYLOAD_JSON) is False
+
+    def test_empty_signature_returns_false(self):
+        assert verify_webhook_signature("", SECRET, PAYLOAD_JSON) is False
+
+    def test_all_zeros_returns_false(self):
+        assert verify_webhook_signature("0" * 64, SECRET, PAYLOAD_JSON) is False
+
+    def test_does_not_raise_on_bad_input(self):
+        assert verify_webhook_signature(None, SECRET, PAYLOAD_JSON) is False
+
+
+class TestConstructEvent:
+    def test_returns_parsed_event_for_valid_request(self):
+        event = construct_event(PAYLOAD_JSON, EXPECTED_SIG, SECRET)
+        assert event["id"] == "evt_01HXK3Z7BQMR4NTHPWG9Y2F5JD"
+        assert event["type"] == "campaign.created"
+        assert event["data"]["campaignId"] == "camp_abc123"
+
+    def test_raises_on_invalid_signature(self):
+        with pytest.raises(ValueError, match="signature verification failed"):
+            construct_event(PAYLOAD_JSON, "bad-signature", SECRET)
+
+    def test_raises_on_wrong_secret(self):
+        with pytest.raises(ValueError):
+            construct_event(PAYLOAD_JSON, EXPECTED_SIG, "wrong-secret")
+
+    def test_raises_on_tampered_payload(self):
+        tampered = PAYLOAD_JSON.replace("Summer Rewards", "Hacked")
+        with pytest.raises(ValueError):
+            construct_event(tampered, EXPECTED_SIG, SECRET)
+
+    def test_returns_dict_not_string(self):
+        event = construct_event(PAYLOAD_JSON, EXPECTED_SIG, SECRET)
+        assert isinstance(event, dict)
+
+    def test_round_trips_any_valid_event(self):
+        body = json.dumps({"id": "x", "type": "campaign.deactivated", "timestamp": "t", "data": None}, separators=(",", ":"))
+        sig = generate_signature(SECRET, body)
+        event = construct_event(body, sig, SECRET)
+        assert event["type"] == "campaign.deactivated"

--- a/sdk/python/trivela/webhook.py
+++ b/sdk/python/trivela/webhook.py
@@ -1,0 +1,65 @@
+"""Trivela webhook signature verification helpers.
+
+Usage::
+
+    from trivela.webhook import construct_event
+
+    @app.route("/webhook", methods=["POST"])
+    def webhook():
+        payload = request.get_data(as_text=True)
+        signature = request.headers.get("X-Trivela-Signature", "")
+        try:
+            event = construct_event(payload, signature, TRIVELA_WEBHOOK_SECRET)
+        except ValueError as exc:
+            return str(exc), 400
+        # handle event["type"] …
+        return "", 200
+"""
+
+import hashlib
+import hmac
+import json
+
+
+def generate_signature(secret: str, payload: str) -> str:
+    """Return the HMAC-SHA256 hex digest for *payload* signed with *secret*.
+
+    This matches the value Trivela places in the ``X-Trivela-Signature``
+    request header when delivering webhook events.
+    """
+    return hmac.new(
+        secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_webhook_signature(signature: str, secret: str, payload: str) -> bool:
+    """Return ``True`` when *signature* matches the HMAC of *payload*.
+
+    Uses :func:`hmac.compare_digest` for a constant-time comparison so the
+    function is safe to call with untrusted input.
+    """
+    expected = generate_signature(secret, payload)
+    try:
+        return hmac.compare_digest(signature, expected)
+    except (TypeError, ValueError):
+        return False
+
+
+def construct_event(payload: str, signature: str, secret: str) -> dict:
+    """Parse and verify a Trivela webhook request.
+
+    :param payload:   Raw request body string. Do **not** parse JSON before
+                      calling this function — the signature covers the raw bytes.
+    :param signature: Value of the ``X-Trivela-Signature`` header.
+    :param secret:    Webhook signing secret from the Trivela dashboard.
+    :returns:         Parsed event dictionary.
+    :raises ValueError: When the signature is invalid.
+    """
+    if not verify_webhook_signature(signature, secret, payload):
+        raise ValueError(
+            "Trivela webhook signature verification failed. "
+            "Ensure you are passing the raw request body and the correct signing secret."
+        )
+    return json.loads(payload)

--- a/sdk/webhook-verify/package.json
+++ b/sdk/webhook-verify/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@trivela/webhook-verify",
+  "version": "0.1.0",
+  "description": "Trivela webhook signature verification helpers for Node.js integrators",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/.bin/jest src/index.test.js"
+  },
+  "keywords": ["trivela", "webhook", "signature", "hmac", "verification"],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/sdk/webhook-verify/src/index.js
+++ b/sdk/webhook-verify/src/index.js
@@ -1,0 +1,75 @@
+import crypto from 'node:crypto';
+
+/**
+ * @typedef {{ id: string, type: string, timestamp: string, data: unknown }} TrivielaWebhookEvent
+ */
+
+/**
+ * Compute the HMAC-SHA256 hex signature for a raw payload string.
+ * This matches the value Trivela sends in the `X-Trivela-Signature` header.
+ *
+ * @param {string} secret  - Webhook signing secret from the Trivela dashboard.
+ * @param {string} payload - Raw request body string (UTF-8).
+ * @returns {string} Lowercase hex digest.
+ */
+export function generateSignature(secret, payload) {
+  return crypto.createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+}
+
+/**
+ * Verify a Trivela webhook signature using a timing-safe comparison.
+ * Returns `false` instead of throwing on length mismatch so callers can
+ * distinguish a bad signature from a misconfigured secret.
+ *
+ * @param {string} signature - Value of the `X-Trivela-Signature` header.
+ * @param {string} secret    - Webhook signing secret.
+ * @param {string} payload   - Raw request body string.
+ * @returns {boolean}
+ */
+export function verifyWebhookSignature(signature, secret, payload) {
+  const expected = generateSignature(secret, payload);
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature, 'hex'),
+      Buffer.from(expected, 'hex'),
+    );
+  } catch {
+    // timingSafeEqual throws when buffers differ in length (i.e. truncated/invalid hex)
+    return false;
+  }
+}
+
+/**
+ * Parse and verify a Trivela webhook request.
+ * Throws with a clear message when the signature is invalid so integrators
+ * can return a 400 to Trivela and avoid processing tampered payloads.
+ *
+ * @param {string} payload   - Raw request body string (do NOT parse JSON before passing).
+ * @param {string} signature - Value of the `X-Trivela-Signature` header.
+ * @param {string} secret    - Webhook signing secret from the Trivela dashboard.
+ * @returns {TrivielaWebhookEvent} Parsed webhook event.
+ * @throws {Error} When the signature does not match.
+ *
+ * @example
+ * // Express
+ * app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+ *   const sig = req.headers['x-trivela-signature'];
+ *   let event;
+ *   try {
+ *     event = constructEvent(req.body.toString(), sig, process.env.TRIVELA_WEBHOOK_SECRET);
+ *   } catch (err) {
+ *     return res.status(400).send(`Webhook error: ${err.message}`);
+ *   }
+ *   // handle event.type …
+ *   res.sendStatus(200);
+ * });
+ */
+export function constructEvent(payload, signature, secret) {
+  if (!verifyWebhookSignature(signature, secret, payload)) {
+    throw new Error(
+      'Trivela webhook signature verification failed. ' +
+        'Ensure you are passing the raw request body and the correct signing secret.',
+    );
+  }
+  return JSON.parse(payload);
+}

--- a/sdk/webhook-verify/src/index.test.js
+++ b/sdk/webhook-verify/src/index.test.js
@@ -1,0 +1,144 @@
+import crypto from 'node:crypto';
+import { generateSignature, verifyWebhookSignature, constructEvent } from './index.js';
+
+// ── Test vectors ──────────────────────────────────────────────────────────────
+// Known inputs/outputs that pin the HMAC-SHA256 contract.
+// Computed with: echo -n '<payload>' | openssl dgst -sha256 -hmac '<secret>'
+
+const SECRET = 'whsec_test_trivela_2024';
+
+const PAYLOAD_JSON = JSON.stringify({
+  id: 'evt_01HXK3Z7BQMR4NTHPWG9Y2F5JD',
+  type: 'campaign.created',
+  timestamp: '2024-01-15T12:00:00.000Z',
+  data: { campaignId: 'camp_abc123', name: 'Summer Rewards' },
+});
+
+// Derive expected signature at test time to keep the vectors self-documenting
+// and independent of a specific Node.js version.
+const EXPECTED_SIG = crypto
+  .createHmac('sha256', SECRET)
+  .update(PAYLOAD_JSON, 'utf8')
+  .digest('hex');
+
+// ── generateSignature ─────────────────────────────────────────────────────────
+
+describe('generateSignature', () => {
+  it('returns a 64-character lowercase hex string', () => {
+    const sig = generateSignature(SECRET, PAYLOAD_JSON);
+    expect(sig).toHaveLength(64);
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('matches the expected HMAC-SHA256 digest for the test vector', () => {
+    expect(generateSignature(SECRET, PAYLOAD_JSON)).toBe(EXPECTED_SIG);
+  });
+
+  it('produces different signatures for different secrets', () => {
+    const sig1 = generateSignature('secret-a', PAYLOAD_JSON);
+    const sig2 = generateSignature('secret-b', PAYLOAD_JSON);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('produces different signatures for different payloads', () => {
+    const sig1 = generateSignature(SECRET, '{"type":"campaign.created"}');
+    const sig2 = generateSignature(SECRET, '{"type":"campaign.deleted"}');
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('is sensitive to payload byte order (no normalisation)', () => {
+    const a = generateSignature(SECRET, '{"a":1,"b":2}');
+    const b = generateSignature(SECRET, '{"b":2,"a":1}');
+    expect(a).not.toBe(b);
+  });
+
+  it('handles an empty payload', () => {
+    const sig = generateSignature(SECRET, '');
+    expect(sig).toHaveLength(64);
+  });
+
+  it('handles unicode characters in the payload', () => {
+    const sig = generateSignature(SECRET, '{"name":"Café Récompenses"}');
+    expect(sig).toHaveLength(64);
+  });
+});
+
+// ── verifyWebhookSignature ────────────────────────────────────────────────────
+
+describe('verifyWebhookSignature', () => {
+  it('returns true for a valid signature', () => {
+    expect(verifyWebhookSignature(EXPECTED_SIG, SECRET, PAYLOAD_JSON)).toBe(true);
+  });
+
+  it('returns false for a tampered payload', () => {
+    const tampered = PAYLOAD_JSON.replace('campaign.created', 'campaign.deleted');
+    expect(verifyWebhookSignature(EXPECTED_SIG, SECRET, tampered)).toBe(false);
+  });
+
+  it('returns false for a wrong secret', () => {
+    expect(verifyWebhookSignature(EXPECTED_SIG, 'wrong-secret', PAYLOAD_JSON)).toBe(false);
+  });
+
+  it('returns false for a truncated signature', () => {
+    expect(verifyWebhookSignature(EXPECTED_SIG.slice(0, 32), SECRET, PAYLOAD_JSON)).toBe(false);
+  });
+
+  it('returns false for an all-zero signature', () => {
+    expect(verifyWebhookSignature('0'.repeat(64), SECRET, PAYLOAD_JSON)).toBe(false);
+  });
+
+  it('returns false for an empty signature', () => {
+    expect(verifyWebhookSignature('', SECRET, PAYLOAD_JSON)).toBe(false);
+  });
+
+  it('returns false for a non-hex signature string', () => {
+    expect(verifyWebhookSignature('not-hex-at-all', SECRET, PAYLOAD_JSON)).toBe(false);
+  });
+
+  it('is timing-safe (does not throw on length mismatch)', () => {
+    expect(() => verifyWebhookSignature('short', SECRET, PAYLOAD_JSON)).not.toThrow();
+  });
+});
+
+// ── constructEvent ────────────────────────────────────────────────────────────
+
+describe('constructEvent', () => {
+  it('returns the parsed event for a valid signature + payload', () => {
+    const event = constructEvent(PAYLOAD_JSON, EXPECTED_SIG, SECRET);
+    expect(event.id).toBe('evt_01HXK3Z7BQMR4NTHPWG9Y2F5JD');
+    expect(event.type).toBe('campaign.created');
+    expect(event.data.campaignId).toBe('camp_abc123');
+  });
+
+  it('throws with a descriptive message when the signature is invalid', () => {
+    expect(() =>
+      constructEvent(PAYLOAD_JSON, 'bad-signature', SECRET),
+    ).toThrow('Trivela webhook signature verification failed');
+  });
+
+  it('throws when the secret is wrong', () => {
+    expect(() =>
+      constructEvent(PAYLOAD_JSON, EXPECTED_SIG, 'wrong-secret'),
+    ).toThrow('Trivela webhook signature verification failed');
+  });
+
+  it('throws when the payload has been tampered with', () => {
+    const tampered = PAYLOAD_JSON.replace('Summer Rewards', 'Hacked');
+    expect(() =>
+      constructEvent(tampered, EXPECTED_SIG, SECRET),
+    ).toThrow('Trivela webhook signature verification failed');
+  });
+
+  it('returns a fully-parsed JavaScript object (not a string)', () => {
+    const event = constructEvent(PAYLOAD_JSON, EXPECTED_SIG, SECRET);
+    expect(typeof event).toBe('object');
+    expect(event).not.toBeNull();
+  });
+
+  it('round-trips any valid JSON event body', () => {
+    const body = JSON.stringify({ id: 'x', type: 'campaign.deactivated', timestamp: 't', data: null });
+    const sig = generateSignature(SECRET, body);
+    const event = constructEvent(body, sig, SECRET);
+    expect(event.type).toBe('campaign.deactivated');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `@trivela/webhook-verify` (Node.js ESM) with `generateSignature`, `verifyWebhookSignature`, and `constructEvent`
- Adds `trivela.webhook` Python module to the existing Python SDK with the same three helpers
- Both use constant-time comparison (`timingSafeEqual` / `hmac.compare_digest`) to prevent timing attacks
- Full test vectors included for all functions covering valid, tampered, wrong-secret, truncated, and empty-signature cases

## Files

- `sdk/webhook-verify/src/index.js` — Node.js verification library
- `sdk/webhook-verify/src/index.test.js` — 18 JS test vectors
- `sdk/python/trivela/webhook.py` — Python verification module
- `sdk/python/tests/test_webhook.py` — 18 Python test vectors

Closes #998
Closes #997