### PR TITLE
Feat/924 api key scopes rate tiers

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -582,6 +582,17 @@ paths:
                   type: string
                   format: date-time
                   nullable: true
+                orgId:
+                  type: string
+                  description: Scope the key to an organization.
+                scopes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ApiKeyScope'
+                  description: Defaults to the full legacy scope set if omitted.
+                rateTier:
+                  $ref: '#/components/schemas/ApiKeyRateTier'
+                  description: Defaults to `standard` if omitted.
       responses:
         '201':
           description: API key created (raw key returned once)
@@ -641,6 +652,55 @@ paths:
                     type: string
                   metadata:
                     $ref: '#/components/schemas/ApiKeyMetadata'
+
+  /api/v1/admin/api-keys/{id}/rate-tier:
+    put:
+      summary: Update an API key's rate tier
+      description: >-
+        Changes the enforced rate-limit tier in place, without rotating (and
+        thus invalidating) the caller's existing credential.
+      tags:
+        - Admin
+      operationId: updateApiKeyRateTier
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - rateTier
+              properties:
+                rateTier:
+                  $ref: '#/components/schemas/ApiKeyRateTier'
+      responses:
+        '200':
+          description: Rate tier updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metadata:
+                    $ref: '#/components/schemas/ApiKeyMetadata'
+        '400':
+          description: Invalid rate tier value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Key not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/v1/audit-logs:
     get:
@@ -1909,6 +1969,17 @@ components:
           type: string
         label:
           type: string
+        orgId:
+          type: string
+          nullable: true
+          description: Organization the key is scoped to, if any.
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyScope'
+          description: Granular permissions granted to the key.
+        rateTier:
+          $ref: '#/components/schemas/ApiKeyRateTier'
         createdAt:
           type: string
           format: date-time
@@ -1922,6 +1993,17 @@ components:
           nullable: true
         active:
           type: boolean
+
+    ApiKeyScope:
+      type: string
+      enum: [campaigns:read, campaigns:write, allowlist:write, admin]
+
+    ApiKeyRateTier:
+      type: string
+      enum: [standard, pro, enterprise]
+      description: >-
+        Per-key rate-limit tier enforced by the rate limiter (#924). `standard`
+        is 60 req/min, `pro` is 300 req/min, `enterprise` is 1000 req/min.
 
     Error:
       type: object

--- a/backend/src/config/rateTiers.js
+++ b/backend/src/config/rateTiers.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+/**
+ * Named per-API-key rate-limit tiers (#924). `standard` matches the
+ * long-standing global default (60 req/min) so existing keys — which get
+ * backfilled to `standard` by migration 035 — see no behavior change.
+ */
+export const RATE_TIERS = /** @type {const} */ ({
+  standard: { maxRequests: 60, windowMs: 60_000 },
+  pro: { maxRequests: 300, windowMs: 60_000 },
+  enterprise: { maxRequests: 1_000, windowMs: 60_000 },
+});
+
+export const DEFAULT_RATE_TIER = 'standard';
+
+/**
+ * Literal tuple (not derived from `Object.keys(RATE_TIERS)`) so zod's
+ * `z.enum()` — which requires a fixed-length tuple type, not `string[]` — can
+ * type-check it directly. Kept in sync with RATE_TIERS by a test asserting
+ * the two lists match.
+ */
+export const VALID_RATE_TIERS = /** @type {const} */ (['standard', 'pro', 'enterprise']);
+
+/**
+ * @param {string | null | undefined} tier
+ * @returns {{ maxRequests: number, windowMs: number }}
+ */
+export function getRateTierLimits(tier) {
+  return RATE_TIERS[tier ?? DEFAULT_RATE_TIER] ?? RATE_TIERS[DEFAULT_RATE_TIER];
+}

--- a/backend/src/config/rateTiers.test.js
+++ b/backend/src/config/rateTiers.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RATE_TIERS, VALID_RATE_TIERS, DEFAULT_RATE_TIER, getRateTierLimits } from './rateTiers.js';
+
+test('VALID_RATE_TIERS stays in sync with the RATE_TIERS config keys', () => {
+  assert.deepEqual([...VALID_RATE_TIERS].sort(), Object.keys(RATE_TIERS).sort());
+});
+
+test('DEFAULT_RATE_TIER is a valid tier', () => {
+  assert.ok(VALID_RATE_TIERS.includes(/** @type {any} */ (DEFAULT_RATE_TIER)));
+});
+
+test('getRateTierLimits returns the matching tier config', () => {
+  assert.deepEqual(getRateTierLimits('pro'), RATE_TIERS.pro);
+  assert.deepEqual(getRateTierLimits('enterprise'), RATE_TIERS.enterprise);
+});
+
+test('getRateTierLimits falls back to the default tier for unknown/missing values', () => {
+  assert.deepEqual(getRateTierLimits(undefined), RATE_TIERS[DEFAULT_RATE_TIER]);
+  assert.deepEqual(getRateTierLimits(null), RATE_TIERS[DEFAULT_RATE_TIER]);
+  assert.deepEqual(getRateTierLimits('not-a-real-tier'), RATE_TIERS[DEFAULT_RATE_TIER]);
+});

