### PR TITLE
feat: bulk CSV point-credit upload and async job queue (#1004)

### DIFF
--- a/backend/src/jobs/bulkCreditJob.js
+++ b/backend/src/jobs/bulkCreditJob.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+/**
+ * Job handler for bulk point-credit operations.
+ *
+ * Each job payload carries a list of validated rows. The handler credits
+ * points for every row and accumulates per-row results so callers can
+ * distinguish partial failures from total ones.
+ *
+ * @param {{
+ *   dal: {
+ *     points: {
+ *       credit: (args: { address: string, amount: number, label?: string, reason?: string }) => unknown
+ *     },
+ *     bulkCreditResults?: {
+ *       upsert?: (result: object) => unknown
+ *     }
+ *   },
+ *   log?: Pick<Console, 'info' | 'warn' | 'error'>
+ * }} deps
+ */
+export function createBulkCreditJobHandler({ dal, log = console }) {
+  /**
+   * @param {{
+   *   jobId: string,
+   *   campaignId?: string,
+   *   rows: Array<{ row: number, address: string, points: number, label?: string }>
+   * }} payload
+   */
+  return async function handleBulkCredit(payload) {
+    const { jobId, campaignId, rows } = payload;
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      log.warn?.(`bulkCreditJob:skip jobId=${jobId} reason=empty_rows`);
+      return;
+    }
+
+    log.info?.(`bulkCreditJob:start jobId=${jobId} rows=${rows.length} campaignId=${campaignId ?? 'none'}`);
+
+    let succeeded = 0;
+    let failed = 0;
+    const failures = [];
+
+    for (const entry of rows) {
+      try {
+        await dal.points.credit({
+          address: entry.address,
+          amount: entry.points,
+          label: entry.label,
+          reason: campaignId ? `bulk-credit:${campaignId}` : 'bulk-credit',
+        });
+        succeeded++;
+      } catch (err) {
+        failed++;
+        const message = err instanceof Error ? err.message : String(err ?? 'unknown');
+        failures.push({ row: entry.row, address: entry.address, error: message });
+        log.warn?.(`bulkCreditJob:row_error jobId=${jobId} row=${entry.row} address=${entry.address} error=${message}`);
+      }
+    }
+
+    log.info?.(`bulkCreditJob:done jobId=${jobId} succeeded=${succeeded} failed=${failed}`);
+
+    if (failed > 0 && failed === rows.length) {
+      throw new Error(`All ${rows.length} rows failed. First error: ${failures[0]?.error}`);
+    }
+  };
+}

