### PR TITLE
feat: complete audit log coverage for all privileged actions

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1666,10 +1666,12 @@ export async function createApp(options = {}) {
     const entity = typeof req.query.entity === 'string' ? req.query.entity.trim() : '';
     const entityId = typeof req.query.entityId === 'string' ? req.query.entityId.trim() : '';
     const action = typeof req.query.action === 'string' ? req.query.action.trim() : '';
+    const orgId = typeof req.query.orgId === 'string' ? req.query.orgId.trim() : '';
     const items = auditLogRepository.list({
       entity: entity || undefined,
       entityId: entityId || undefined,
       action: action || undefined,
+      orgId: orgId || undefined,
     });
     return res.json(paginateItems(items, req.query));
   }
@@ -1699,9 +1701,16 @@ export async function createApp(options = {}) {
       });
     }
     const { cursor } = result.data;
+    const previousCursor = indexerCursorState.cursor;
     indexerCursorState.cursor = cursor;
     indexerCursorState.updatedAt = new Date().toISOString();
     indexerCursorState.source = 'api';
+    recordAuditEntry(req, {
+      action: 'update',
+      entity: 'indexerCursor',
+      entityId: 'global',
+      diff: { previousCursor, newCursor: cursor },
+    });
     return res.status(200).json({
       ok: true,
       cursor: indexerCursorState.cursor,
@@ -2313,6 +2322,12 @@ export async function createApp(options = {}) {
         hardLimit,
         windowSeconds,
       });
+      recordAuditEntry(req, {
+        action: 'update',
+        entity: 'usageQuota',
+        entityId: `${orgId}:${resource}`,
+        diff: { orgId, resource, softLimit, hardLimit, windowSeconds },
+      });
       return res.json(quota);
     });
 
@@ -2772,6 +2787,7 @@ export async function createApp(options = {}) {
       orgMemberRepository,
       requireMasterKey,
       requireApiKey,
+      recordAuditEntry,
     });
     app.use(prefix, rateLimiter, orgRouter);
 
@@ -2787,6 +2803,7 @@ export async function createApp(options = {}) {
       variantRepo: variantRepository,
       variantService,
       campaignRepo: campaignRepository,
+      recordAuditEntry,
     });
     app.use(prefix, rateLimiter, ...guard, variantRouter);
 
