### PR TITLE
Feat/930 prometheus metrics red jobs rpc

### DIFF
--- a/backend/src/dal/sqliteJobQueueRepository.js
+++ b/backend/src/dal/sqliteJobQueueRepository.js
@@ -92,6 +92,10 @@ export function createSqliteJobQueueRepository({ db }) {
 
   const countDeadStmt = db.prepare(`SELECT COUNT(*) AS n FROM job_queue WHERE status = 'dead'`);
 
+  const countByStatusStmt = db.prepare(
+    `SELECT COUNT(*) AS n FROM job_queue WHERE status = ?`,
+  );
+
   const findByIdStmt = db.prepare('SELECT * FROM job_queue WHERE id = ? LIMIT 1');
 
   const deleteByIdStmt = db.prepare('DELETE FROM job_queue WHERE id = ?');
@@ -201,6 +205,17 @@ export function createSqliteJobQueueRepository({ db }) {
   }
 
   /**
+   * Count jobs currently in a given status ('pending' | 'running' | 'dead').
+   * Used to report queue depth for monitoring (#930).
+   *
+   * @param {string} status
+   */
+  function countByStatus(status) {
+    const row = countByStatusStmt.get(status);
+    return row?.n ?? 0;
+  }
+
+  /**
    * @param {string} id
    */
   function getById(id) {
@@ -216,5 +231,16 @@ export function createSqliteJobQueueRepository({ db }) {
     return info.changes > 0;
   }
 
-  return { enqueue, claimNext, ack, nack, recoverStale, listDead, countDead, getById, removeById };
+  return {
+    enqueue,
+    claimNext,
+    ack,
+    nack,
+    recoverStale,
+    listDead,
+    countDead,
+    countByStatus,
+    getById,
+    removeById,
+  };
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -943,6 +943,8 @@ export async function createApp(options = {}) {
 
     // RPC pool saturation metrics.
     const poolStatus = rpcPool.getStatus();
+    const jobRunnerStatus = jobRunner.getStatus();
+    const durableJobQueueStatus = durableJobQueue.getStatus();
 
     const payload = [
       '# HELP trivela_requests_total Total HTTP requests handled.',
@@ -985,6 +987,22 @@ export async function createApp(options = {}) {
       '# HELP trivela_rpc_pool_unhealthy Unhealthy RPC endpoints in the pool.',
       '# TYPE trivela_rpc_pool_unhealthy gauge',
       `trivela_rpc_pool_unhealthy ${poolStatus.unhealthy}`,
+      // Job queue depth (issue #930 — RED + queue + RPC metrics).
+      '# HELP trivela_job_queue_depth Jobs waiting to run, by queue.',
+      '# TYPE trivela_job_queue_depth gauge',
+      `trivela_job_queue_depth{queue="in_memory"} ${jobRunnerStatus.queued}`,
+      `trivela_job_queue_depth{queue="durable"} ${durableJobQueueStatus.pending}`,
+      '# HELP trivela_job_queue_running Jobs currently executing, by queue.',
+      '# TYPE trivela_job_queue_running gauge',
+      `trivela_job_queue_running{queue="in_memory"} ${jobRunnerStatus.running}`,
+      `trivela_job_queue_running{queue="durable"} ${durableJobQueueStatus.running}`,
+      '# HELP trivela_job_queue_dead_total Jobs moved to the dead-letter queue after exhausting retries.',
+      '# TYPE trivela_job_queue_dead_total gauge',
+      `trivela_job_queue_dead_total{queue="durable"} ${durableJobQueueStatus.dead}`,
+      // Cross-queue dead-letter size (feeds the pre-existing DLQGrowth alert).
+      '# HELP trivela_dlq_size_total Total jobs (across all queues) in the dead-letter store.',
+      '# TYPE trivela_dlq_size_total gauge',
+      `trivela_dlq_size_total ${failedJobRepository.count()}`,
       // Indexer metrics (#532).
       ...Object.entries(eventIndexer?.getMetrics?.() ?? {})
         .map(([key, value]) => [

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -447,6 +447,25 @@ test('GET /metrics exposes minimal Prometheus metrics', async () => {
   }
 });
 
+test('GET /metrics exposes job queue depth and DLQ size (#930)', async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/metrics`);
+    assert.equal(response.status, 200);
+
+    const body = await response.text();
+    assert.match(body, /trivela_job_queue_depth\{queue="in_memory"\} \d+/);
+    assert.match(body, /trivela_job_queue_depth\{queue="durable"\} \d+/);
+    assert.match(body, /trivela_job_queue_running\{queue="in_memory"\} \d+/);
+    assert.match(body, /trivela_job_queue_running\{queue="durable"\} \d+/);
+    assert.match(body, /trivela_job_queue_dead_total\{queue="durable"\} \d+/);
+    assert.match(body, /trivela_dlq_size_total \d+/);
+  } finally {
+    await stopTestServer(server);
+  }
+});
+
 test('POST /api/v1/campaigns creates a new campaign and returns it', async () => {
   const { server, baseUrl } = await startTestServer();
 

--- a/backend/src/jobs/durableJobQueue.js
+++ b/backend/src/jobs/durableJobQueue.js
@@ -139,5 +139,17 @@ export function createDurableJobQueue(
     }
   }
 
-  return { enqueue, start, stop };
+  /**
+   * Queue depth snapshot for monitoring (#930): counts pending/running jobs
+   * and the dead-letter backlog directly from the store.
+   */
+  function getStatus() {
+    return {
+      pending: store.countByStatus('pending'),
+      running: store.countByStatus('running'),
+      dead: store.countDead(),
+    };
+  }
+
+  return { enqueue, start, stop, getStatus };
 }

--- a/backend/src/jobs/durableJobQueue.test.js
+++ b/backend/src/jobs/durableJobQueue.test.js
@@ -179,6 +179,25 @@ test('durableJobQueue: listDead and countDead pagination', async () => {
   queue.stop();
 });
 
+test('durableJobQueue: getStatus reports pending/running/dead depth (#930)', async () => {
+  const { store, queue } = await setup({});
+  const now = new Date().toISOString();
+
+  assert.deepEqual(queue.getStatus(), { pending: 0, running: 0, dead: 0 });
+
+  store.enqueue({ type: 'job', payload: null, runAt: now, enqueuedAt: now, maxAttempts: 1 });
+  store.enqueue({ type: 'job', payload: null, runAt: now, enqueuedAt: now, maxAttempts: 1 });
+  assert.deepEqual(queue.getStatus(), { pending: 2, running: 0, dead: 0 });
+
+  const claimed = store.claimNext(60_000);
+  assert.deepEqual(queue.getStatus(), { pending: 1, running: 1, dead: 0 });
+
+  store.nack(claimed.id, { isDead: true, errorMessage: 'boom' });
+  assert.deepEqual(queue.getStatus(), { pending: 1, running: 0, dead: 1 });
+
+  queue.stop();
+});
+
 test('durableJobQueue: removeById deletes a job', async () => {
   const { store, queue } = await setup({});
   const now = new Date().toISOString();

--- a/backend/src/jobs/jobRunner.js
+++ b/backend/src/jobs/jobRunner.js
@@ -169,9 +169,18 @@ export function createJobRunner({
 
   scheduleNext();
 
+  /**
+   * Queue depth snapshot for monitoring (#930): jobs waiting in-memory plus
+   * whether the runner is currently executing one.
+   */
+  function getStatus() {
+    return { queued: queue.length, running: running ? 1 : 0 };
+  }
+
   return {
     enqueue,
     stop,
+    getStatus,
     // Exposed so callers (e.g. an admin "retry from dead-letter" endpoint)
     // can rebuild a job after an operator reviews it.
     _computeBackoffMs: computeBackoffMs,

--- a/backend/src/jobs/jobRunner.test.js
+++ b/backend/src/jobs/jobRunner.test.js
@@ -202,3 +202,38 @@ test('jobRunner uses environment-driven defaults when enqueue omits options', as
   assert.equal(attempts, 2, 'runner should respect defaultMaxAttempts');
   assert.equal(observedMaxAttempts, 2);
 });
+
+test('jobRunner getStatus reports queue depth and in-flight state (#930)', async () => {
+  let resolveStarted;
+  const started = new Promise((resolve) => {
+    resolveStarted = resolve;
+  });
+  let resolveHandler;
+  const runner = createJobRunner({
+    handlers: {
+      slow: () =>
+        new Promise((resolve) => {
+          resolveStarted();
+          resolveHandler = resolve;
+        }),
+    },
+    logger: silentLogger(),
+  });
+
+  assert.deepEqual(runner.getStatus(), { queued: 0, running: 0 });
+
+  runner.enqueue('slow', null, { maxAttempts: 1, baseDelayMs: 1, maxDelayMs: 5 });
+  runner.enqueue('other', null, { maxAttempts: 1, baseDelayMs: 1, maxDelayMs: 5 });
+
+  await started;
+  assert.deepEqual(runner.getStatus(), { queued: 1, running: 1 });
+
+  resolveHandler();
+  const deadline = Date.now() + 500;
+  while (runner.getStatus().running === 1 && Date.now() < deadline) {
+    await tick(5);
+  }
+  runner.stop();
+
+  assert.deepEqual(runner.getStatus(), { queued: 0, running: 0 });
+});

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -118,6 +118,43 @@ repeatedly fail authentication on a guarded route.
 4. Tune thresholds via `AUTH_LOCKOUT_SOFT_THRESHOLD`, `AUTH_LOCKOUT_HARD_THRESHOLD`, and
    `AUTH_LOCKOUT_BASE_MS` if the defaults are too aggressive/lenient, then restart the backend.
 
+## DLQ Investigation
+
+Triggered by the `DLQGrowth` alert, or a rising `trivela_dlq_size_total` / `trivela_job_queue_dead_total`
+on `/metrics`. Both background job queues (the in-memory `jobRunner` and the persistent
+`durableJobQueue`) write to the same `failed_jobs` table once a job exhausts `maxAttempts`.
+
+1. List recent dead-letter entries to see which job `type` is failing and why:
+   - In-memory `jobRunner` failures: `GET /api/v1/jobs/failed`
+   - Durable `durableJobQueue` failures: `GET /api/v1/admin/jobs/dlq` (requires the master API key)
+   ```bash
+   curl -s "$API_URL/api/v1/jobs/failed?limit=20" -H "x-api-key: $API_KEY" | jq
+   ```
+2. Check backend logs around the failure timestamps for the underlying error
+   (`job:dead type=... error=...` / `durableQueue:dead type=... error=...`).
+3. Fix the root cause (bad payload, downstream outage, bug in the handler).
+4. If the jobs are now safe to retry, re-enqueue via `POST /api/v1/jobs/retry/:id` (in-memory) or
+   `POST /api/v1/admin/jobs/:id/replay` (durable); otherwise leave them so the DLQ count reflects
+   only unresolved failures.
+5. Watch `trivela_job_queue_depth{queue="durable"}` in Grafana → Trivela Jobs
+   (`monitoring/dashboards/trivela-jobs.json`) to confirm the backlog is draining, not just the DLQ.
+
+## Job Queue Backlog
+
+Triggered by the `JobQueueBacklog` alert, or `trivela_job_queue_depth{queue="durable"}` climbing on
+`/metrics`. This means jobs are being enqueued faster than the durable queue's single poller can
+drain them (default `pollIntervalMs` = 5 s, one job per poll).
+
+1. Confirm the backend process is up and `durableJobQueue.start()` is running (check `/health` and
+   backend logs for `durableQueue:` entries).
+2. Check whether one job `type` dominates the backlog — a slow or hanging handler blocks the whole
+   queue since `processNext()` processes one job at a time.
+3. If the backlog is due to a legitimate traffic spike, it should self-drain; if a handler is stuck
+   or erroring repeatedly, expect it to also show up as [DLQ growth](#dlq-investigation) once
+   `maxAttempts` is exhausted.
+4. As a stopgap, restart the backend to clear any wedged in-flight job (protected by the
+   `visibilityTimeoutMs` stale-job recovery on the next `start()`).
+
 ## Database Migration Failures
 
 If `npm run db:migrate` fails during deployment:

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -62,6 +62,25 @@ hanging indefinitely.
 
 ---
 
+## 4a. Job queue backlog SLO
+
+| Signal                    | SLI                                                    | SLO target                    |
+| -------------------------- | ------------------------------------------------------ | ------------------------------ |
+| Durable queue backlog      | `trivela_job_queue_depth{queue="durable"}`              | ≤ 100 pending jobs sustained   |
+| Durable queue drain rate   | Backlog should trend down between polls (see dashboard) | No sustained growth over 10 min |
+| Dead-letter queue size     | `trivela_dlq_size_total`                                | 0 sustained; investigate any growth |
+
+**Alert:** `JobQueueBacklog` fires when `trivela_job_queue_depth{queue="durable"} > 100` for 10
+continuous minutes. `DLQGrowth` fires when the dead-letter store grows by more than 10 jobs over 15
+minutes — see [`docs/RUNBOOK.md#dlq-investigation`](RUNBOOK.md#dlq-investigation) and
+[`docs/RUNBOOK.md#job-queue-backlog`](RUNBOOK.md#job-queue-backlog).
+
+**Dashboard:** Grafana → Trivela Jobs (`monitoring/dashboards/trivela-jobs.json`) — queue depth,
+in-flight jobs, and dead-letter backlog for both the in-memory (`jobRunner`) and persistent
+(`durableJobQueue`) queues.
+
+---
+
 ## 5. Synthetic canary SLO
 
 | Signal                  | SLI                               | SLO target                      |
@@ -99,7 +118,9 @@ Budget resets at the start of each calendar month.
 
 ## 8. Measurement & reporting
 
-- **Dashboard:** Grafana → Trivela API (`monitoring/dashboards/trivela-api.json`).
+- **Dashboards:** Grafana → Trivela API (`monitoring/dashboards/trivela-api.json`), Trivela RPC &
+  Pools (`monitoring/dashboards/trivela-rpc-pools.json`), Trivela Jobs
+  (`monitoring/dashboards/trivela-jobs.json`).
 - **Alert rules:** `monitoring/alerting/alerting_rules.yml`.
 - **Alertmanager:** `monitoring/alertmanager.yml` (routes to `#trivela-alerts`, `#trivela-critical`,
   PagerDuty for critical journeys).

--- a/monitoring/alerting/alerting_rules.yml
+++ b/monitoring/alerting/alerting_rules.yml
@@ -189,6 +189,25 @@ groups:
           description: '{{ $value }} DB write errors on the campaigns table in the last 5 minutes.'
           runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#db-backup-restore'
 
+  # ── Job queues ──────────────────────────────────────────────────────────────
+  - name: trivela_jobs
+    interval: 60s
+    rules:
+      # Durable queue backlog not draining (issue #930 — job queue depth metric)
+      - alert: JobQueueBacklog
+        expr: |
+          trivela_job_queue_depth{job="trivela-backend",queue="durable"} > 100
+        for: 10m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: 'Durable job queue backlog is growing'
+          description: >-
+            {{ $value }} jobs pending in the durable queue for over 10 minutes. The poller may be
+            stuck behind a slow handler, or jobs are being enqueued faster than they can drain.
+          runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#job-queue-backlog'
+
   # ── DLQ ─────────────────────────────────────────────────────────────────────
   - name: trivela_dlq
     interval: 60s

--- a/monitoring/alerting/alerting_rules_test.yml
+++ b/monitoring/alerting/alerting_rules_test.yml
@@ -138,6 +138,39 @@ tests:
                 the RPC tier.'
               runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#rpc-pool-saturation'
 
+  # ── JobQueueBacklog ─────────────────────────────────────────────────────────
+  - interval: 1m
+    input_series:
+      - series: 'trivela_job_queue_depth{job="trivela-backend",queue="durable"}'
+        values: '150+0x15' # steady backlog of 150 pending jobs for 15m
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: JobQueueBacklog
+        exp_alerts:
+          - exp_labels:
+              job: trivela-backend
+              queue: durable
+              severity: warning
+              team: backend
+            exp_annotations:
+              summary: 'Durable job queue backlog is growing'
+              description:
+                '150 jobs pending in the durable queue for over 10 minutes. The poller may be stuck
+                behind a slow handler, or jobs are being enqueued faster than they can drain.'
+              runbook_url: 'https://github.com/FinesseStudioLab/Trivela/blob/main/docs/RUNBOOK.md#job-queue-backlog'
+
+  # ── JobQueueBacklog does NOT fire below threshold ─────────────────────────
+  - interval: 1m
+    input_series:
+      - series: 'trivela_job_queue_depth{job="trivela-backend",queue="durable"}'
+        values: '20+0x15'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: JobQueueBacklog
+        exp_alerts: []
+
   # ── DLQGrowth ───────────────────────────────────────────────────────────────
   - interval: 1m
     input_series:

--- a/monitoring/dashboards/trivela-jobs.json
+++ b/monitoring/dashboards/trivela-jobs.json
@@ -1,0 +1,146 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.4.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "Trivela background job queue depth, in-flight jobs, and dead-letter backlog.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "trivela_job_queue_depth{job=\"trivela-backend\",queue=\"in_memory\"}",
+          "legendFormat": "in-memory",
+          "refId": "A"
+        },
+        {
+          "expr": "trivela_job_queue_depth{job=\"trivela-backend\",queue=\"durable\"}",
+          "legendFormat": "durable (pending)",
+          "refId": "B"
+        }
+      ],
+      "title": "Job Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "min": 0 },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "trivela_job_queue_running{job=\"trivela-backend\",queue=\"in_memory\"}",
+          "legendFormat": "in-memory",
+          "refId": "A"
+        },
+        {
+          "expr": "trivela_job_queue_running{job=\"trivela-backend\",queue=\"durable\"}",
+          "legendFormat": "durable",
+          "refId": "B"
+        }
+      ],
+      "title": "Jobs In Flight",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "green", "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 10 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "trivela_job_queue_dead_total{job=\"trivela-backend\",queue=\"durable\"}",
+          "legendFormat": "dead-letter jobs",
+          "refId": "A"
+        }
+      ],
+      "title": "Durable Queue — Dead-Letter Backlog",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "green", "mode": "thresholds" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 20 }, { "color": "red", "value": 100 }]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 8 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "expr": "trivela_job_queue_depth{job=\"trivela-backend\",queue=\"durable\"}",
+          "legendFormat": "pending",
+          "refId": "A"
+        }
+      ],
+      "title": "Durable Queue — Pending Now",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["trivela", "jobs", "queue"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Trivela Jobs",
+  "uid": "trivela-jobs",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Closes #930. Fills the one real gap in Trivela's Prometheus setup — job queue depth — and finishes wiring RED + queue + RPC metrics into Grafana and docs, per the issue's acceptance criteria.

RED metrics (`trivela_requests_total`, `trivela_request_errors_total`, `trivela_http_request_duration_ms`) and RPC pool health (`trivela_rpc_pool_*`) already existed on `/metrics` and in Grafana from prior work. This PR adds job queue depth and closes out the remaining acceptance criteria.

## What's new

- **`trivela_job_queue_depth`** / **`trivela_job_queue_running`** — gauges labeled `queue="in_memory"` (the in-process `jobRunner`) and `queue="durable"` (the SQLite-backed `durableJobQueue`).
- **`trivela_job_queue_dead_total`** — dead-lettered jobs in the durable queue.
- **`trivela_dlq_size_total`** — total jobs across both queues in the shared `failed_jobs` dead-letter store. This also makes the **pre-existing `DLQGrowth` alert** functional for the first time — it referenced a metric that was never actually emitted anywhere in the codebase.
- New **`monitoring/dashboards/trivela-jobs.json`** Grafana dashboard (queue depth, in-flight jobs, dead-letter backlog), auto-discovered by the existing dashboard provisioner alongside `trivela-api.json` and `trivela-rpc-pools.json`.
- New **`JobQueueBacklog`** alert (fires when the durable queue backlog exceeds 100 pending jobs for 10m) with matching `promtool` unit tests.
- Docs: new "Job queue backlog SLO" section in `docs/SLO.md`, and "DLQ Investigation" / "Job Queue Backlog" runbook sections in `docs/RUNBOOK.md` (matching the anchors the alerts link to).

## Implementation

- `getStatus()` added to `jobRunner` and `durableJobQueue`, backed by a new `countByStatus()` on `sqliteJobQueueRepository`.
- `/metrics` in `backend/src/index.js` reads these once per scrape and renders the new series.

## Testing

- Unit tests for the new `getStatus()` methods on both queues.
- Extended the existing `/metrics` test to assert the new series are present and well-formed.
- `promtool test rules` passes (17 rules, including 2 new `JobQueueBacklog` cases) — validated via Docker against the real `prom/prometheus` image.
- Full live smoke test: booted the backend + Prometheus + Grafana in Docker, confirmed `/metrics` output, Prometheus scraping with correct labels, alert rules evaluating cleanly, and the new "Trivela Jobs" dashboard rendering real data through the provisioned datasource.
- `eslint` / `tsc --noEmit` clean on all touched files (pre-existing, unrelated warnings/errors elsewhere untouched).

## Acceptance criteria

- [x] `/metrics` exposes RED + queue + RPC metrics.
- [x] Wired into Grafana dashboards.
- [x] Documented.
