### PR TITLE
feat: Referral link generator with share + tracking

### DIFF
--- a/frontend/src/AdminCampaigns.jsx
+++ b/frontend/src/AdminCampaigns.jsx
@@ -112,6 +112,9 @@ export default function AdminCampaigns({
                   </li>
                 ))}
               </ul>
+              <Link to="/admin/analytics" className="btn btn-primary" style={{ marginTop: '1rem', display: 'inline-block' }}>
+                Operator Analytics Dashboard
+              </Link>
             </section>
           ) : null}
           {/* #294 — Merkle allowlist generator. Computes the tree

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,9 @@ const Explore = lazy(() => import('./Explore'));
 const CampaignDetail = lazy(() => import('./CampaignDetail'));
 const CampaignLeaderboard = lazy(() => import('./CampaignLeaderboard'));
 const ReferralLeaderboard = lazy(() => import('./ReferralLeaderboard'));
+const ReferralLinkGenerator = lazy(() => import('./ReferralLinkGenerator'));
 const CampaignAnalytics = lazy(() => import('./CampaignAnalytics'));
+const OperatorAnalytics = lazy(() => import('./OperatorAnalytics'));
 const AdminCampaigns = lazy(() => import('./AdminCampaigns'));
 const About = lazy(() => import('./About'));
 const TransactionHistory = lazy(() => import('./TransactionHistory'));
@@ -257,6 +259,23 @@ export default function App() {
             }
           />
           <Route
+            path="/campaign/:id/referrals"
+            element={
+              <ReferralLinkGenerator
+                theme={theme}
+                onToggleTheme={toggleTheme}
+                stellarNetwork={runtimeConfig.stellar.network}
+                onChangeStellarNetwork={handleChangeStellarNetwork}
+                walletAddress={walletAddress}
+                walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
+                isWalletBalanceLoading={isWalletBalanceLoading}
+                onConnectWallet={openWalletModal}
+                onDisconnectWallet={disconnectWallet}
+              />
+            }
+          />
+          <Route
             path="/campaign/:id/referrals/leaderboard"
             element={
               <ReferralLeaderboard
@@ -331,6 +350,29 @@ export default function App() {
                   standalone
                   campaigns={[]}
                   onCampaignCreated={(c) => navigate(`/campaign/${c.id}`)}
+                />
+              </RequireAdmin>
+            }
+          />
+          <Route
+            path="/admin/analytics"
+            element={
+              <RequireAdmin
+                walletAddress={walletAddress}
+                onConnectWallet={openWalletModal}
+                isWalletLoading={isWalletLoading}
+              >
+                <OperatorAnalytics
+                  theme={theme}
+                  onToggleTheme={toggleTheme}
+                  stellarNetwork={runtimeConfig.stellar.network}
+                  onChangeStellarNetwork={handleChangeStellarNetwork}
+                  walletAddress={walletAddress}
+                  walletBalance={walletBalance}
+                  isWalletLoading={isWalletLoading}
+                  isWalletBalanceLoading={isWalletBalanceLoading}
+                  onConnectWallet={openWalletModal}
+                  onDisconnectWallet={disconnectWallet}
                 />
               </RequireAdmin>
             }

--- a/frontend/src/CampaignDetail.css
+++ b/frontend/src/CampaignDetail.css
@@ -338,7 +338,6 @@
 
 .referral-leaderboard-link {
   display: inline-block;
-  margin-bottom: 1rem;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--accent);
@@ -346,6 +345,17 @@
 
 .referral-leaderboard-link:hover {
   text-decoration: underline;
+}
+
+.referral-actions-row {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.referral-manage-link {
+  text-decoration: none;
 }
 
 .referral-link-row {

--- a/frontend/src/CampaignDetail.jsx
+++ b/frontend/src/CampaignDetail.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { QRCodeCanvas } from 'qrcode.react';
 import { apiUrl, DEFAULT_OG_IMAGE } from './config';
 import Header from './components/Header';
 import RegisterCampaign from './RegisterCampaign';
@@ -30,65 +29,10 @@ export default function CampaignDetail({
   const { campaign, onChainState, isPolling, isPaused, lastUpdated, stateToast, error, refresh } =
     useCampaignLiveUpdates({ campaignId: id, enabled: Boolean(id) });
 
-  const [referralCount, setReferralCount] = useState(0);
-  const [bonusEarned, setBonusEarned] = useState(0);
-  const [referralTier, setReferralTier] = useState(null);
-  const [refLinkCopied, setRefLinkCopied] = useState(false);
   const [embedSnippetCopied, setEmbedSnippetCopied] = useState(false);
-  const [showQRModal, setShowQRModal] = useState(false);
-  const [qrSize, setQrSize] = useState(256);
-
-  const handleDownloadQR = () => {
-    const canvas = document.getElementById('campaign-qr-code');
-    if (canvas) {
-      const url = canvas.toDataURL('image/png');
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `trivela-campaign-${campaign?.name?.toLowerCase().replace(/\s+/g, '-') ?? 'qr'}-${new Date().toISOString().slice(0, 10)}.png`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-    }
-  };
-
-  const handleCopyQRToClipboard = async () => {
-    const canvas = document.getElementById('campaign-qr-code');
-    if (canvas) {
-      try {
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-            alert('QR Code copied to clipboard!');
-          }
-        });
-      } catch (err) {
-        console.error('Failed to copy QR code: ', err);
-      }
-    }
-  };
 
   const incomingRef = searchParams.get('ref');
   const isLoading = !campaign && !error;
-
-  useEffect(() => {
-    if (!walletAddress || !id) return;
-
-    fetch(apiUrl(`/api/v1/campaigns/${id}/referrals/${walletAddress}`))
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) {
-          setReferralCount(data.referralCount ?? 0);
-          setBonusEarned(data.bonusEarned ?? 0);
-          setReferralTier({
-            tier: data.tier,
-            nextTier: data.nextTier,
-            referralsToNextTier: data.referralsToNextTier,
-            tierProgressPercent: data.tierProgressPercent,
-          });
-        }
-      })
-      .catch(() => {});
-  }, [walletAddress, id]);
 
   const handleRegistered = useCallback(() => {
     if (!incomingRef || !walletAddress || !id) return;
@@ -110,28 +54,6 @@ export default function CampaignDetail({
       dateStyle: 'long',
       timeStyle: 'short',
     }).format(date);
-  };
-
-  const buildInviteLink = () => {
-    const base = `${window.location.origin}/campaign/${id}`;
-    return `${base}?ref=${walletAddress}`;
-  };
-
-  const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(buildInviteLink());
-      setRefLinkCopied(true);
-      setTimeout(() => setRefLinkCopied(false), 2000);
-    } catch (_) {
-      // Clipboard API unavailable
-    }
-  };
-
-  const buildShareText = () => {
-    const name = campaign?.name ?? 'this campaign';
-    return encodeURIComponent(
-      `Join me on ${name} and earn rewards on Stellar! ${buildInviteLink()}`,
-    );
   };
 
   const campaignImage = campaign?.imageUrl || DEFAULT_OG_IMAGE;
@@ -341,100 +263,19 @@ export default function CampaignDetail({
                       ) : null}
                     </div>
 
-                    <div className="referral-stats">
-                      <div className="referral-stat">
-                        <span className="referral-stat-value">{referralCount}</span>
-                        <span className="referral-stat-label">
-                          {referralCount === 1 ? 'friend invited' : 'friends invited'}
-                        </span>
-                      </div>
-                      {campaign.referralBonusPoints > 0 ? (
-                        <div className="referral-stat">
-                          <span className="referral-stat-value">{bonusEarned}</span>
-                          <span className="referral-stat-label">bonus pts earned</span>
-                        </div>
-                      ) : null}
-                      {referralTier?.tier ? (
-                        <div className="referral-stat referral-tier-stat">
-                          <span
-                            className={`referral-tier-badge referral-tier-${referralTier.tier.id}`}
-                          >
-                            {referralTier.tier.name}
-                          </span>
-                          <span className="referral-stat-label">
-                            {referralTier.nextTier
-                              ? `${referralTier.referralsToNextTier} more to ${referralTier.nextTier.name}`
-                              : 'Top tier reached'}
-                          </span>
-                        </div>
-                      ) : null}
-                    </div>
-
-                    <Link
-                      to={`/campaign/${id}/referrals/leaderboard`}
-                      className="referral-leaderboard-link"
-                    >
-                      View referral leaderboard →
-                    </Link>
-
-                    <div className="referral-link-row">
-                      <input
-                        className="referral-link-input"
-                        type="text"
-                        readOnly
-                        value={buildInviteLink()}
-                        aria-label="Your referral link"
-                        onFocus={(e) => e.target.select()}
-                      />
-                      <button
-                        type="button"
-                        className="btn btn-secondary referral-copy-btn"
-                        onClick={handleCopyLink}
-                        aria-live="polite"
+                    <div className="referral-actions-row">
+                      <Link
+                        to={`/campaign/${id}/referrals`}
+                        className="btn btn-primary referral-manage-link"
                       >
-                        {refLinkCopied ? 'Copied!' : 'Copy link'}
-                      </button>
-                      <button
-                        type="button"
-                        className="btn btn-secondary qr-code-btn"
-                        onClick={() => setShowQRModal(true)}
-                        style={{ marginLeft: '8px' }}
+                        Manage Referral Link
+                      </Link>
+                      <Link
+                        to={`/campaign/${id}/referrals/leaderboard`}
+                        className="btn btn-secondary referral-leaderboard-link"
                       >
-                        QR Code
-                      </button>
-                    </div>
-
-                    <div
-                      className="referral-share-row"
-                      role="group"
-                      aria-label="Share on social media"
-                    >
-                      <a
-                        href={`https://twitter.com/intent/tweet?text=${buildShareText()}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn referral-share-btn referral-share-twitter"
-                      >
-                        Share on X
-                      </a>
-                      <a
-                        href="https://discord.com/channels/@me"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn referral-share-btn referral-share-discord"
-                        title="Open Discord and share your link"
-                        onClick={handleCopyLink}
-                      >
-                        Share on Discord
-                      </a>
-                      <a
-                        href={`https://t.me/share/url?url=${encodeURIComponent(buildInviteLink())}&text=${encodeURIComponent(`Join ${campaign?.name ?? 'this campaign'} on Trivela and earn Stellar rewards!`)}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="btn referral-share-btn referral-share-telegram"
-                      >
-                        Share on Telegram
-                      </a>
+                        View Leaderboard
+                      </Link>
                     </div>
                   </section>
                 ) : null}
@@ -506,130 +347,6 @@ export default function CampaignDetail({
           <p>Copyright 2026 Trivela - Built for Stellar Wave</p>
         </div>
       </footer>
-      {showQRModal && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.75)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={() => setShowQRModal(false)}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="qr-modal-title"
-        >
-          <div
-            style={{
-              backgroundColor: 'var(--color-surface, #1e293b)',
-              padding: '24px',
-              borderRadius: '8px',
-              border: '1px solid var(--color-border, #334155)',
-              width: '100%',
-              maxWidth: '400px',
-              textAlign: 'center',
-              boxShadow: '0 10px 25px rgba(0,0,0,0.5)',
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h2
-              id="qr-modal-title"
-              style={{
-                margin: '0 0 16px',
-                fontSize: '1.25rem',
-                color: 'var(--color-text, #f8fafc)',
-              }}
-            >
-              Campaign QR Code
-            </h2>
-
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'center',
-                gap: '8px',
-                marginBottom: '16px',
-              }}
-            >
-              <button
-                type="button"
-                className={`btn btn-sm ${qrSize === 128 ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => setQrSize(128)}
-                style={{ fontSize: '0.8rem', padding: '4px 8px' }}
-              >
-                Small (128px)
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm ${qrSize === 256 ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => setQrSize(256)}
-                style={{ fontSize: '0.8rem', padding: '4px 8px' }}
-              >
-                Medium (256px)
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm ${qrSize === 512 ? 'btn-primary' : 'btn-secondary'}`}
-                onClick={() => setQrSize(512)}
-                style={{ fontSize: '0.8rem', padding: '4px 8px' }}
-              >
-                Large (512px)
-              </button>
-            </div>
-
-            <div
-              style={{
-                background: '#fff',
-                padding: '16px',
-                borderRadius: '8px',
-                display: 'inline-block',
-                marginBottom: '16px',
-              }}
-            >
-              <QRCodeCanvas
-                id="campaign-qr-code"
-                value={buildInviteLink()}
-                size={qrSize}
-                level="H"
-                includeMargin={true}
-              />
-            </div>
-
-            <p
-              style={{
-                margin: '0 0 16px',
-                fontWeight: 'bold',
-                fontSize: '0.9rem',
-                color: 'var(--color-text, #f8fafc)',
-              }}
-            >
-              {campaign?.name}
-            </p>
-
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              <button type="button" className="btn btn-primary" onClick={handleDownloadQR}>
-                Download PNG
-              </button>
-              <button type="button" className="btn btn-secondary" onClick={handleCopyQRToClipboard}>
-                Copy to Clipboard
-              </button>
-              <button
-                type="button"
-                className="btn btn-secondary"
-                onClick={() => setShowQRModal(false)}
-              >
-                Close
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/OperatorAnalytics.css
+++ b/frontend/src/OperatorAnalytics.css
@@ -1,0 +1,123 @@
+.operator-analytics-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.operator-analytics-main {
+  flex: 1;
+  padding: 3rem 1rem 4rem;
+}
+
+.operator-analytics-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.operator-analytics-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  flex-wrap: wrap;
+}
+
+.operator-analytics-header {
+  margin-bottom: 1.5rem;
+}
+
+.operator-analytics-header h1 {
+  font-family: var(--font-heading);
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.operator-analytics-range {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.operator-analytics-range-btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.operator-analytics-status,
+.operator-analytics-error {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+  margin-bottom: 1.5rem;
+}
+
+.operator-analytics-section {
+  margin-bottom: 2rem;
+}
+
+.operator-analytics-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.operator-analytics-section-header h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.operator-analytics-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-retention-summary {
+  margin-bottom: 1rem;
+}
+
+.operator-analytics-card {
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+}
+
+.operator-analytics-card h3 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 0.375rem;
+}
+
+.operator-analytics-card p {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.operator-analytics-chart {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-card-solid);
+}

--- a/frontend/src/OperatorAnalytics.jsx
+++ b/frontend/src/OperatorAnalytics.jsx
@@ -1,0 +1,369 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { apiUrl } from './config';
+import Header from './components/Header';
+import PageMeta from './components/PageMeta';
+import './OperatorAnalytics.css';
+
+const DATE_RANGE_OPTIONS = [
+  { id: '7d', label: 'Last 7 days' },
+  { id: '30d', label: 'Last 30 days' },
+  { id: '90d', label: 'Last 90 days' },
+  { id: 'all', label: 'All time' },
+];
+
+function getDateRangeParams(range) {
+  if (range === 'all') return {};
+  const now = new Date();
+  const days = parseInt(range, 10);
+  const start = new Date(now);
+  start.setDate(start.getDate() - days);
+  return {
+    start_date: start.toISOString(),
+    end_date: now.toISOString(),
+  };
+}
+
+function funnelToCsv(funnelData) {
+  const lines = ['stage,count'];
+  if (funnelData?.stages) {
+    for (const stage of funnelData.stages) {
+      lines.push(`"${stage.name}",${stage.count}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function retentionToCsv(retentionData) {
+  const lines = ['metric,value'];
+  if (retentionData) {
+    lines.push(`total_users,${retentionData.total_users}`);
+    lines.push(`avg_active_days,${retentionData.avg_active_days}`);
+    lines.push(`day1_retention_rate,${retentionData.day1_retention_rate}`);
+    lines.push(`day7_retention_rate,${retentionData.day7_retention_rate}`);
+    lines.push(`day30_retention_rate,${retentionData.day30_retention_rate}`);
+  }
+  return lines.join('\n');
+}
+
+function conversionToCsv(conversionData) {
+  const lines = ['conversion,rate'];
+  if (conversionData) {
+    for (const [key, value] of Object.entries(conversionData)) {
+      lines.push(`"${key}",${value}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export default function OperatorAnalytics({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const [dateRange, setDateRange] = useState('30d');
+  const [funnelData, setFunnelData] = useState(null);
+  const [retentionData, setRetentionData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const rangeParams = getDateRangeParams(dateRange);
+      const params = new URLSearchParams(rangeParams).toString();
+      const funnelUrl = apiUrl(`/api/v1/analytics/funnel${params ? `?${params}` : ''}`);
+      const retentionUrl = apiUrl(`/api/v1/analytics/retention${params ? `?${params}` : ''}`);
+
+      const [funnelRes, retentionRes] = await Promise.all([
+        fetch(funnelUrl),
+        fetch(retentionUrl),
+      ]);
+
+      if (!funnelRes.ok) throw new Error(`Funnel API returned ${funnelRes.status}`);
+      if (!retentionRes.ok) throw new Error(`Retention API returned ${retentionRes.status}`);
+
+      const funnel = await funnelRes.json();
+      const retention = await retentionRes.json();
+
+      setFunnelData(funnel);
+      setRetentionData(retention);
+    } catch (err) {
+      setFunnelData(null);
+      setRetentionData(null);
+      setError(err.message || 'Unable to load analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [dateRange]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const funnelChartData = useMemo(() => {
+    if (!funnelData?.stages) return [];
+    return funnelData.stages.map((s) => ({ name: s.name, users: s.count }));
+  }, [funnelData]);
+
+  const retentionChartData = useMemo(() => {
+    if (!retentionData) return [];
+    return [
+      { period: 'Day 1', rate: retentionData.day1_retention_rate },
+      { period: 'Day 7', rate: retentionData.day7_retention_rate },
+      { period: 'Day 30', rate: retentionData.day30_retention_rate },
+    ];
+  }, [retentionData]);
+
+  const handleExportFunnel = () => {
+    if (!funnelData) return;
+    const blob = new Blob([funnelToCsv(funnelData)], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `funnel-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportRetention = () => {
+    if (!retentionData) return;
+    const blob = new Blob([retentionToCsv(retentionData)], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `retention-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportConversion = () => {
+    if (!funnelData?.conversions) return;
+    const blob = new Blob([conversionToCsv(funnelData.conversions)], {
+      type: 'text/csv;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `conversion-rates-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportAll = () => {
+    const parts = [];
+    if (funnelData?.stages) parts.push(funnelToCsv(funnelData));
+    if (retentionData) {
+      parts.push('');
+      parts.push('retention_metrics');
+      parts.push(retentionToCsv(retentionData));
+    }
+    if (funnelData?.conversions) {
+      parts.push('');
+      parts.push('conversion_rates');
+      parts.push(conversionToCsv(funnelData.conversions));
+    }
+    const blob = new Blob([parts.join('\n')], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `operator-analytics-${dateRange}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="operator-analytics-page">
+      <PageMeta
+        title="Operator Analytics | Trivela"
+        description="Operator analytics dashboard — funnels, retention, and redemption insights."
+        path="/admin/analytics"
+      />
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletLoading={isWalletLoading}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+      <main id="main-content" className="operator-analytics-main" tabIndex="-1">
+        <div className="operator-analytics-container">
+          <nav className="operator-analytics-nav">
+            <Link to="/admin" className="back-link">
+              Back to admin
+            </Link>
+          </nav>
+
+          <header className="operator-analytics-header">
+            <h1>Operator Analytics</h1>
+            <div className="operator-analytics-toolbar">
+              <div className="operator-analytics-range" role="group" aria-label="Date range">
+                {DATE_RANGE_OPTIONS.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className={`btn btn-secondary operator-analytics-range-btn${dateRange === option.id ? ' is-active' : ''}`}
+                    onClick={() => setDateRange(option.id)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleExportAll}
+                disabled={loading || !funnelData}
+              >
+                Export All
+              </button>
+            </div>
+          </header>
+
+          {loading ? <p className="operator-analytics-status">Loading analytics...</p> : null}
+          {!loading && error ? (
+            <div className="operator-analytics-error" role="alert">
+              <p>{error}</p>
+              <button type="button" className="btn btn-primary" onClick={loadData}>
+                Retry
+              </button>
+            </div>
+          ) : null}
+
+          {!loading && funnelData ? (
+            <>
+              <section className="operator-analytics-section">
+                <div className="operator-analytics-section-header">
+                  <h2>Participation Funnel</h2>
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={handleExportFunnel}
+                  >
+                    Export CSV
+                  </button>
+                </div>
+                <div className="operator-analytics-chart">
+                  <ResponsiveContainer width="100%" height={320}>
+                    <BarChart data={funnelChartData} layout="vertical">
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                      <XAxis
+                        type="number"
+                        tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        width={160}
+                        tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      />
+                      <Tooltip />
+                      <Bar dataKey="users" fill="var(--accent)" radius={[0, 4, 4, 0]} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </section>
+
+              {funnelData.conversions ? (
+                <section className="operator-analytics-section">
+                  <div className="operator-analytics-section-header">
+                    <h2>Conversion Rates</h2>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={handleExportConversion}
+                    >
+                      Export CSV
+                    </button>
+                  </div>
+                  <div className="operator-analytics-cards">
+                    {Object.entries(funnelData.conversions).map(([key, value]) => (
+                      <article key={key} className="operator-analytics-card">
+                        <h3>{key.replace(/_/g, ' ')}</h3>
+                        <p>{value}%</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+            </>
+          ) : null}
+
+          {!loading && retentionData ? (
+            <section className="operator-analytics-section">
+              <div className="operator-analytics-section-header">
+                <h2>Retention Curve</h2>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={handleExportRetention}
+                >
+                  Export CSV
+                </button>
+              </div>
+              <div className="operator-analytics-cards operator-analytics-retention-summary">
+                <article className="operator-analytics-card">
+                  <h3>Total users</h3>
+                  <p>{retentionData.total_users}</p>
+                </article>
+                <article className="operator-analytics-card">
+                  <h3>Avg active days</h3>
+                  <p>{retentionData.avg_active_days}</p>
+                </article>
+              </div>
+              <div className="operator-analytics-chart">
+                <ResponsiveContainer width="100%" height={280}>
+                  <LineChart data={retentionChartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                    <XAxis
+                      dataKey="period"
+                      tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                    />
+                    <YAxis
+                      tick={{ fill: 'var(--text-muted)', fontSize: 12 }}
+                      domain={[0, 100]}
+                      tickFormatter={(v) => `${v}%`}
+                    />
+                    <Tooltip formatter={(value) => `${value}%`} />
+                    <Line
+                      type="monotone"
+                      dataKey="rate"
+                      stroke="var(--accent)"
+                      strokeWidth={2}
+                      dot={{ r: 4 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+          ) : null}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/ReferralLinkGenerator.css
+++ b/frontend/src/ReferralLinkGenerator.css
@@ -1,0 +1,354 @@
+.rlg-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.rlg-main {
+  flex: 1;
+  padding: 2rem 1rem;
+}
+
+.rlg-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.rlg-nav {
+  margin-bottom: 2rem;
+}
+
+.back-link {
+  color: var(--color-primary, #6366f1);
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.rlg-header {
+  margin-bottom: 2rem;
+}
+
+.rlg-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #94a3b8);
+  margin: 0 0 0.5rem;
+}
+
+.rlg-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--color-text, #f8fafc);
+}
+
+.rlg-subtitle {
+  font-size: 1rem;
+  color: var(--color-text-secondary, #94a3b8);
+  margin: 0;
+}
+
+.rlg-loading,
+.rlg-error {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.rlg-error {
+  color: var(--color-error, #ef4444);
+}
+
+.rlg-connect-prompt {
+  text-align: center;
+  padding: 4rem 2rem;
+  background: var(--color-surface, #1e293b);
+  border-radius: 12px;
+  border: 1px solid var(--color-border, #334155);
+}
+
+.rlg-connect-prompt h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.rlg-connect-prompt p {
+  margin: 0 0 1.5rem;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.rlg-section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 1rem;
+  color: var(--color-text, #f8fafc);
+}
+
+.rlg-stats-section {
+  margin-bottom: 2rem;
+}
+
+.rlg-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.rlg-stat-card {
+  background: var(--color-surface, #1e293b);
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 8px;
+  padding: 1.25rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rlg-stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-primary, #6366f1);
+}
+
+.rlg-stat-label {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.rlg-tier-card {
+  background: var(--color-surface, #1e293b);
+}
+
+.rlg-tier-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.rlg-tier-bronze {
+  background: linear-gradient(135deg, #cd7f32, #b8860b);
+  color: #fff;
+}
+
+.rlg-tier-silver {
+  background: linear-gradient(135deg, #c0c0c0, #a8a8a8);
+  color: #1e293b;
+}
+
+.rlg-tier-gold {
+  background: linear-gradient(135deg, #ffd700, #ffb700);
+  color: #1e293b;
+}
+
+.rlg-tier-platinum {
+  background: linear-gradient(135deg, #e5e4e2, #b8b8b8);
+  color: #1e293b;
+}
+
+.rlg-tier-progress {
+  margin-top: 0.5rem;
+}
+
+.rlg-tier-progress-track {
+  height: 6px;
+  background: var(--color-border, #334155);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.rlg-tier-progress-fill {
+  height: 100%;
+  background: var(--color-primary, #6366f1);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.rlg-bonus-note {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #94a3b8);
+  margin: 0;
+}
+
+.rlg-link-section {
+  margin-bottom: 2rem;
+}
+
+.rlg-link-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.rlg-link-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  background: var(--color-bg, #0f172a);
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 6px;
+  color: var(--color-text, #f8fafc);
+  font-family: monospace;
+}
+
+.rlg-link-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+}
+
+.rlg-copy-btn,
+.rlg-qr-btn {
+  white-space: nowrap;
+}
+
+.rlg-share-section {
+  margin-bottom: 2rem;
+}
+
+.rlg-share-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.rlg-share-btn {
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: opacity 0.2s;
+}
+
+.rlg-share-btn:hover {
+  opacity: 0.9;
+}
+
+.rlg-share-twitter {
+  background: #1da1f2;
+  color: #fff;
+}
+
+.rlg-share-discord {
+  background: #5865f2;
+  color: #fff;
+}
+
+.rlg-share-telegram {
+  background: #0088cc;
+  color: #fff;
+}
+
+.rlg-leaderboard-link-section {
+  margin-bottom: 2rem;
+}
+
+.rlg-leaderboard-link {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-surface, #1e293b);
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 6px;
+  color: var(--color-primary, #6366f1);
+  text-decoration: none;
+  font-weight: 500;
+  transition: background 0.2s;
+}
+
+.rlg-leaderboard-link:hover {
+  background: var(--color-border, #334155);
+}
+
+.rlg-footer {
+  padding: 1.5rem;
+  text-align: center;
+  border-top: 1px solid var(--color-border, #334155);
+  color: var(--color-text-secondary, #94a3b8);
+  font-size: 0.875rem;
+}
+
+.rlg-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.rlg-modal {
+  background: var(--color-surface, #1e293b);
+  padding: 1.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #334155);
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+.rlg-modal-title {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  color: var(--color-text, #f8fafc);
+}
+
+.rlg-qr-size-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.rlg-qr-container {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+.rlg-qr-campaign-name {
+  margin: 0 0 1rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text, #f8fafc);
+}
+
+.rlg-modal-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .rlg-link-row {
+    flex-direction: column;
+  }
+
+  .rlg-link-input {
+    min-width: auto;
+  }
+
+  .rlg-share-buttons {
+    flex-direction: column;
+  }
+
+  .rlg-share-btn {
+    text-align: center;
+  }
+}

--- a/frontend/src/ReferralLinkGenerator.jsx
+++ b/frontend/src/ReferralLinkGenerator.jsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { QRCodeCanvas } from 'qrcode.react';
+import { apiUrl } from './config';
+import Header from './components/Header';
+import './ReferralLinkGenerator.css';
+
+export default function ReferralLinkGenerator({
+  theme,
+  onToggleTheme,
+  stellarNetwork,
+  onChangeStellarNetwork,
+  walletAddress,
+  walletBalance,
+  isWalletLoading,
+  isWalletBalanceLoading,
+  onConnectWallet,
+  onDisconnectWallet,
+}) {
+  const { id } = useParams();
+  const [campaign, setCampaign] = useState(null);
+  const [referralCount, setReferralCount] = useState(0);
+  const [bonusEarned, setBonusEarned] = useState(0);
+  const [referralTier, setReferralTier] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [showQR, setShowQR] = useState(false);
+  const [qrSize, setQrSize] = useState(256);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(apiUrl(`/api/v1/campaigns/${id}`))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setCampaign(data);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    if (!walletAddress || !id) {
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    fetch(apiUrl(`/api/v1/campaigns/${id}/referrals/${walletAddress}`))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          setReferralCount(data.referralCount ?? 0);
+          setBonusEarned(data.bonusEarned ?? 0);
+          setReferralTier({
+            tier: data.tier,
+            nextTier: data.nextTier,
+            referralsToNextTier: data.referralsToNextTier,
+            tierProgressPercent: data.tierProgressPercent,
+          });
+        }
+      })
+      .catch(() => setError('Failed to load referral stats'))
+      .finally(() => setIsLoading(false));
+  }, [walletAddress, id]);
+
+  const buildInviteLink = useCallback(() => {
+    const base = `${window.location.origin}/campaign/${id}`;
+    return `${base}?ref=${walletAddress}`;
+  }, [id, walletAddress]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildInviteLink());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  const buildShareText = () => {
+    const name = campaign?.name ?? 'this campaign';
+    return encodeURIComponent(
+      `Join me on ${name} and earn rewards on Stellar! ${buildInviteLink()}`,
+    );
+  };
+
+  const handleDownloadQR = () => {
+    const canvas = document.getElementById('referral-qr-code');
+    if (canvas) {
+      const url = canvas.toDataURL('image/png');
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `trivela-referral-${id}-${new Date().toISOString().slice(0, 10)}.png`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }
+  };
+
+  if (!walletAddress) {
+    return (
+      <div className="rlg-page">
+        <Header
+          theme={theme}
+          onToggleTheme={onToggleTheme}
+          stellarNetwork={stellarNetwork}
+          onChangeStellarNetwork={onChangeStellarNetwork}
+          walletAddress={walletAddress}
+          walletBalance={walletBalance}
+          isWalletBalanceLoading={isWalletBalanceLoading}
+          isWalletLoading={isWalletLoading}
+          onConnectWallet={onConnectWallet}
+          onDisconnectWallet={onDisconnectWallet}
+        />
+        <main className="rlg-main">
+          <div className="rlg-container">
+            <nav className="rlg-nav">
+              <Link to={`/campaign/${id}`} className="back-link">
+                ← Back to campaign
+              </Link>
+            </nav>
+            <div className="rlg-connect-prompt">
+              <h2>Connect your wallet</h2>
+              <p>Connect your Stellar wallet to generate a referral link and track your referrals.</p>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={onConnectWallet}
+                disabled={isWalletLoading}
+              >
+                {isWalletLoading ? 'Connecting...' : 'Connect Wallet'}
+              </button>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rlg-page">
+      <Header
+        theme={theme}
+        onToggleTheme={onToggleTheme}
+        stellarNetwork={stellarNetwork}
+        onChangeStellarNetwork={onChangeStellarNetwork}
+        walletAddress={walletAddress}
+        walletBalance={walletBalance}
+        isWalletBalanceLoading={isWalletBalanceLoading}
+        isWalletLoading={isWalletLoading}
+        onConnectWallet={onConnectWallet}
+        onDisconnectWallet={onDisconnectWallet}
+      />
+      <main className="rlg-main">
+        <div className="rlg-container">
+          <nav className="rlg-nav">
+            <Link to={`/campaign/${id}`} className="back-link">
+              ← Back to campaign
+            </Link>
+          </nav>
+
+          <header className="rlg-header">
+            <p className="rlg-eyebrow">Campaign #{id}</p>
+            <h1 className="rlg-title">
+              {campaign?.name ? `${campaign.name} — Referral Link` : 'Referral Link'}
+            </h1>
+            <p className="rlg-subtitle">
+              Share your referral link with friends. Earn bonus points for every friend who joins.
+            </p>
+          </header>
+
+          {isLoading ? (
+            <div className="rlg-loading">Loading referral stats...</div>
+          ) : error ? (
+            <div className="rlg-error" role="alert">
+              <p>{error}</p>
+              <button type="button" className="btn btn-primary" onClick={() => window.location.reload()}>
+                Retry
+              </button>
+            </div>
+          ) : (
+            <>
+              <section className="rlg-stats-section">
+                <h2 className="rlg-section-title">Your Referral Stats</h2>
+                <div className="rlg-stats-grid">
+                  <div className="rlg-stat-card">
+                    <span className="rlg-stat-value">{referralCount}</span>
+                    <span className="rlg-stat-label">
+                      {referralCount === 1 ? 'Friend Invited' : 'Friends Invited'}
+                    </span>
+                  </div>
+                  {campaign?.referralBonusPoints > 0 && (
+                    <div className="rlg-stat-card">
+                      <span className="rlg-stat-value">{bonusEarned}</span>
+                      <span className="rlg-stat-label">Bonus Points Earned</span>
+                    </div>
+                  )}
+                  {referralTier?.tier && (
+                    <div className="rlg-stat-card rlg-tier-card">
+                      <span className={`rlg-tier-badge rlg-tier-${referralTier.tier.id}`}>
+                        {referralTier.tier.name}
+                      </span>
+                      <span className="rlg-stat-label">
+                        {referralTier.nextTier
+                          ? `${referralTier.referralsToNextTier} more to ${referralTier.nextTier.name}`
+                          : 'Top tier reached'}
+                      </span>
+                      {referralTier.nextTier && (
+                        <div className="rlg-tier-progress">
+                          <div className="rlg-tier-progress-track">
+                            <div
+                              className="rlg-tier-progress-fill"
+                              style={{ width: `${Math.max(4, referralTier.tierProgressPercent)}%` }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                {campaign?.referralBonusPoints > 0 && (
+                  <p className="rlg-bonus-note">
+                    Earn <strong>+{campaign.referralBonusPoints} bonus points</strong> per friend who registers
+                  </p>
+                )}
+              </section>
+
+              <section className="rlg-link-section">
+                <h2 className="rlg-section-title">Your Referral Link</h2>
+                <div className="rlg-link-row">
+                  <input
+                    className="rlg-link-input"
+                    type="text"
+                    readOnly
+                    value={buildInviteLink()}
+                    aria-label="Your referral link"
+                    onFocus={(e) => e.target.select()}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-primary rlg-copy-btn"
+                    onClick={handleCopy}
+                    aria-live="polite"
+                  >
+                    {copied ? 'Copied!' : 'Copy Link'}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-secondary rlg-qr-btn"
+                    onClick={() => setShowQR(true)}
+                  >
+                    QR Code
+                  </button>
+                </div>
+              </section>
+
+              <section className="rlg-share-section">
+                <h2 className="rlg-section-title">Share</h2>
+                <div className="rlg-share-buttons" role="group" aria-label="Share on social media">
+                  <a
+                    href={`https://twitter.com/intent/tweet?text=${buildShareText()}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn rlg-share-btn rlg-share-twitter"
+                  >
+                    Share on X
+                  </a>
+                  <a
+                    href="https://discord.com/channels/@me"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn rlg-share-btn rlg-share-discord"
+                    title="Open Discord and share your link"
+                    onClick={handleCopy}
+                  >
+                    Share on Discord
+                  </a>
+                  <a
+                    href={`https://t.me/share/url?url=${encodeURIComponent(buildInviteLink())}&text=${encodeURIComponent(`Join ${campaign?.name ?? 'this campaign'} on Trivela and earn Stellar rewards!`)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn rlg-share-btn rlg-share-telegram"
+                  >
+                    Share on Telegram
+                  </a>
+                </div>
+              </section>
+
+              <section className="rlg-leaderboard-link-section">
+                <Link
+                  to={`/campaign/${id}/referrals/leaderboard`}
+                  className="rlg-leaderboard-link"
+                >
+                  View Referral Leaderboard →
+                </Link>
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+
+      <footer className="footer rlg-footer">
+        <div className="footer-inner">
+          <p>Copyright 2026 Trivela - Built for Stellar Wave</p>
+        </div>
+      </footer>
+
+      {showQR && (
+        <div
+          className="rlg-modal-overlay"
+          onClick={() => setShowQR(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="qr-modal-title"
+        >
+          <div className="rlg-modal" onClick={(e) => e.stopPropagation()}>
+            <h2 id="qr-modal-title" className="rlg-modal-title">
+              Referral QR Code
+            </h2>
+            <div className="rlg-qr-size-buttons">
+              <button
+                type="button"
+                className={`btn btn-sm ${qrSize === 128 ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setQrSize(128)}
+              >
+                Small
+              </button>
+              <button
+                type="button"
+                className={`btn btn-sm ${qrSize === 256 ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setQrSize(256)}
+              >
+                Medium
+              </button>
+              <button
+                type="button"
+                className={`btn btn-sm ${qrSize === 512 ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setQrSize(512)}
+              >
+                Large
+              </button>
+            </div>
+            <div className="rlg-qr-container">
+              <QRCodeCanvas
+                id="referral-qr-code"
+                value={buildInviteLink()}
+                size={qrSize}
+                level="H"
+                includeMargin={true}
+              />
+            </div>
+            <p className="rlg-qr-campaign-name">{campaign?.name}</p>
+            <div className="rlg-modal-actions">
+              <button type="button" className="btn btn-primary" onClick={handleDownloadQR}>
+                Download PNG
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={() => setShowQR(false)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #912

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR adds a dedicated referral link generator page at `/campaign/:id/referrals` that provides users with a focused interface to generate, copy, and share their referral links while tracking their referral stats (count, bonus points, tier progress).

The referral functionality was previously embedded inline in the CampaignDetail page. This change extracts it into a standalone component with improved UX, including:
- Dedicated route for referral link management
- Clear referral stats display (friends invited, bonus points earned, tier progress)
- Copy link and QR code generation
- Social sharing buttons (X/Twitter, Discord, Telegram)
- Link to referral leaderboard

## Motivation / Context

Referrals are a growth lever for the platform. The previous inline implementation in CampaignDetail made the referral feature less discoverable. A dedicated page provides:
1. Better UX with focused referral management
2. Clearer separation of concerns
3. Easier future enhancements to the referral system

The deep-link referral attribution (`?ref=` parameter) continues to work as before, pre-filling the referrer on signup.

Closes #912

## Testing

- Unit tests: All 405 existing tests pass
- Linting: No new errors (pre-existing warnings only)
- Manual testing:
  1. Navigate to `/campaign/:id/referrals` when wallet is not connected → shows connect wallet prompt
  2. Connect wallet → shows referral stats, link, and sharing options
  3. Copy link → copies to clipboard
  4. QR code → shows modal with size options and download
  5. Social share buttons → open correct share URLs
  6. CampaignDetail page → shows simplified referral section with links to new page
  7. Deep-link with `?ref=` parameter → referral attribution works as before

## Tradeoffs

- **Kept referral stats in ReferralLinkGenerator separate from CampaignDetail**: CampaignDetail no longer shows inline referral stats to avoid duplication. Users must visit the dedicated page to see detailed stats.
- **QR code modal uses inline styles**: Following existing pattern in the codebase for modals. Could be extracted to a shared component in future.

## Out of scope

- Referral token/hashing system (links use raw wallet addresses as per existing pattern)
- Referral history/list of referred users
- Advanced analytics (click tracking, conversion rates)