--- a/backend/src/routes/bulkCredit.js
+++ b/backend/src/routes/bulkCredit.js
@@ -1,0 +1,148 @@
+// @ts-check
+import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import multer from 'multer';
+import { parseAllowlistCsv, validateGAddress, MAX_ALLOWLIST_ROWS } from '../lib/allowlist/csv.js';
+
+const DEFAULT_POINTS_PER_ROW = 1;
+const MAX_CSV_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Admin API for bulk point-credit via CSV upload.
+ *
+ * Routes:
+ *   POST   /api/v1/bulk-credit/upload   – parse + validate CSV, return preview
+ *   POST   /api/v1/bulk-credit/submit   – enqueue a validated batch for async execution
+ *   GET    /api/v1/bulk-credit/:jobId   – poll job status
+ *
+ * @param {{
+ *   jobQueue: { enqueue: (type: string, payload: unknown) => void },
+ *   jobStore?: { getStatus?: (jobId: string) => object | null },
+ *   requireApiKey: import('express').RequestHandler | import('express').RequestHandler[],
+ *   log?: Pick<Console, 'info' | 'warn' | 'error'>,
+ * }} deps
+ * @returns {import('express').Router}
+ */
+export function createBulkCreditRouter({ jobQueue, jobStore, requireApiKey, log = console }) {
+  const router = Router();
+  const auth = Array.isArray(requireApiKey) ? requireApiKey : [requireApiKey];
+
+  const csvUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: MAX_CSV_BYTES },
+  });
+
+  // ── POST /api/v1/bulk-credit/upload ──────────────────────────────────────────
+  // Parse and validate a CSV file. Returns a preview — nothing is written yet.
+
+  router.post('/bulk-credit/upload', ...auth, csvUpload.single('file'), (req, res) => {
+    if (!req.file && !req.body?.csv) {
+      return res.status(400).json({ error: 'No CSV data provided', code: 'MISSING_CSV' });
+    }
+
+    const raw = req.file ? req.file.buffer.toString('utf8') : String(req.body.csv);
+    const { rows } = parseAllowlistCsv(raw);
+
+    if (rows.length === 0) {
+      return res.status(400).json({ error: 'CSV contains no rows', code: 'EMPTY_CSV' });
+    }
+
+    if (rows.length > MAX_ALLOWLIST_ROWS) {
+      return res.status(400).json({
+        error: `CSV exceeds maximum of ${MAX_ALLOWLIST_ROWS} rows`,
+        code: 'CSV_TOO_LARGE',
+      });
+    }
+
+    const invalid = rows.filter((r) => !validateGAddress(r.address));
+    if (invalid.length > 0) {
+      return res.status(400).json({
+        error: 'CSV contains invalid Stellar addresses',
+        code: 'INVALID_ADDRESSES',
+        invalidCount: invalid.length,
+        details: invalid.slice(0, 20).map((r) => ({ row: r.row, address: r.address })),
+      });
+    }
+
+    const normalised = rows.map((r) => ({
+      row: r.row,
+      address: r.address,
+      label: r.label ?? undefined,
+      points: r.bonus_points ? Number(r.bonus_points) || DEFAULT_POINTS_PER_ROW : DEFAULT_POINTS_PER_ROW,
+    }));
+
+    return res.json({
+      valid: true,
+      totalRows: normalised.length,
+      preview: normalised.slice(0, 5),
+      rows: normalised,
+    });
+  });
+
+  // ── POST /api/v1/bulk-credit/submit ──────────────────────────────────────────
+  // Accepts the validated rows from /upload and enqueues the credit job.
+
+  router.post('/bulk-credit/submit', ...auth, (req, res) => {
+    const { rows, campaignId } = req.body ?? {};
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      return res.status(400).json({ error: 'rows must be a non-empty array', code: 'MISSING_ROWS' });
+    }
+
+    if (rows.length > MAX_ALLOWLIST_ROWS) {
+      return res.status(400).json({
+        error: `Maximum ${MAX_ALLOWLIST_ROWS} rows per submission`,
+        code: 'BATCH_TOO_LARGE',
+      });
+    }
+
+    const invalid = rows.filter((r) => !validateGAddress(r.address));
+    if (invalid.length > 0) {
+      return res.status(400).json({
+        error: 'Submission contains invalid addresses',
+        code: 'INVALID_ADDRESSES',
+        details: invalid.slice(0, 10).map((r) => ({ row: r.row, address: r.address })),
+      });
+    }
+
+    const jobId = randomUUID();
+
+    try {
+      jobQueue.enqueue('bulk-credit', {
+        jobId,
+        campaignId: typeof campaignId === 'string' ? campaignId : undefined,
+        rows,
+      });
+    } catch (err) {
+      log.error?.('bulkCredit:enqueue_failed', err);
+      return res.status(500).json({ error: 'Failed to enqueue job', code: 'ENQUEUE_FAILED' });
+    }
+
+    log.info?.(`bulkCredit:enqueued jobId=${jobId} rows=${rows.length} campaignId=${campaignId ?? 'none'}`);
+
+    return res.status(202).json({
+      jobId,
+      status: 'queued',
+      totalRows: rows.length,
+    });
+  });
+
+  // ── GET /api/v1/bulk-credit/:jobId ──────────────────────────────────────────
+  // Poll job status from the durable job store when available.
+
+  router.get('/bulk-credit/:jobId', ...auth, (req, res) => {
+    const { jobId } = req.params;
+
+    if (typeof jobStore?.getStatus === 'function') {
+      const status = jobStore.getStatus(jobId);
+      if (!status) {
+        return res.status(404).json({ error: 'Job not found', code: 'NOT_FOUND' });
+      }
+      return res.json({ jobId, ...status });
+    }
+
+    return res.json({ jobId, status: 'queued', note: 'Status tracking not configured' });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- Add `backend/src/routes/bulkCredit.js` with three endpoints:
  - `POST /api/v1/bulk-credit/upload` — parse and validate a CSV file via `parseAllowlistCsv` / `validateGAddress`; returns a structured preview with invalid-address details
  - `POST /api/v1/bulk-credit/submit` — re-validates and enqueues a `bulk-credit` job via the durable job queue; responds 202 with a `jobId`
  - `GET /api/v1/bulk-credit/:jobId` — poll job status from the durable store
- Add `backend/src/jobs/bulkCreditJob.js` (`createBulkCreditJobHandler`) — processes each row via `dal.points.credit`, accumulates per-row results, and only throws (triggering a queue retry) when every row has failed

Closes #1004