@@ -2820,7 +2837,7 @@ export async function createApp(options = {}) {
     const featureFlagService = createFeatureFlagService({
       featureFlagRepository: dal.featureFlags,
     });
-    const featureFlagRouter = createFeatureFlagRoutes({ featureFlagService });
+    const featureFlagRouter = createFeatureFlagRoutes({ featureFlagService, requireApiKey, recordAuditEntry });
     app.use(`${prefix}/feature-flags`, rateLimiter, featureFlagRouter);
 
     // #560 — Public read API over indexed data (cursor-paginated, ETag cached)

--- a/backend/src/routes/featureFlags.js
+++ b/backend/src/routes/featureFlags.js
@@ -2,9 +2,13 @@
 import express from 'express';
 
 /**
- * @param {{ featureFlagService: ReturnType<import('../services/featureFlagService.js').createFeatureFlagService> }} deps
+ * @param {{
+ *   featureFlagService: ReturnType<import('../services/featureFlagService.js').createFeatureFlagService>,
+ *   requireApiKey: import('express').RequestHandler[],
+ *   recordAuditEntry: (req: import('express').Request, entry: { action: string, entity: string, entityId: string, diff: unknown }) => void,
+ * }} deps
  */
-export function createFeatureFlagRoutes({ featureFlagService }) {
+export function createFeatureFlagRoutes({ featureFlagService, requireApiKey, recordAuditEntry }) {
   const router = express.Router();
 
   // Hydrate client with all flags (evaluated values not stored rules)
@@ -25,7 +29,7 @@ export function createFeatureFlagRoutes({ featureFlagService }) {
   });
 
   // Admin: create or update a flag
-  router.post('/', (req, res) => {
+  router.post('/', requireApiKey, (req, res) => {
     const { flagKey, enabled, targeting, description } = req.body ?? {};
     if (!flagKey || typeof flagKey !== 'string') {
       return res.status(400).json({ error: 'flagKey is required' });
@@ -36,13 +40,25 @@ export function createFeatureFlagRoutes({ featureFlagService }) {
       targeting: targeting ?? {},
       description: description ?? null,
     });
+    recordAuditEntry(req, {
+      action: 'upsert',
+      entity: 'featureFlag',
+      entityId: flagKey,
+      diff: { enabled: flag.enabled, targeting: flag.targeting, description: flag.description },
+    });
     res.status(201).json(flag);
   });
 
   // Admin: delete a flag (kill-switch removal)
-  router.delete('/:key', (req, res) => {
+  router.delete('/:key', requireApiKey, (req, res) => {
     const deleted = featureFlagService.deleteFlag(req.params.key);
     if (!deleted) return res.status(404).json({ error: 'Flag not found' });
+    recordAuditEntry(req, {
+      action: 'delete',
+      entity: 'featureFlag',
+      entityId: req.params.key,
+      diff: null,
+    });
     res.status(204).end();
   });
 

--- a/backend/src/routes/orgs.js
+++ b/backend/src/routes/orgs.js
@@ -21,9 +21,10 @@ import { VALID_ROLES } from '../dal/sqliteOrgMemberRepository.js';
  *   orgMemberRepository: ReturnType<import('../dal/sqliteOrgMemberRepository.js').createSqliteOrgMemberRepository>,
  *   requireMasterKey: import('express').RequestHandler[],
  *   requireApiKey: import('express').RequestHandler[],
+ *   recordAuditEntry: (req: import('express').Request, entry: { action: string, entity: string, entityId: string, diff: unknown }) => void,
  * }} deps
  */
-export function createOrgRoutes({ orgMemberRepository, requireMasterKey, requireApiKey }) {
+export function createOrgRoutes({ orgMemberRepository, requireMasterKey, requireApiKey, recordAuditEntry }) {
   const router = Router();
 
   // ── Create org (master-key only — bootstrapping) ──────────────────────────
@@ -34,6 +35,12 @@ export function createOrgRoutes({ orgMemberRepository, requireMasterKey, require
       return res.status(400).json({ error: 'name is required', code: 'VALIDATION_ERROR' });
     }
     const org = orgMemberRepository.createOrg({ name: name.trim() });
+    recordAuditEntry(req, {
+      action: 'create',
+      entity: 'organization',
+      entityId: org.id,
+      diff: { name: name.trim() },
+    });
     return res.status(201).json(org);
   });
 
@@ -60,6 +67,13 @@ export function createOrgRoutes({ orgMemberRepository, requireMasterKey, require
 
     const deleted = orgMemberRepository.deleteOrg(req.params.orgId);
     if (!deleted) return res.status(404).json({ error: 'Org not found', code: 'ORG_NOT_FOUND' });
+
+    recordAuditEntry(req, {
+      action: 'delete',
+      entity: 'organization',
+      entityId: req.params.orgId,
+      diff: null,
+    });
 
     return res.status(204).end();
   });
@@ -99,6 +113,12 @@ export function createOrgRoutes({ orgMemberRepository, requireMasterKey, require
           orgId: req.params.orgId,
           apiKeyId: apiKeyId.trim(),
           role,
+        });
+        recordAuditEntry(req, {
+          action: 'add_member',
+          entity: 'organization_member',
+          entityId: membership.id,
+          diff: { orgId: req.params.orgId, apiKeyId: apiKeyId.trim(), role },
         });
         return res.status(201).json(membership);
       } catch (err) {
@@ -172,6 +192,12 @@ export function createOrgRoutes({ orgMemberRepository, requireMasterKey, require
       }
 
       orgMemberRepository.updateRole(req.params.membershipId, role);
+      recordAuditEntry(req, {
+        action: 'update_member',
+        entity: 'organization_member',
+        entityId: req.params.membershipId,
+        diff: { orgId: req.params.orgId, previousRole: membership.role, newRole: role },
+      });
       return res.json({ ...membership, role });
     },
   );
@@ -200,6 +226,12 @@ export function createOrgRoutes({ orgMemberRepository, requireMasterKey, require
       }
 
       orgMemberRepository.removeMember(req.params.membershipId);
+      recordAuditEntry(req, {
+        action: 'remove_member',
+        entity: 'organization_member',
+        entityId: req.params.membershipId,
+        diff: { orgId: req.params.orgId, apiKeyId: membership.apiKeyId, role: membership.role },
+      });
       return res.status(204).end();
     },
   );

--- a/backend/src/routes/variants.js
+++ b/backend/src/routes/variants.js
@@ -14,8 +14,9 @@ import {
  * @param {ReturnType<import('../dal/sqliteVariantRepository.js').createSqliteVariantRepository>} deps.variantRepo
  * @param {ReturnType<import('../services/variantService.js').createVariantService>} deps.variantService
  * @param {ReturnType<import('../dal/sqliteCampaignRepository.js').createSqliteCampaignRepository>} deps.campaignRepo
+ * @param {(req: import('express').Request, entry: { action: string, entity: string, entityId: string, diff: unknown }) => void} deps.recordAuditEntry
  */
-export function createVariantRoutes({ variantRepo, variantService, campaignRepo }) {
+export function createVariantRoutes({ variantRepo, variantService, campaignRepo, recordAuditEntry }) {
   const router = express.Router();
 
   // Create a new variant for a campaign
@@ -58,6 +59,13 @@ export function createVariantRoutes({ variantRepo, variantService, campaignRepo 
         isControl: data.isControl,
         active: data.active,
         config: data.config,
+      });
+
+      recordAuditEntry(req, {
+        action: 'create',
+        entity: 'variant',
+        entityId: variant.id,
+        diff: { campaignId, variantKey: data.variantKey, name: data.name, trafficWeight: data.trafficWeight, isControl: data.isControl, active: data.active },
       });
 
       res.status(201).json(variant);
@@ -143,6 +151,13 @@ export function createVariantRoutes({ variantRepo, variantService, campaignRepo 
 
       const updated = variantRepo.updateVariant(variantId, validation.data);
 
+      recordAuditEntry(req, {
+        action: 'update',
+        entity: 'variant',
+        entityId: variantId,
+        diff: validation.data,
+      });
+
       res.json(updated);
     } catch (error) {
       console.error('Error updating variant:', error);
@@ -167,6 +182,12 @@ export function createVariantRoutes({ variantRepo, variantService, campaignRepo 
       const deleted = variantRepo.deleteVariant(variantId);
 
       if (deleted) {
+        recordAuditEntry(req, {
+          action: 'delete',
+          entity: 'variant',
+          entityId: variantId,
+          diff: null,
+        });
         res.status(204).send();
       } else {
         res.status(500).json({ error: 'Failed to delete variant' });


### PR DESCRIPTION
Closes #762

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

---

## Summary

This PR adds tamper-evident audit logging to all remaining privileged admin/privileged routes that were previously untracked. The existing audit infrastructure (hash chaining, append-only table, verify endpoint) was already in place — this change closes the coverage gaps.

**Newly audited operations:**
- Feature flag create/update/delete (POST/DELETE `/feature-flags`)
- Variant create/update/delete (POST/PUT/DELETE `/campaigns/:id/variants/:variantId`)
- Organization create/delete (POST/DELETE `/orgs/:orgId`)
- Organization member add/update/remove (POST/PUT/DELETE `/orgs/:orgId/members/:id`)
- Indexer cursor updates (POST `/indexer/cursor`)
- Usage quota changes (PUT `/admin/usage/quotas`)

**Additional improvements:**
- Feature flag mutation routes now require API key authentication (`requireApiKey` middleware)
- Global `/audit-logs` endpoint now supports `orgId` query parameter for org-scoped filtering

## Motivation / Context

For a financial platform, every privileged action must be captured in a tamper-evident audit log for forensics and compliance. While the core audit infrastructure (hash-chained entries, verify endpoint, CSV/JSON export) was already implemented, several admin-level operations were not writing audit rows. This PR ensures complete coverage.

Closes #762