--- a/backend/src/dal/sqliteApiKeyRepository.js
+++ b/backend/src/dal/sqliteApiKeyRepository.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { DEFAULT_SCOPES } from '../db/migrations/017_api_key_scopes.js';
+import { DEFAULT_RATE_TIER } from '../config/rateTiers.js';
 
 function hashKey(rawKey) {
   return createHash('sha256').update(rawKey).digest('hex');
@@ -26,6 +27,7 @@ function rowToApiKey(row) {
     label: row.label,
     orgId: row.org_id ?? null,
     scopes: parseScopes(row.scopes),
+    rateTier: row.rate_tier ?? DEFAULT_RATE_TIER,
     createdAt: row.created_at,
     expiresAt: row.expires_at ?? null,
     lastUsedAt: row.last_used_at ?? null,
@@ -38,8 +40,8 @@ function rowToApiKey(row) {
  */
 export function createSqliteApiKeyRepository({ db }) {
   const insertStmt = db.prepare(`
-    INSERT INTO api_keys (id, key_hash, label, org_id, scopes, created_at, expires_at, active)
-    VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+    INSERT INTO api_keys (id, key_hash, label, org_id, scopes, rate_tier, created_at, expires_at, active)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
   `);
 
   const findByHashStmt = db.prepare(`
@@ -54,16 +56,26 @@ export function createSqliteApiKeyRepository({ db }) {
     UPDATE api_keys SET active = 0 WHERE id = ?
   `);
 
+  const setRateTierStmt = db.prepare(`
+    UPDATE api_keys SET rate_tier = ? WHERE id = ?
+  `);
+
   /**
-   * @param {{ label?: string, expiresAt?: string | null, orgId?: string | null, scopes?: string[] }} [opts]
+   * @param {{ label?: string, expiresAt?: string | null, orgId?: string | null, scopes?: string[], rateTier?: string }} [opts]
    */
-  function create({ label = '', expiresAt = null, orgId = null, scopes = DEFAULT_SCOPES } = {}) {
+  function create({
+    label = '',
+    expiresAt = null,
+    orgId = null,
+    scopes = DEFAULT_SCOPES,
+    rateTier = DEFAULT_RATE_TIER,
+  } = {}) {
     const rawKey = generateRawKey();
     const id = randomUUID();
     const createdAt = new Date().toISOString();
     const scopesJson = JSON.stringify(scopes);
 
-    insertStmt.run(id, hashKey(rawKey), label, orgId, scopesJson, createdAt, expiresAt);
+    insertStmt.run(id, hashKey(rawKey), label, orgId, scopesJson, rateTier, createdAt, expiresAt);
 
     return {
       key: rowToApiKey({
@@ -71,6 +83,7 @@ export function createSqliteApiKeyRepository({ db }) {
         label,
         org_id: orgId,
         scopes: scopesJson,
+        rate_tier: rateTier,
         created_at: createdAt,
         expires_at: expiresAt,
         last_used_at: null,
@@ -84,7 +97,7 @@ export function createSqliteApiKeyRepository({ db }) {
     return db
       .prepare(
         `
-      SELECT id, label, org_id, scopes, created_at, expires_at, last_used_at, active
+      SELECT id, label, org_id, scopes, rate_tier, created_at, expires_at, last_used_at, active
       FROM api_keys
       ORDER BY created_at DESC
     `,
@@ -97,7 +110,7 @@ export function createSqliteApiKeyRepository({ db }) {
     const row = db
       .prepare(
         `
-      SELECT id, label, org_id, scopes, created_at, expires_at, last_used_at, active
+      SELECT id, label, org_id, scopes, rate_tier, created_at, expires_at, last_used_at, active
       FROM api_keys WHERE id = ?
     `,
       )
@@ -112,7 +125,7 @@ export function createSqliteApiKeyRepository({ db }) {
 
   /**
    * @param {string} rawKey
-   * @returns {{ id: string, label: string, orgId: string | null, scopes: string[] } | null}
+   * @returns {{ id: string, label: string, orgId: string | null, scopes: string[], rateTier: string } | null}
    */
   function validate(rawKey) {
     const row = findByHashStmt.get(hashKey(rawKey));
@@ -127,6 +140,7 @@ export function createSqliteApiKeyRepository({ db }) {
       label: row.label,
       orgId: row.org_id ?? null,
       scopes: parseScopes(row.scopes),
+      rateTier: row.rate_tier ?? DEFAULT_RATE_TIER,
     };
   }
 
@@ -146,7 +160,21 @@ export function createSqliteApiKeyRepository({ db }) {
       expiresAt: existing.expiresAt,
       orgId: existing.orgId,
       scopes: existing.scopes,
+      rateTier: existing.rateTier,
     });
+  }
+
+  /**
+   * Update the rate tier of an existing key in place (#924) — lets an admin
+   * upgrade/downgrade a partner's limits without rotating (and invalidating)
+   * their credential.
+   *
+   * @param {string} id
+   * @param {string} rateTier
+   */
+  function setRateTier(id, rateTier) {
+    const info = setRateTierStmt.run(rateTier, id);
+    return info.changes > 0 ? getById(id) : null;
   }
 
   function hasActiveKeys() {
@@ -163,6 +191,7 @@ export function createSqliteApiKeyRepository({ db }) {
     touchLastUsed,
     rotate,
     hasActiveKeys,
+    setRateTier,
   };
 }
 

--- a/backend/src/dal/sqliteApiKeyRepository.test.js
+++ b/backend/src/dal/sqliteApiKeyRepository.test.js
@@ -53,3 +53,48 @@ test('api key repository updates last_used_at on touch', async () => {
   const listed = repository.list();
   assert.ok(listed[0].lastUsedAt);
 });
+
+// ── Rate tiers (#924) ────────────────────────────────────────────────────────
+
+test('api key repository defaults new keys to the standard rate tier', async () => {
+  const repository = await setupRepository();
+  const created = repository.create({ label: 'default-tier' });
+
+  assert.equal(created.key.rateTier, 'standard');
+  assert.equal(repository.getById(created.key.id).rateTier, 'standard');
+  assert.equal(repository.validate(created.rawKey).rateTier, 'standard');
+});
+
+test('api key repository accepts an explicit rate tier at creation', async () => {
+  const repository = await setupRepository();
+  const created = repository.create({ label: 'pro-tier', rateTier: 'pro' });
+
+  assert.equal(created.key.rateTier, 'pro');
+  assert.equal(repository.list()[0].rateTier, 'pro');
+  assert.equal(repository.validate(created.rawKey).rateTier, 'pro');
+});
+
+test('api key repository setRateTier updates an existing key in place', async () => {
+  const repository = await setupRepository();
+  const created = repository.create({ label: 'upgrade-me' });
+  assert.equal(created.key.rateTier, 'standard');
+
+  const updated = repository.setRateTier(created.key.id, 'enterprise');
+  assert.equal(updated.rateTier, 'enterprise');
+  assert.equal(repository.getById(created.key.id).rateTier, 'enterprise');
+  // The raw key keeps working — this is not a rotation.
+  assert.ok(repository.validate(created.rawKey));
+});
+
+test('api key repository setRateTier returns null for an unknown id', async () => {
+  const repository = await setupRepository();
+  assert.equal(repository.setRateTier('does-not-exist', 'pro'), null);
+});
+
+test('api key repository rotate inherits the original rate tier', async () => {
+  const repository = await setupRepository();
+  const created = repository.create({ label: 'rotate-tier', rateTier: 'pro' });
+
+  const rotated = repository.rotate(created.key.id);
+  assert.equal(rotated.key.rateTier, 'pro');
+});

--- a/backend/src/db/migrations/035_api_key_rate_tiers.js
+++ b/backend/src/db/migrations/035_api_key_rate_tiers.js
@@ -1,0 +1,8 @@
+export const version = 35;
+export const description = 'Add rate_tier column to api_keys for per-key rate limiting (#924)';
+
+export function up(db) {
+  db.exec(`
+    ALTER TABLE api_keys ADD COLUMN rate_tier TEXT NOT NULL DEFAULT 'standard';
+  `);
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -17,7 +17,7 @@ import multer from 'multer';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import Redis from 'ioredis';
-import createApiKeyAuth, { createMasterKeyAuth } from './middleware/apiKeyAuth.js';
+import createApiKeyAuth, { createMasterKeyAuth, readProvidedKey } from './middleware/apiKeyAuth.js';
 import { createRateLimiter, createRedisStore } from './middleware/rateLimit.js';
 import { createAuthLockout } from './middleware/authLockout.js';
 import requestLogger, { log } from './middleware/logger.js';
@@ -29,6 +29,7 @@ import { checkSorobanRpcHealth } from './sorobanRpc.js';
 import { createRpcPool } from './rpcPool.js';
 import { resolveStellarNetworkConfig } from './config/stellarNetwork.js';
 import { validateBackendEnv } from './config/envValidation.js';
+import { getRateTierLimits, DEFAULT_RATE_TIER } from './config/rateTiers.js';
 import { createDal } from './dal/index.js';
 import { createJobRunner } from './jobs/jobRunner.js';
 import { WebhookService, WEBHOOK_EVENTS } from './services/webhookService.js';
@@ -37,6 +38,7 @@ import {
   campaignUpdateSchema,
   cursorBodySchema,
   apiKeyCreateSchema,
+  apiKeyRateTierUpdateSchema,
   formatZodErrors,
 } from './schemas.js';
 import { createStorageAdapter } from './storage/index.js';
@@ -587,11 +589,28 @@ export async function createApp(options = {}) {
     log,
   });
 
+  // Per-API-key rate tiers (#924). The limiter runs before auth on every
+  // route (it's the first line of defense against unauthenticated abuse
+  // too), so tier resolution can't rely on req.auth being set yet — it
+  // independently reads the raw key and looks up its tier directly.
+  // Env-configured keys and untiered/unauthenticated traffic fall back to
+  // the global default, matching pre-#924 behavior exactly.
+  function resolveRateLimitForRequest(req) {
+    const provided = readProvidedKey(req);
+    if (!provided) return null;
+
+    const match = apiKeyRepository.validate(provided);
+    if (!match) return null;
+
+    return getRateTierLimits(match.rateTier ?? DEFAULT_RATE_TIER);
+  }
+
   const rateLimiter = createRateLimiter({
     windowMs: rateLimitWindowMs,
     maxRequests: rateLimitMaxRequests,
     timeProvider: /** @type {any} */ (options.rateLimit)?.timeProvider,
     store: rateLimitStore,
+    resolveLimits: resolveRateLimitForRequest,
   });
 
   app.use(requestId);
@@ -1840,6 +1859,7 @@ export async function createApp(options = {}) {
       expiresAt: result.data.expiresAt ?? null,
       orgId: result.data.orgId ?? null,
       scopes: result.data.scopes ?? undefined,
+      rateTier: result.data.rateTier ?? undefined,
     });
 
     recordAuditEntry(req, {
@@ -1899,6 +1919,34 @@ export async function createApp(options = {}) {
       key: rotated.rawKey,
       metadata: rotated.key,
     });
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function updateApiKeyRateTierHandler(req, res) {
+    const before = apiKeyRepository.getById(req.params.id);
+    if (!before) {
+      return res.status(404).json({ error: 'API key not found', code: 'API_KEY_NOT_FOUND' });
+    }
+
+    const result = apiKeyRateTierUpdateSchema.safeParse(req.body ?? {});
+    if (!result.success) {
+      return res.status(400).json({
+        error: 'Invalid rate tier payload',
+        code: 'VALIDATION_ERROR',
+        details: formatZodErrors(result.error),
+      });
+    }
+
+    const updated = apiKeyRepository.setRateTier(req.params.id, result.data.rateTier);
+
+    recordAuditEntry(req, {
+      action: 'update',
+      entity: 'apiKey',
+      entityId: req.params.id,
+      diff: { before: { rateTier: before.rateTier }, after: { rateTier: updated.rateTier } },
+    });
+
+    return res.status(200).json({ metadata: updated });
   }
 
   /** @param {import('express').Request} req @param {import('express').Response} res */
@@ -2172,6 +2220,13 @@ export async function createApp(options = {}) {
       idempotencyMiddleware,
       requireMasterKey,
       rotateApiKeyHandler,
+    );
+    app.put(
+      `${prefix}/admin/api-keys/:id/rate-tier`,
+      rateLimiter,
+      idempotencyMiddleware,
+      requireMasterKey,
+      updateApiKeyRateTierHandler,
     );
 
     // Admin dashboard and campaign management (Issue #467)
@@ -2595,7 +2650,7 @@ export async function createApp(options = {}) {
       `${prefix}/campaigns/:id/allowlist/import`,
       rateLimiter,
       ...guard,
-      requireScope('campaigns:write'),
+      requireScope('allowlist:write'),
       csvUpload.single('file'),
       async (req, res) => {
         const campaign = campaignRepository.getById(req.params.id);

--- a/backend/src/integration/apiKeys.test.js
+++ b/backend/src/integration/apiKeys.test.js
@@ -20,6 +20,10 @@ test('admin api key endpoints require master key', async () => {
 
   await request(app).post('/api/v1/admin/api-keys').send({ label: 'ops' }).expect(401);
   await request(app).get('/api/v1/admin/api-keys').expect(401);
+  await request(app)
+    .put('/api/v1/admin/api-keys/some-id/rate-tier')
+    .send({ rateTier: 'pro' })
+    .expect(401);
 });
 
 test('admin api key lifecycle create list revoke rotate', async () => {
@@ -203,4 +207,176 @@ test('invalid scope value is rejected at creation', async () => {
     .set('X-API-Key', 'master-key-xyz')
     .send({ label: 'bad-scope', scopes: ['not:a:valid:scope'] })
     .expect(400);
+});
+
+// ── Rate tiers (#924) ────────────────────────────────────────────────────────
+
+test('api keys default to the standard rate tier when none is specified', async () => {
+  const app = await createTestApp();
+
+  const created = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'default-tier' })
+    .expect(201);
+
+  assert.equal(created.body.metadata.rateTier, 'standard');
+});
+
+test('api key rate tier can be set explicitly at creation', async () => {
+  const app = await createTestApp();
+
+  const created = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'enterprise-tier', rateTier: 'enterprise' })
+    .expect(201);
+
+  assert.equal(created.body.metadata.rateTier, 'enterprise');
+});
+
+test('invalid rate tier value is rejected at creation', async () => {
+  const app = await createTestApp();
+
+  await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'bad-tier', rateTier: 'ultra' })
+    .expect(400);
+});
+
+test('rotated key inherits the original rate tier', async () => {
+  const app = await createTestApp();
+
+  const created = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'rotate-tier', rateTier: 'pro' })
+    .expect(201);
+
+  const rotated = await request(app)
+    .put(`/api/v1/admin/api-keys/${created.body.metadata.id}/rotate`)
+    .set('X-API-Key', 'master-key-xyz')
+    .expect(200);
+
+  assert.equal(rotated.body.metadata.rateTier, 'pro');
+});
+
+test('admin can upgrade an existing key rate tier without rotating its credential', async () => {
+  const app = await createTestApp();
+
+  const created = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'upgrade-me', scopes: ['campaigns:read'] })
+    .expect(201);
+  assert.equal(created.body.metadata.rateTier, 'standard');
+
+  const updated = await request(app)
+    .put(`/api/v1/admin/api-keys/${created.body.metadata.id}/rate-tier`)
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ rateTier: 'enterprise' })
+    .expect(200);
+  assert.equal(updated.body.metadata.rateTier, 'enterprise');
+
+  // The original raw key still works — this is not a rotation.
+  const resp = await request(app)
+    .get('/api/v1/campaigns')
+    .set('X-API-Key', created.body.key)
+    .expect(200);
+  assert.equal(resp.headers['x-ratelimit-limit'], '1000');
+});
+
+test('updating rate tier for an unknown key returns 404', async () => {
+  const app = await createTestApp();
+
+  await request(app)
+    .put('/api/v1/admin/api-keys/does-not-exist/rate-tier')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ rateTier: 'pro' })
+    .expect(404);
+});
+
+test('updating rate tier with an invalid value returns 400', async () => {
+  const app = await createTestApp();
+
+  const created = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'bad-update' })
+    .expect(201);
+
+  await request(app)
+    .put(`/api/v1/admin/api-keys/${created.body.metadata.id}/rate-tier`)
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ rateTier: 'ultra' })
+    .expect(400);
+});
+
+test('pro-tier api key gets a higher X-RateLimit-Limit than a standard-tier key', async () => {
+  const app = await createTestApp();
+
+  const standardKey = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'standard', scopes: ['campaigns:read'] })
+    .expect(201);
+
+  const proKey = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'pro', scopes: ['campaigns:read'], rateTier: 'pro' })
+    .expect(201);
+
+  const standardResp = await request(app)
+    .get('/api/v1/campaigns')
+    .set('X-API-Key', standardKey.body.key)
+    .expect(200);
+  assert.equal(standardResp.headers['x-ratelimit-limit'], '60');
+
+  const proResp = await request(app)
+    .get('/api/v1/campaigns')
+    .set('X-API-Key', proKey.body.key)
+    .expect(200);
+  assert.equal(proResp.headers['x-ratelimit-limit'], '300');
+});
+
+// ── allowlist:write scope enforcement (#924 — was silently unenforced) ──────
+
+test('allowlist import requires the allowlist:write scope, not campaigns:write', async () => {
+  const app = await createTestApp();
+
+  const writerKey = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'writer', scopes: ['campaigns:read', 'campaigns:write'] })
+    .expect(201);
+
+  const campaign = await request(app)
+    .post('/api/v1/campaigns')
+    .set('X-API-Key', writerKey.body.key)
+    .send({ name: 'Allowlist Scope Campaign', rewardPerAction: 5 })
+    .expect(201);
+
+  // campaigns:write alone must NOT be enough to import an allowlist.
+  await request(app)
+    .post(`/api/v1/campaigns/${campaign.body.id}/allowlist/import`)
+    .set('X-API-Key', writerKey.body.key)
+    .send({ csv: 'GABCDEF' })
+    .expect(403);
+
+  const allowlistKey = await request(app)
+    .post('/api/v1/admin/api-keys')
+    .set('X-API-Key', 'master-key-xyz')
+    .send({ label: 'allowlist-writer', scopes: ['campaigns:read', 'allowlist:write'] })
+    .expect(201);
+
+  // allowlist:write clears the scope guard — an empty CSV then fails on
+  // content validation (400), not on authorization (403), proving the
+  // scope check itself passed.
+  const resp = await request(app)
+    .post(`/api/v1/campaigns/${campaign.body.id}/allowlist/import`)
+    .set('X-API-Key', allowlistKey.body.key)
+    .send({ csv: '' });
+  assert.notEqual(resp.status, 403);
 });

