### PR TITLE
feat: scheduled digest email reports with opt-out support (#1003)

### DIFF
--- a/backend/src/jobs/scheduledReportJob.js
+++ b/backend/src/jobs/scheduledReportJob.js
@@ -1,0 +1,148 @@
+// @ts-check
+
+/**
+ * Scheduled digest email job.
+ *
+ * Sends a periodic analytics / campaign-summary report to opted-in users.
+ * The schedule (cron expression or interval) is configured externally via the
+ * job runner — this module only contains the per-run logic.
+ *
+ * Opt-out is honoured via the `notification_preferences.email_enabled` flag.
+ * When `email_enabled = 0`, the user is silently skipped.
+ *
+ * @param {{
+ *   dal: {
+ *     notificationPreferences: {
+ *       getByUserId: (userId: string) => { email_enabled: 0 | 1 } | null
+ *     },
+ *     reportSubscriptions?: {
+ *       listActive: () => Array<{ userId: string, email: string, reportType: string, schedule: string }>
+ *     },
+ *     campaignStats?: {
+ *       summaryForUser: (userId: string, range: string) => object
+ *     }
+ *   },
+ *   mailer: {
+ *     send: (opts: { to: string, subject: string, html: string, text?: string }) => Promise<void>
+ *   },
+ *   reportSchedule?: string,
+ *   logger?: Pick<Console, 'info' | 'warn' | 'error'>
+ * }} deps
+ */
+export function createScheduledReportJob({
+  dal,
+  mailer,
+  reportSchedule = 'weekly',
+  logger = console,
+}) {
+  /**
+   * Run the scheduled digest report.
+   * Fetches all active subscriptions, respects opt-outs, sends emails.
+   *
+   * @param {{ now?: Date }} [opts]
+   */
+  async function run({ now = new Date() } = {}) {
+    const rangeLabel = reportSchedule === 'daily' ? 'last 24 hours' : 'last 7 days';
+    logger.info?.(`scheduledReport:start schedule=${reportSchedule} rangeLabel="${rangeLabel}"`);
+
+    const subscriptions = dal.reportSubscriptions?.listActive?.() ?? [];
+    if (subscriptions.length === 0) {
+      logger.info?.('scheduledReport:skip reason=no_active_subscriptions');
+      return { sent: 0, skipped: 0 };
+    }
+
+    let sent = 0;
+    let skipped = 0;
+
+    for (const sub of subscriptions) {
+      // Honour the per-user opt-out preference
+      const prefs = dal.notificationPreferences.getByUserId(sub.userId);
+      if (prefs && prefs.email_enabled === 0) {
+        logger.info?.(`scheduledReport:skip userId=${sub.userId} reason=opted_out`);
+        skipped++;
+        continue;
+      }
+
+      // Skip if this subscription's schedule doesn't match the current run
+      if (sub.schedule && sub.schedule !== reportSchedule) {
+        skipped++;
+        continue;
+      }
+
+      let stats = null;
+      try {
+        stats = dal.campaignStats?.summaryForUser?.(sub.userId, rangeLabel) ?? null;
+      } catch (err) {
+        logger.warn?.(`scheduledReport:stats_error userId=${sub.userId}`, err);
+      }
+
+      const { html, text } = buildReportEmail({ sub, stats, rangeLabel, now });
+
+      try {
+        await mailer.send({
+          to: sub.email,
+          subject: `Trivela ${reportSchedule} report — ${formatDate(now)}`,
+          html,
+          text,
+        });
+        sent++;
+        logger.info?.(`scheduledReport:sent userId=${sub.userId} email=${sub.email}`);
+      } catch (err) {
+        logger.error?.(`scheduledReport:send_failed userId=${sub.userId} email=${sub.email}`, err);
+        // Continue to next subscriber — partial failure is acceptable
+      }
+    }
+
+    logger.info?.(`scheduledReport:done sent=${sent} skipped=${skipped}`);
+    return { sent, skipped };
+  }
+
+  return { run };
+}
+
+/**
+ * Build the HTML + text body for a report email.
+ *
+ * @param {{
+ *   sub: { userId: string, email: string, reportType: string },
+ *   stats: object | null,
+ *   rangeLabel: string,
+ *   now: Date
+ * }} opts
+ */
+function buildReportEmail({ sub, stats, rangeLabel, now }) {
+  const dateStr = formatDate(now);
+  const statsSection = stats
+    ? `<pre>${JSON.stringify(stats, null, 2)}</pre>`
+    : '<p>No campaign data available for this period.</p>';
+
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Trivela Report</title></head>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px">
+  <h1 style="color:#1a1a2e">Trivela Report — ${dateStr}</h1>
+  <p>Here is your <strong>${rangeLabel}</strong> summary.</p>
+  ${statsSection}
+  <hr>
+  <p style="color:#888;font-size:12px">
+    To stop receiving these emails, update your notification preferences in the Trivela dashboard.
+  </p>
+</body>
+</html>`;
+
+  const text = [
+    `Trivela Report — ${dateStr}`,
+    `Period: ${rangeLabel}`,
+    '',
+    stats ? JSON.stringify(stats, null, 2) : 'No campaign data available for this period.',
+    '',
+    'To unsubscribe, update your notification preferences in the Trivela dashboard.',
+  ].join('\n');
+
+  return { html, text };
+}
+
+/** @param {Date} d */
+function formatDate(d) {
+  return d.toISOString().slice(0, 10);
+}

--- a/backend/src/routes/reportSubscriptions.js
+++ b/backend/src/routes/reportSubscriptions.js
@@ -1,0 +1,160 @@
+// @ts-check
+import { Router } from 'express';
+
+const VALID_SCHEDULES = ['daily', 'weekly', 'monthly'];
+const VALID_REPORT_TYPES = ['campaign-summary', 'analytics-digest', 'referral-digest'];
+
+/**
+ * User-facing API for managing scheduled report email subscriptions.
+ *
+ * Routes:
+ *   GET    /api/v1/report-subscriptions          – list current user's subscriptions
+ *   POST   /api/v1/report-subscriptions          – subscribe to a report
+ *   PATCH  /api/v1/report-subscriptions/:id      – update schedule or report type
+ *   DELETE /api/v1/report-subscriptions/:id      – unsubscribe (opt-out)
+ *
+ * @param {{
+ *   dal: {
+ *     reportSubscriptions: {
+ *       listByUserId: (userId: string) => object[],
+ *       create: (args: { userId: string, email: string, reportType: string, schedule: string }) => object,
+ *       update: (args: { id: string, userId: string, schedule?: string, reportType?: string }) => object | null,
+ *       delete: (args: { id: string, userId: string }) => boolean,
+ *     },
+ *     notificationPreferences: {
+ *       getByUserId: (userId: string) => { email_enabled: 0 | 1 } | null
+ *     }
+ *   },
+ *   requireAuth: import('express').RequestHandler | import('express').RequestHandler[],
+ *   log?: Pick<Console, 'info' | 'warn' | 'error'>
+ * }} deps
+ */
+export function createReportSubscriptionsRouter({ dal, requireAuth, log = console }) {
+  const router = Router();
+  const auth = Array.isArray(requireAuth) ? requireAuth : [requireAuth];
+
+  // ── GET /api/v1/report-subscriptions ────────────────────────────────────────
+
+  router.get('/report-subscriptions', ...auth, (req, res) => {
+    const userId = req.user?.id ?? req.headers['x-user-id'];
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+    const subscriptions = dal.reportSubscriptions.listByUserId(String(userId));
+    return res.json({ subscriptions });
+  });
+
+  // ── POST /api/v1/report-subscriptions ───────────────────────────────────────
+
+  router.post('/report-subscriptions', ...auth, (req, res) => {
+    const userId = req.user?.id ?? req.headers['x-user-id'];
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+
+    // Respect the global email opt-out preference
+    const prefs = dal.notificationPreferences.getByUserId(String(userId));
+    if (prefs && prefs.email_enabled === 0) {
+      return res.status(403).json({
+        error: 'Email notifications are disabled for your account. Enable them in notification preferences first.',
+        code: 'EMAIL_OPTED_OUT',
+      });
+    }
+
+    const { email, reportType = 'campaign-summary', schedule = 'weekly' } = req.body ?? {};
+
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      return res.status(400).json({ error: 'Valid email address is required', code: 'INVALID_EMAIL' });
+    }
+
+    if (!VALID_REPORT_TYPES.includes(reportType)) {
+      return res.status(400).json({
+        error: `reportType must be one of: ${VALID_REPORT_TYPES.join(', ')}`,
+        code: 'INVALID_REPORT_TYPE',
+      });
+    }
+
+    if (!VALID_SCHEDULES.includes(schedule)) {
+      return res.status(400).json({
+        error: `schedule must be one of: ${VALID_SCHEDULES.join(', ')}`,
+        code: 'INVALID_SCHEDULE',
+      });
+    }
+
+    try {
+      const subscription = dal.reportSubscriptions.create({
+        userId: String(userId),
+        email,
+        reportType,
+        schedule,
+      });
+      log.info?.(`reportSubscriptions:created userId=${userId} schedule=${schedule} type=${reportType}`);
+      return res.status(201).json({ subscription });
+    } catch (err) {
+      log.error?.('reportSubscriptions:create_failed', err);
+      return res.status(500).json({ error: 'Failed to create subscription', code: 'INTERNAL_ERROR' });
+    }
+  });
+
+  // ── PATCH /api/v1/report-subscriptions/:id ──────────────────────────────────
+
+  router.patch('/report-subscriptions/:id', ...auth, (req, res) => {
+    const userId = req.user?.id ?? req.headers['x-user-id'];
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+
+    const { schedule, reportType } = req.body ?? {};
+
+    if (schedule && !VALID_SCHEDULES.includes(schedule)) {
+      return res.status(400).json({
+        error: `schedule must be one of: ${VALID_SCHEDULES.join(', ')}`,
+        code: 'INVALID_SCHEDULE',
+      });
+    }
+
+    if (reportType && !VALID_REPORT_TYPES.includes(reportType)) {
+      return res.status(400).json({
+        error: `reportType must be one of: ${VALID_REPORT_TYPES.join(', ')}`,
+        code: 'INVALID_REPORT_TYPE',
+      });
+    }
+
+    const updated = dal.reportSubscriptions.update({
+      id: req.params.id,
+      userId: String(userId),
+      schedule,
+      reportType,
+    });
+
+    if (!updated) {
+      return res.status(404).json({ error: 'Subscription not found', code: 'NOT_FOUND' });
+    }
+
+    return res.json({ subscription: updated });
+  });
+
+  // ── DELETE /api/v1/report-subscriptions/:id ─────────────────────────────────
+  // Explicit opt-out. Removing a subscription stops future emails for that report.
+
+  router.delete('/report-subscriptions/:id', ...auth, (req, res) => {
+    const userId = req.user?.id ?? req.headers['x-user-id'];
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHORIZED' });
+    }
+
+    const deleted = dal.reportSubscriptions.delete({
+      id: req.params.id,
+      userId: String(userId),
+    });
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Subscription not found', code: 'NOT_FOUND' });
+    }
+
+    log.info?.(`reportSubscriptions:deleted id=${req.params.id} userId=${userId}`);
+    return res.status(204).send();
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- Add `backend/src/jobs/scheduledReportJob.js` (`createScheduledReportJob`) — iterates active report subscriptions, skips users who have `notification_preferences.email_enabled = 0` (global opt-out) or whose subscription schedule doesn't match the current run; sends HTML + plain-text digest email via an injected mailer; partial failures (one user's send bounces) do not abort the full run

- Add `backend/src/routes/reportSubscriptions.js` (`createReportSubscriptionsRouter`) with four endpoints:
  - `GET /api/v1/report-subscriptions` — list the current user's active subscriptions
  - `POST /api/v1/report-subscriptions` — subscribe to a report (schedule: daily/weekly/monthly; reportType: campaign-summary/analytics-digest/referral-digest); blocked when the global `email_enabled = 0` to prevent silent drops
  - `PATCH /api/v1/report-subscriptions/:id` — change schedule or report type
  - `DELETE /api/v1/report-subscriptions/:id` — explicit opt-out / cancel

Closes #1003