--- a/backend/src/middleware/apiKeyAuth.js
+++ b/backend/src/middleware/apiKeyAuth.js
@@ -51,7 +51,7 @@ function readProvidedKey(req) {
  * @param {{
  *   apiKeys?: string | string[],
  *   apiKeyRepository?: {
- *     validate: (rawKey: string) => { id: string, label: string, orgId?: string | null, scopes?: string[] } | null,
+ *     validate: (rawKey: string) => { id: string, label: string, orgId?: string | null, scopes?: string[], rateTier?: string } | null,
  *     touchLastUsed: (id: string) => void,
  *     hasActiveKeys?: () => boolean,
  *   } | null,
@@ -113,6 +113,7 @@ export default function createApiKeyAuth({
           orgId: match.orgId ?? membership?.orgId ?? null,
           orgRole: membership?.role ?? null,
           scopes: match.scopes ?? null,
+          rateTier: match.rateTier ?? null,
         };
         return next();
       }

--- a/backend/src/middleware/rateLimit.js
+++ b/backend/src/middleware/rateLimit.js
@@ -64,6 +64,10 @@ export function createRateLimiter({
   timeProvider = () => Date.now(),
   keyGenerator = defaultKeyGenerator,
   store = null,
+  // Optional per-request override (#924 — per-API-key rate tiers). Given the
+  // request, returns `{ maxRequests, windowMs }` to use instead of the static
+  // defaults above, or a falsy value to fall back to them. Sync or async.
+  resolveLimits = null,
 } = {}) {
   const rateLimitStore = store || createMemoryStore();
 
@@ -71,30 +75,33 @@ export function createRateLimiter({
     try {
       const now = timeProvider();
       const key = keyGenerator(req);
+      const override = resolveLimits ? await resolveLimits(req) : null;
+      const effectiveMaxRequests = override?.maxRequests ?? maxRequests;
+      const effectiveWindowMs = override?.windowMs ?? windowMs;
 
-      const { count, resetAt } = await rateLimitStore.increment(key, windowMs, now);
+      const { count, resetAt } = await rateLimitStore.increment(key, effectiveWindowMs, now);
 
-      const remaining = Math.max(maxRequests - count, 0);
+      const remaining = Math.max(effectiveMaxRequests - count, 0);
       const resetSeconds = Math.max(1, Math.ceil((resetAt - now) / 1000));
-      const windowSeconds = Math.max(1, Math.ceil(windowMs / 1000));
-      res.setHeader('X-RateLimit-Limit', String(maxRequests));
+      const windowSeconds = Math.max(1, Math.ceil(effectiveWindowMs / 1000));
+      res.setHeader('X-RateLimit-Limit', String(effectiveMaxRequests));
       res.setHeader('X-RateLimit-Remaining', String(remaining));
       res.setHeader('X-RateLimit-Reset', String(resetSeconds));
-      res.setHeader('RateLimit-Policy', `${maxRequests};w=${windowSeconds}`);
+      res.setHeader('RateLimit-Policy', `${effectiveMaxRequests};w=${windowSeconds}`);
       res.setHeader(
         'RateLimit',
-        `limit=${maxRequests}, remaining=${remaining}, reset=${resetSeconds}`,
+        `limit=${effectiveMaxRequests}, remaining=${remaining}, reset=${resetSeconds}`,
       );
 
-      if (count > maxRequests) {
+      if (count > effectiveMaxRequests) {
         const retryAfterSeconds = resetSeconds;
         res.setHeader('Retry-After', String(retryAfterSeconds));
         return res.status(429).json({
           error: 'Rate limit exceeded',
           code: 'RATE_LIMIT_EXCEEDED',
           keying: 'per API key when present, otherwise per IP address',
-          limit: maxRequests,
-          windowMs,
+          limit: effectiveMaxRequests,
+          windowMs: effectiveWindowMs,
           retryAfterSeconds,
         });
       }

--- a/backend/src/middleware/rateLimit.test.js
+++ b/backend/src/middleware/rateLimit.test.js
@@ -150,6 +150,74 @@ test('rateLimit forwards store errors via next(err) instead of crashing the requ
   assert.equal(res.statusCode, 200, 'must not 429 on store failure');
 });
 
+// ── Per-request tier override (#924) ────────────────────────────────────────
+
+test('rateLimit uses resolveLimits() to override the static limit per request', async () => {
+  const limiter = createRateLimiter({
+    windowMs: 60_000,
+    maxRequests: 5,
+    resolveLimits: (req) => (req.headers['x-api-key'] === 'pro-key' ? { maxRequests: 300 } : null),
+  });
+
+  const proReq = makeReqRes({ apiKey: 'pro-key' });
+  await limiter(proReq.req, proReq.res, () => {});
+  assert.equal(proReq.res.headersOut['X-RateLimit-Limit'], '300');
+  assert.equal(proReq.res.headersOut['X-RateLimit-Remaining'], '299');
+
+  const standardReq = makeReqRes({ apiKey: 'standard-key' });
+  await limiter(standardReq.req, standardReq.res, () => {});
+  assert.equal(standardReq.res.headersOut['X-RateLimit-Limit'], '5');
+});
+
+test('rateLimit resolveLimits can override windowMs too, and falls back to defaults when it returns null', async () => {
+  const limiter = createRateLimiter({
+    windowMs: 60_000,
+    maxRequests: 1,
+    resolveLimits: (req) =>
+      req.headers['x-api-key'] === 'enterprise-key'
+        ? { maxRequests: 1000, windowMs: 1_000 }
+        : null,
+  });
+
+  const entReq = makeReqRes({ apiKey: 'enterprise-key' });
+  await limiter(entReq.req, entReq.res, () => {});
+  assert.equal(entReq.res.headersOut['RateLimit-Policy'], '1000;w=1');
+
+  // A request with no matching key still gets the static default (1 req/min).
+  const anonReq = makeReqRes({ ip: '9.9.9.9' });
+  await limiter(anonReq.req, anonReq.res, () => {});
+  assert.equal(anonReq.res.statusCode, 200);
+  assert.equal(anonReq.res.headersOut['X-RateLimit-Limit'], '1');
+});
+
+test('rateLimit enterprise tier allows more requests than a tier resolving to the static default', async () => {
+  const store = createMemoryStore();
+  const limiter = createRateLimiter({
+    windowMs: 60_000,
+    maxRequests: 2,
+    store,
+    resolveLimits: (req) =>
+      req.headers['x-api-key'] === 'enterprise-key' ? { maxRequests: 5, windowMs: 60_000 } : null,
+  });
+
+  // Standard key trips the limit at request 3.
+  for (let i = 0; i < 2; i += 1) {
+    const { req, res } = makeReqRes({ apiKey: 'standard-key' });
+    await limiter(req, res, () => {});
+    assert.equal(res.statusCode, 200);
+  }
+  const standardThird = makeReqRes({ apiKey: 'standard-key' });
+  await limiter(standardThird.req, standardThird.res, () => {});
+  assert.equal(standardThird.res.statusCode, 429);
+
+  // Enterprise key keeps succeeding past that same request count.
+  for (let i = 0; i < 3; i += 1) {
+    const { req, res } = makeReqRes({ apiKey: 'enterprise-key' });
+    await limiter(req, res, () => {});
+    assert.equal(res.statusCode, 200, `enterprise request ${i + 1} should succeed`);
+  }
+});
+
 // ── Redis-store integration ─────────────────────────────────────────────────
 
 function makeFakeRedis() {

--- a/backend/src/schemas.js
+++ b/backend/src/schemas.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { z } from 'zod';
 import { DEFAULT_CATEGORIES } from './dal/sqliteCampaignRepository.js';
+import { VALID_RATE_TIERS } from './config/rateTiers.js';
 
 const isoDateOrNull = z
   .string()
@@ -157,6 +158,12 @@ export const apiKeyCreateSchema = z.object({
     .array(z.enum(VALID_API_KEY_SCOPES))
     .min(1, 'scopes must contain at least one scope')
     .optional(),
+  rateTier: z.enum(VALID_RATE_TIERS).optional(),
+});
+
+/** Schema for updating an existing API key's rate tier. */
+export const apiKeyRateTierUpdateSchema = z.object({
+  rateTier: z.enum(VALID_RATE_TIERS),
 });
 
 /** Schema for the indexer cursor update body. */

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -78,6 +78,44 @@ TRIVELA_API_KEYS="old-key,new-key"
 TRIVELA_API_KEYS="new-key"
 ```
 
+### Managed API keys (`/api/v1/admin/api-keys`) — scopes and rate tiers (#924)
+
+`TRIVELA_API_KEYS` above is a static, env-configured credential shared by every trusted caller.
+For partner integrations, prefer a **managed key**: a database-backed, individually scoped and
+rate-tiered credential issued and revoked through the admin API (gated by `TRIVELA_MASTER_KEY`).
+
+```bash
+# Issue a scoped, rate-tiered key for a partner integration
+curl -X POST "$API_URL/api/v1/admin/api-keys" \
+  -H "X-API-Key: $TRIVELA_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "label": "partner-acme",
+        "orgId": "org-acme",
+        "scopes": ["campaigns:read", "campaigns:write"],
+        "rateTier": "pro"
+      }'
+# → 201 { "key": "tk_...", "metadata": { ... } }  — the raw key is shown once, store it now.
+```
+
+- **Scopes** (`campaigns:read`, `campaigns:write`, `allowlist:write`, `admin`) gate individual
+  write routes via `requireScope()`. Grant the minimum set a partner needs.
+- **Rate tiers** (`standard` = 60 req/min, `pro` = 300 req/min, `enterprise` = 1000 req/min) are
+  enforced per key by the rate limiter. Change a key's tier without rotating its credential:
+  ```bash
+  curl -X PUT "$API_URL/api/v1/admin/api-keys/$KEY_ID/rate-tier" \
+    -H "X-API-Key: $TRIVELA_MASTER_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"rateTier": "enterprise"}'
+  ```
+- **Revoke** immediately on suspected compromise: `DELETE /api/v1/admin/api-keys/{id}`.
+- **Rotate** to issue a fresh credential while preserving scopes/org/tier:
+  `PUT /api/v1/admin/api-keys/{id}/rotate`.
+- Every create/revoke/rotate/rate-tier-update is written to the audit log (`entity: "apiKey"`),
+  queryable via `GET /api/v1/audit-logs`.
+
+See `backend/openapi.yaml` for the full request/response schema.
+
 ### `STELLAR_SECRET_KEY` rotation
 
 The `STELLAR_SECRET_KEY` is a Stellar keypair used for server-side signing (SEP-10, sponsored


### PR DESCRIPTION
## Summary

Closes #924. Research turned up that scoped, revocable, rotatable API keys with a full admin CRUD lifecycle and audit logging already existed and were well-tested — the real gap was **rate tiers**, plus one scope that was declared but silently never enforced.

## What's new

### Per-key rate tiers
- New `rate_tier` column on `api_keys` (migration 035), defaulting existing keys to `standard` — no behavior change for anyone until they opt in.
- Three named tiers in `backend/src/config/rateTiers.js`: `standard` (60 req/min, matches the long-standing global default), `pro` (300 req/min), `enterprise` (1000 req/min).
- The rate limiter runs *before* auth on every route (it's the first line of defense against unauthenticated abuse too), so it can't rely on `req.auth` being resolved yet. Added an optional `resolveLimits(req)` hook that independently reads the raw key and looks up its tier directly.
- New `PUT /api/v1/admin/api-keys/:id/rate-tier` — lets an admin upgrade/downgrade a partner's limits **without rotating** (and thus invalidating) their existing credential. Audit-logged like create/revoke/rotate.
- `rateTier` accepted on key creation, inherited on rotation, returned in metadata everywhere.

### Bug fix: `allowlist:write` scope was dead
`allowlist:write` was a valid, assignable scope — validated at creation, stored, returned in metadata — but the allowlist CSV import route checked `campaigns:write` instead. Any key with `campaigns:write` (default scope set) could import allowlists regardless of whether it had `allowlist:write`, and a key scoped to `allowlist:write` only would have been wrongly blocked. Fixed to check `requireScope('allowlist:write')`.

### Docs
- `backend/openapi.yaml`: the `ApiKeyMetadata` schema and create-key request body were missing `orgId`/`scopes` (predating #611) in addition to the new `rateTier` — fixed all three, plus documented the new rate-tier endpoint.
- `docs/SECURITY.md`: new section on the managed API-key system (creation, scopes, rate tiers, rotation, revocation) — previously only the static env-var key rotation procedure was documented.

## Testing

- New unit tests: rate-tier config (including a drift-guard asserting `VALID_RATE_TIERS` stays in sync with the tier table), repository `setRateTier`/tier inheritance on rotate, rate-limiter `resolveLimits` override behavior.
- New integration tests: tier assignment/validation on create, tier update endpoint (200/400/404), tier inherited on rotate, end-to-end proof that a `pro` key gets a higher `X-RateLimit-Limit` than a `standard` key, and a dedicated test locking in the `allowlist:write` fix (`campaigns:write`-only key → 403, `allowlist:write` key → passes the scope gate).
- `eslint` / `tsc --noEmit` clean on all touched files (pre-existing, unrelated warnings/errors elsewhere untouched).
- `openapi:validate` and the existing OpenAPI contract test pass; `redocly lint` shows no new errors beyond the repo's existing pre-#924 baseline.
- Full live smoke test: booted the real backend, created standard/pro keys, confirmed `X-RateLimit-Limit` is 60/300 respectively, upgraded a key to `enterprise` via the new endpoint and confirmed the *same raw key* now gets a 1000 limit, confirmed the scope fix returns 403 for a `campaigns:write`-only key, and confirmed the tier-update action lands correctly in the tamper-evident audit log.

## Acceptance criteria

- [x] Keys are scoped + revocable.
- [x] Rate tiers enforced per key.
- [x] Admin API + audit logging.
