### PR TITLE
GDPR: fix broken PII purge, add export endpoint, document immutability

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -702,6 +702,130 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/v1/pii/export-user:
+    post:
+      summary: Export all off-chain PII for a wallet address or email (GDPR right of access)
+      description: >-
+        Returns every row across off-chain tables (participation, credits/claims,
+        referrals, notification preferences, push subscriptions, etc.) matching the
+        given identifier. Web Push credential fields (`p256dh`, `auth`) are redacted.
+        See `docs/EVENT_SCHEMA.md` for the on-chain immutability notes this endpoint
+        is scoped by.
+      tags:
+        - Admin
+      operationId: exportPiiForUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - identifier
+              properties:
+                identifier:
+                  type: string
+                  description: Wallet address (G...) or email to export data for.
+      responses:
+        '200':
+          description: Export payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PiiExportResponse'
+        '400':
+          description: Missing identifier
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/v1/pii/purge-user:
+    post:
+      summary: Erase all off-chain PII for a wallet address or email (GDPR right to erasure)
+      description: >-
+        Hard-deletes every row across off-chain tables matching the given identifier.
+        Has no effect on-chain — see `docs/EVENT_SCHEMA.md` for the immutability and
+        re-indexing caveats. Idempotent: re-running against an already-purged
+        identifier is a safe no-op.
+      tags:
+        - Admin
+      operationId: purgePiiForUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - identifier
+              properties:
+                identifier:
+                  type: string
+                  description: Wallet address (G...) or email to purge data for.
+      responses:
+        '200':
+          description: Purge result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PiiPurgeResponse'
+        '400':
+          description: Missing identifier
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /api/v1/pii/purge-campaign:
+    post:
+      summary: Erase campaign-scoped PII rows (referrals, allowlist entries, etc.)
+      tags:
+        - Admin
+      operationId: purgePiiForCampaign
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - campaignId
+              properties:
+                campaignId:
+                  type: string
+      responses:
+        '200':
+          description: Purge result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PiiPurgeResponse'
+        '400':
+          description: Missing campaignId
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /api/v1/audit-logs:
     get:
       summary: List audit logs
@@ -2004,6 +2128,42 @@ components:
       description: >-
         Per-key rate-limit tier enforced by the rate limiter (#924). `standard`
         is 60 req/min, `pro` is 300 req/min, `enterprise` is 1000 req/min.
+
+    PiiExportResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        identifier:
+          type: string
+        exportedAt:
+          type: string
+          format: date-time
+        data:
+          type: object
+          description: >-
+            One key per off-chain table with at least one matching row (empty
+            tables are omitted). Values are arrays of the raw rows, except
+            push_subscriptions.p256dh/auth which are redacted.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+
+    PiiPurgeResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        purged:
+          type: array
+          items:
+            type: object
+            properties:
+              table:
+                type: string
+              count:
+                type: integer
 
     Error:
       type: object

--- a/backend/src/dal/softDelete.test.js
+++ b/backend/src/dal/softDelete.test.js
@@ -3,7 +3,7 @@ import test from 'node:test';
 import Database from 'better-sqlite3';
 import { runMigrations } from '../db/migrate.js';
 import { createSqliteCampaignRepository } from './sqliteCampaignRepository.js';
-import { purgePiiForUser, purgePiiForCampaign } from '../services/piiPurgeService.js';
+import { purgePiiForUser, purgePiiForCampaign, exportPiiForUser } from '../services/piiPurgeService.js';
 
 async function setupTestRepository(seed = []) {
   const db = new Database(':memory:');
@@ -286,6 +286,93 @@ test('purgePiiForUser returns empty result when no PII found', async () => {
   const { db } = await setupTestRepository();
   const result = purgePiiForUser(db, 'nonexistent');
   assert.equal(result.purged.length, 0);
+});
+
+test('purgePiiForUser covers notification_preferences and unsubscribe_tokens (#927)', async () => {
+  const { db } = await setupTestRepository();
+  const now = new Date().toISOString();
+
+  db.prepare(
+    'INSERT INTO notification_preferences (user_address, channel, event_type, enabled, updated_at) VALUES (?, ?, ?, 1, ?)',
+  ).run('user1', 'email', '*', now);
+  db.prepare(
+    'INSERT INTO unsubscribe_tokens (token, user_address, channel, created_at) VALUES (?, ?, ?, ?)',
+  ).run('tok-1', 'user1', 'email', now);
+
+  const result = purgePiiForUser(db, 'user1');
+  assert.ok(result.purged.some((p) => p.table === 'notification_preferences'));
+  assert.ok(result.purged.some((p) => p.table === 'unsubscribe_tokens'));
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS n FROM notification_preferences WHERE user_address = ?').get('user1').n,
+    0,
+  );
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS n FROM unsubscribe_tokens WHERE user_address = ?').get('user1').n,
+    0,
+  );
+});
+
+// ─── PII Export Tests (#927) ────────────────────────────────────────────────
+
+test('exportPiiForUser returns matching rows keyed by table', async () => {
+  const { db } = await setupTestRepository();
+
+  db.prepare(
+    'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+  ).run(1, 'user1', 'user2', new Date().toISOString());
+  db.prepare(
+    'INSERT INTO credit_events (user, amount, ledger, tx_hash, created_at) VALUES (?, ?, ?, ?, ?)',
+  ).run('user1', '100', 42, 'tx1', new Date().toISOString());
+
+  const result = exportPiiForUser(db, 'user1');
+  assert.equal(result.identifier, 'user1');
+  assert.ok(result.exportedAt);
+  assert.equal(result.data.referrals.length, 1);
+  assert.equal(result.data.referrals[0].referrer_address, 'user1');
+  assert.equal(result.data.credit_events.length, 1);
+  assert.equal(result.data.credit_events[0].amount, '100');
+});
+
+test('exportPiiForUser matches a wallet appearing only as referee, not just referrer', async () => {
+  const { db } = await setupTestRepository();
+  db.prepare(
+    'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+  ).run(1, 'referrerOnly', 'refereeOnly', new Date().toISOString());
+
+  const result = exportPiiForUser(db, 'refereeOnly');
+  assert.equal(result.data.referrals.length, 1);
+  assert.equal(result.data.referrals[0].referee_address, 'refereeOnly');
+});
+
+test('exportPiiForUser omits tables with no matching rows', async () => {
+  const { db } = await setupTestRepository();
+  const result = exportPiiForUser(db, 'nonexistent');
+  assert.deepEqual(result.data, {});
+});
+
+test('exportPiiForUser redacts push_subscriptions credential fields', async () => {
+  const { db } = await setupTestRepository();
+  db.prepare(
+    'INSERT INTO push_subscriptions (user, endpoint, p256dh, auth, user_agent, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run('user1', 'https://push.example/abc', 'real-p256dh-key', 'real-auth-secret', 'test-agent', Date.now());
+
+  const result = exportPiiForUser(db, 'user1');
+  assert.equal(result.data.push_subscriptions.length, 1);
+  const sub = result.data.push_subscriptions[0];
+  assert.equal(sub.p256dh, '[REDACTED]');
+  assert.equal(sub.auth, '[REDACTED]');
+  assert.equal(sub.endpoint, 'https://push.example/abc', 'endpoint should stay visible');
+});
+
+test('exportPiiForUser does not delete or modify any data', async () => {
+  const { db } = await setupTestRepository();
+  db.prepare(
+    'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+  ).run(1, 'user1', 'user2', new Date().toISOString());
+
+  exportPiiForUser(db, 'user1');
+
+  assert.equal(db.prepare('SELECT COUNT(*) AS n FROM referrals').get().n, 1);
 });
 
 // ─── Integration Test ────────────────────────────────────────────────────────

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -104,7 +104,7 @@ import {
 } from './routes/notifications.js';
 import { createOperatorBalanceJob } from './jobs/operatorBalanceJob.js';
 import { createPruningJob } from './jobs/pruningJob.js';
-import { purgePiiForUser, purgePiiForCampaign } from './services/piiPurgeService.js';
+import { purgePiiForUser, purgePiiForCampaign, exportPiiForUser } from './services/piiPurgeService.js';
 import { createModerationService } from './moderation/moderationService.js';
 import { createContentModerationMiddleware } from './middleware/contentModeration.js';
 import createFaucetRoutes from './routes/faucet.js';
@@ -1618,10 +1618,6 @@ export async function createApp(options = {}) {
     if (!identifier || typeof identifier !== 'string') {
       return res.status(400).json({ error: 'identifier is required', code: 'VALIDATION_ERROR' });
     }
-    const dal = campaignRepository.db ? { db: campaignRepository.db } : null;
-    if (!dal || !dal.db) {
-      return res.status(500).json({ error: 'Database not available', code: 'DB_UNAVAILABLE' });
-    }
     const result = purgePiiForUser(dal.db, identifier);
     recordAuditEntry(req, {
       action: 'pii_purge',
@@ -1638,16 +1634,30 @@ export async function createApp(options = {}) {
     if (!campaignId) {
       return res.status(400).json({ error: 'campaignId is required', code: 'VALIDATION_ERROR' });
     }
-    const dal = campaignRepository.db ? { db: campaignRepository.db } : null;
-    if (!dal || !dal.db) {
-      return res.status(500).json({ error: 'Database not available', code: 'DB_UNAVAILABLE' });
-    }
     const result = purgePiiForCampaign(dal.db, campaignId);
     recordAuditEntry(req, {
       action: 'pii_purge',
       entity: 'campaign',
       entityId: String(campaignId),
       diff: result,
+    });
+    return res.json({ success: true, ...result });
+  }
+
+  /** @param {import('express').Request} req @param {import('express').Response} res */
+  function exportPiiUser(req, res) {
+    const { identifier } = req.body;
+    if (!identifier || typeof identifier !== 'string') {
+      return res.status(400).json({ error: 'identifier is required', code: 'VALIDATION_ERROR' });
+    }
+    const result = exportPiiForUser(dal.db, identifier);
+    recordAuditEntry(req, {
+      action: 'pii_export',
+      entity: 'user',
+      entityId: identifier,
+      // Row counts only — never the exported data itself — so the audit
+      // trail never becomes a second copy of the PII it's logging about.
+      diff: { tables: Object.fromEntries(Object.entries(result.data).map(([t, rows]) => [t, rows.length])) },
     });
     return res.json({ success: true, ...result });
   }
@@ -2297,32 +2307,35 @@ export async function createApp(options = {}) {
       listDeletedCampaigns,
     );
 
-    // PII purge routes (admin only)
+    // GDPR / PII purge + export routes (admin only, issue #927).
+    //
+    // Bug fix: this used to be two competing route registrations per path —
+    // Express only ever dispatches the first match, so the second
+    // (requireScope('org:manage'), a scope that isn't even in
+    // VALID_API_KEY_SCOPES and so could never actually pass) was silently
+    // unreachable dead code. The live behavior was "any valid tenant API
+    // key can purge any user's PII site-wide" — replaced with a single
+    // requireMasterKey-gated registration per path, consistent with every
+    // other admin-sensitive route in this file.
     app.post(
       `${prefix}/pii/purge-user`,
       rateLimiter,
-      requireApiKey,
-      purgePiiUser,
-    );
-    app.post(
-      `${prefix}/pii/purge-user`,
-      rateLimiter,
-      ...guard,
-      requireScope('org:manage'),
+      idempotencyMiddleware,
+      requireMasterKey,
       purgePiiUser,
     );
     app.post(
       `${prefix}/pii/purge-campaign`,
       rateLimiter,
-      requireApiKey,
+      idempotencyMiddleware,
+      requireMasterKey,
       purgePiiCampaign,
     );
     app.post(
-      `${prefix}/pii/purge-campaign`,
+      `${prefix}/pii/export-user`,
       rateLimiter,
-      ...guard,
-      requireScope('org:manage'),
-      purgePiiCampaign,
+      requireMasterKey,
+      exportPiiUser,
     );
 
     // Campaign translations (i18n)

--- a/backend/src/integration/pii.test.js
+++ b/backend/src/integration/pii.test.js
@@ -1,0 +1,284 @@
+// @ts-check
+//
+// Integration tests for the GDPR PII export/purge endpoints (issue #927).
+//
+// The route handlers (`purgePiiUser`/`purgePiiCampaign`/`exportPiiUser` in
+// index.js) used to always 500 — they referenced `campaignRepository.db`,
+// a property that doesn't exist, instead of the app's real `dal.db` — and
+// were reachable with any valid tenant API key rather than the master key,
+// because of a dead duplicate route registration. Neither bug had any test
+// coverage. These tests exercise the real HTTP layer end-to-end against a
+// shared on-disk SQLite file so seeded rows and the routes under test see
+// the same data.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import request from 'supertest';
+import { createApp } from '../index.js';
+import { runMigrations } from '../db/migrate.js';
+
+async function createTestApp(dbPath, options = {}) {
+  return createApp({
+    dbPath,
+    campaigns: [],
+    disableJobs: true,
+    skipEnvValidation: true,
+    masterKey: 'master-key-xyz',
+    apiKeys: '',
+    ...options,
+  });
+}
+
+/** Seeds via a second raw connection to the same on-disk DB file. */
+async function withSeededDb(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'trivela-pii-test-'));
+  const dbPath = join(dir, 'test.db');
+  const app = await createTestApp(dbPath);
+  const db = new Database(dbPath);
+  try {
+    return await fn({ app, db });
+  } finally {
+    db.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('purge-user requires master key', async () => {
+  await withSeededDb(async ({ app }) => {
+    await request(app)
+      .post('/api/v1/pii/purge-user')
+      .send({ identifier: 'GABC' })
+      .expect(401);
+  });
+});
+
+test('export-user requires master key', async () => {
+  await withSeededDb(async ({ app }) => {
+    await request(app)
+      .post('/api/v1/pii/export-user')
+      .send({ identifier: 'GABC' })
+      .expect(401);
+  });
+});
+
+test('purge-user returns 400 when identifier is missing', async () => {
+  await withSeededDb(async ({ app }) => {
+    const res = await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({})
+      .expect(400);
+    assert.equal(res.body.code, 'VALIDATION_ERROR');
+  });
+});
+
+test('export-user returns an empty data object for an unknown identifier', async () => {
+  await withSeededDb(async ({ app }) => {
+    const res = await request(app)
+      .post('/api/v1/pii/export-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GUNKNOWNWALLET' })
+      .expect(200);
+    assert.equal(res.body.success, true);
+    assert.deepEqual(res.body.data, {});
+  });
+});
+
+test('export-user returns seeded rows across multiple tables, redacting push credentials', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+    ).run(1, 'GWALLET1', 'GWALLET2', now);
+    db.prepare(
+      'INSERT INTO push_subscriptions (user, endpoint, p256dh, auth, user_agent, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('GWALLET1', 'https://push.example/x', 'secret-p256dh', 'secret-auth', 'ua', Date.now());
+
+    const res = await request(app)
+      .post('/api/v1/pii/export-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GWALLET1' })
+      .expect(200);
+
+    assert.equal(res.body.data.referrals.length, 1);
+    assert.equal(res.body.data.push_subscriptions.length, 1);
+    assert.equal(res.body.data.push_subscriptions[0].p256dh, '[REDACTED]');
+    assert.equal(res.body.data.push_subscriptions[0].auth, '[REDACTED]');
+    assert.equal(res.body.data.push_subscriptions[0].endpoint, 'https://push.example/x');
+  });
+});
+
+test('purge-user deletes seeded rows and a follow-up export comes back empty', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+    ).run(1, 'GPURGEME', 'GOTHER', now);
+    db.prepare(
+      'INSERT INTO credit_events (user, amount, ledger, tx_hash, created_at) VALUES (?, ?, ?, ?, ?)',
+    ).run('GPURGEME', '50', 1, 'tx1', now);
+
+    const purgeRes = await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GPURGEME' })
+      .expect(200);
+
+    assert.equal(purgeRes.body.success, true);
+    assert.ok(purgeRes.body.purged.some((p) => p.table === 'referrals'));
+    assert.ok(purgeRes.body.purged.some((p) => p.table === 'credit_events'));
+
+    const exportRes = await request(app)
+      .post('/api/v1/pii/export-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GPURGEME' })
+      .expect(200);
+    assert.deepEqual(exportRes.body.data, {});
+  });
+});
+
+test('purge-user does not affect an unrelated wallet', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    // GTARGET's own independent data (a referral to a third party, not
+    // GBYSTANDER — a shared referral row is a relationship record, so
+    // purging one side necessarily removes the whole row; that's covered
+    // by the "deletes seeded rows" test above, not this one).
+    db.prepare(
+      'INSERT INTO credit_events (user, amount, ledger, tx_hash, created_at) VALUES (?, ?, ?, ?, ?)',
+    ).run('GTARGET', '10', 1, 'tx-target', now);
+    // GBYSTANDER's own, entirely independent data.
+    db.prepare(
+      'INSERT INTO credit_events (user, amount, ledger, tx_hash, created_at) VALUES (?, ?, ?, ?, ?)',
+    ).run('GBYSTANDER', '75', 1, 'tx-bystander', now);
+
+    await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GTARGET' })
+      .expect(200);
+
+    const exportRes = await request(app)
+      .post('/api/v1/pii/export-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GBYSTANDER' })
+      .expect(200);
+    assert.equal(exportRes.body.data.credit_events.length, 1);
+    assert.equal(exportRes.body.data.credit_events[0].amount, '75');
+  });
+});
+
+test('purge-user and export-user are audit-logged with counts only, never the underlying PII', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO notification_channel_settings (user_id, phone_number, updated_at) VALUES (?, ?, ?)',
+    ).run('GAUDITME', '+15551234567', now);
+
+    await request(app)
+      .post('/api/v1/pii/export-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GAUDITME' })
+      .expect(200);
+    await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ identifier: 'GAUDITME' })
+      .expect(200);
+
+    const rows = db
+      .prepare("SELECT action, entity, entity_id, diff FROM audit_logs WHERE entity_id = ? ORDER BY id")
+      .all('GAUDITME');
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].action, 'pii_export');
+    assert.equal(rows[1].action, 'pii_purge');
+    for (const row of rows) {
+      assert.equal(row.entity, 'user');
+      assert.ok(!row.diff.includes('+15551234567'), 'audit diff must never contain the raw phone number');
+    }
+  });
+});
+
+test('purge-user is idempotent: replaying the same Idempotency-Key returns the cached result without re-erroring', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+    ).run(1, 'GIDEMPOTENT', 'GOTHER2', now);
+
+    const idempotencyKey = 'gdpr-purge-test-key-1';
+
+    const first = await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .set('Idempotency-Key', idempotencyKey)
+      .send({ identifier: 'GIDEMPOTENT' })
+      .expect(200);
+
+    const second = await request(app)
+      .post('/api/v1/pii/purge-user')
+      .set('X-API-Key', 'master-key-xyz')
+      .set('Idempotency-Key', idempotencyKey)
+      .send({ identifier: 'GIDEMPOTENT' })
+      .expect(200);
+
+    assert.equal(second.headers['idempotent-previous-request'], 'true');
+    assert.deepEqual(second.body, first.body);
+  });
+});
+
+test('purge-campaign requires master key and validates campaignId', async () => {
+  await withSeededDb(async ({ app }) => {
+    await request(app)
+      .post('/api/v1/pii/purge-campaign')
+      .send({ campaignId: '1' })
+      .expect(401);
+
+    await request(app)
+      .post('/api/v1/pii/purge-campaign')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({})
+      .expect(400);
+  });
+});
+
+test('purge-campaign deletes campaign-scoped rows via the real dal.db wiring', async () => {
+  await withSeededDb(async ({ app, db }) => {
+    const now = new Date().toISOString();
+    db.prepare(
+      'INSERT INTO referrals (campaign_id, referrer_address, referee_address, created_at) VALUES (?, ?, ?, ?)',
+    ).run(7, 'GCAMPUSER1', 'GCAMPUSER2', now);
+
+    const res = await request(app)
+      .post('/api/v1/pii/purge-campaign')
+      .set('X-API-Key', 'master-key-xyz')
+      .send({ campaignId: '7' })
+      .expect(200);
+
+    assert.equal(res.body.success, true);
+    assert.ok(res.body.purged.some((p) => p.table === 'referrals'));
+  });
+});
+
+// Sanity check that migrations actually ran against the shared file (guards
+// against a future setup regression silently making every test above a
+// false positive against an empty/unmigrated schema).
+test('sanity: the shared test db has the expected schema', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'trivela-pii-test-sanity-'));
+  const dbPath = join(dir, 'test.db');
+  try {
+    const db = new Database(dbPath);
+    await runMigrations(db);
+    const table = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='referrals'")
+      .get();
+    assert.ok(table);
+    db.close();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -1,7 +1,10 @@
 // Notification service for creating in-app notifications when key events occur.
 // Issue #914 — in-app notifications for credits, claims, and unlocks.
 
-import { logger } from '../lib/logger.js';
+// Bug fix (unrelated to #927, but blocked verifying it): this imported a
+// module that doesn't exist, crashing every test/boot path that transitively
+// loads index.js -> notificationService.js.
+import { log as logger } from '../middleware/logger.js';
 
 /**
  * @param {{

--- a/backend/src/services/piiPurgeService.js
+++ b/backend/src/services/piiPurgeService.js
@@ -15,6 +15,8 @@ const PII_TABLES = [
   { table: 'allowlists', columns: ['address'] },
   { table: 'notifications', columns: ['user_id'] },
   { table: 'notification_channel_settings', columns: ['user_id'] },
+  { table: 'notification_preferences', columns: ['user_address'] },
+  { table: 'unsubscribe_tokens', columns: ['user_address'] },
   { table: 'push_subscriptions', columns: ['user'] },
   { table: 'claimable_balances', columns: ['user_address'] },
   { table: 'user_activities', columns: ['user_address'] },
@@ -94,6 +96,51 @@ export function purgePiiForUser(db, identifier) {
   }
 
   return { purged };
+}
+
+/**
+ * Fields that hold raw Web Push credential material rather than
+ * human-meaningful data — replaced with a presence marker in exports so a
+ * GDPR data-access request doesn't hand out live push-subscription secrets.
+ */
+const REDACTED_FIELDS = {
+  push_subscriptions: ['p256dh', 'auth'],
+};
+
+/**
+ * Export all PII for a specific user (wallet address or email), for GDPR
+ * "right of access" requests. Reuses the same PII_TABLES map as
+ * purgePiiForUser so "which tables hold this identifier" is defined once.
+ *
+ * @param {import('better-sqlite3').Database} db
+ * @param {string} identifier - Wallet address or email to export
+ * @returns {{ identifier: string, exportedAt: string, data: Record<string, object[]> }}
+ */
+export function exportPiiForUser(db, identifier) {
+  const data = {};
+
+  for (const { table, columns } of PII_TABLES) {
+    try {
+      const where = columns.map((c) => `${c} = ?`).join(' OR ');
+      const rows = db
+        .prepare(`SELECT * FROM ${table} WHERE ${where}`)
+        .all(...columns.map(() => identifier));
+
+      if (rows.length > 0) {
+        const redact = REDACTED_FIELDS[table];
+        data[table] = redact
+          ? rows.map((row) => ({
+              ...row,
+              ...Object.fromEntries(redact.map((field) => [field, '[REDACTED]'])),
+            }))
+          : rows;
+      }
+    } catch (err) {
+      log.warn(`[pii-export] Failed to query ${table}: ${err.message}`);
+    }
+  }
+
+  return { identifier, exportedAt: new Date().toISOString(), data };
 }
 
 /**

--- a/docs/EVENT_SCHEMA.md
+++ b/docs/EVENT_SCHEMA.md
@@ -76,3 +76,26 @@ Events without a projection handler (`paused`, `mxcredit`, `ratlset`, etc.) are 
 4. Every `snapshot` event ledger **must** match the `ledger` field stored in the `snapshots` table
    row for that `snapshot_id`.
 5. No event may be processed twice (idempotency via `UNIQUE(tx_hash, event_index)`).
+6. **GDPR / data retention (#927).** The Stellar/Soroban ledger is public and permanently
+   immutable — this backend has no ability to delete, redact, or alter a wallet's on-chain
+   transaction history, including `credit`/`claim`/`refbonus` events already emitted. The
+   master-key-gated `POST /api/v1/pii/purge-user` endpoint
+   (`backend/src/services/piiPurgeService.js`, `PII_TABLES`) only erases this backend's
+   **off-chain copies** of that data — the projection tables listed above (`participants`,
+   `credit_events`, `claim_events`, `balances`, `vesting_schedules`, `vested_claim_events`,
+   `referral_credits`) plus `referrals` and the notification/preference/push-subscription tables.
+   If the indexer's checkpoint (`indexer_checkpoints`, migration 020) is ever reset and a fresh
+   instance re-indexes from an early ledger, `eventIndexer.js` will recreate those projection rows
+   for the purged wallet from on-chain history — erasure is **not** permanent against a future
+   full re-index, and this caveat should be disclosed to anyone processing an erasure request.
+   `POST /api/v1/pii/export-user` (`exportPiiForUser`) covers the same table set for GDPR
+   "right of access" requests.
+
+   Organization-staff PII (`organization_members`/`organization_invitations`, keyed by email
+   rather than wallet address) is a separate identity axis — org team members managing
+   campaigns, not rewards-platform participants — but is included in `PII_TABLES` since the
+   purge/export `identifier` accepts either a wallet address or an email.
+
+   `analytics_events` is handled separately: `validateEvent()` in `analyticsService.js` already
+   rejects wallet/email/IP fields at write time, and `purgePiiForUser` additionally scans and
+   redacts any matching value found in stored event `properties` as a defensive backstop.


### PR DESCRIPTION
## Summary

Closes #927. A separate, recently-merged PR (#1076, "soft-delete and retention policy") had already landed most of the delete-side plumbing for this issue (`piiPurgeService.js`, `/pii/purge-user`, `/pii/purge-campaign`) — but it turned out to be **completely non-functional** (every call 500'd) and had a real access-control hole. This PR fixes both bugs, adds the missing export side, and closes out the remaining acceptance criteria rather than building a parallel implementation.

## What was broken

- **`purgePiiUser`/`purgePiiCampaign` always 500'd.** They read `campaignRepository.db`, a property that doesn't exist on that repository — so `dal` was always `null` and every request failed with `DB_UNAVAILABLE`. Fixed to use the real `dal.db` that's already in scope in `index.js`.
- **Auth was effectively "any valid API key."** Each purge route had *two* competing registrations for the same path. Express only ever dispatches the first match, so the second registration — gated by `requireScope('org:manage')`, a scope that isn't even in `VALID_API_KEY_SCOPES` and so could never actually pass — was silently dead code. The live behavior was any tenant's API key could purge any other user's PII site-wide. Replaced both with a single `requireMasterKey`-gated registration, consistent with every other admin-sensitive route in the codebase.
- **Zero test coverage** for the actual HTTP routes. Existing tests (`softDelete.test.js`) called the service functions directly against a hand-built `db`, which is exactly why neither bug above was ever caught.
- **A third, unrelated but blocking bug**: `notificationService.js` (from a different recently-merged feature) imports a module that doesn't exist, crashing *every* test/boot path that loads `index.js`. Fixed as a one-line prerequisite — nothing could be verified without it.

## What's new

- **`exportPiiForUser`** (`piiPurgeService.js`) — reuses the same `PII_TABLES` map as the purge function (single source of truth for which off-chain tables hold wallet/email-linked PII), returning matched rows per table. Web Push credential fields (`p256dh`, `auth`) are redacted; everything else is returned as-is.
- **`POST /api/v1/pii/export-user`** — master-key gated, symmetric with the (now-fixed) `purge-user`. Audit-logged with per-table row counts only — never the exported data itself, so the erasure/access trail never becomes a second copy of the PII it's logging about.
- Filled two gaps in `PII_TABLES`: `notification_preferences` and `unsubscribe_tokens` were missing.
- `idempotencyMiddleware` added to both purge routes (previously absent), so a retried purge request replays the cached result instead of re-processing.
- **Docs**: extended `docs/EVENT_SCHEMA.md`'s on-chain/off-chain parity rules with the GDPR corollary — the Stellar ledger is public and permanently immutable, purge only erases this backend's off-chain copies, and a future full re-index would recreate the projection tables from chain history (erasure isn't permanent against that case). Also documented that org-staff email PII (`organization_members`/`organization_invitations`) is in scope since `identifier` already accepts either a wallet address or an email.
- `backend/openapi.yaml` — documented all three `/pii/*` paths (two of which existed but were never in the spec) plus new `PiiExportResponse`/`PiiPurgeResponse` schemas.

## Testing

- New `backend/src/integration/pii.test.js` — the first route-level coverage this feature has ever had: master-key required, validation, export/purge round-trip against real cross-table data (referrals, credit_events, push_subscriptions, notification_channel_settings), unrelated-wallet isolation, audit log contains counts only, and `Idempotency-Key` replay behavior.
- Extended `backend/src/dal/softDelete.test.js` with `exportPiiForUser` unit tests (multi-table export, referee-only matching, redaction, empty-result shape, no side effects) and purge coverage for the two newly-added tables.
- `eslint`/`tsc --noEmit` clean on all touched files (pre-existing, unrelated warnings/errors elsewhere untouched).
- `openapi:validate` passes.
- Live smoke test: booted the real backend, created a campaign + referral for a test wallet, confirmed export returns the row, purge deletes it, a follow-up export comes back empty, and both actions appear in the audit log (tamper-evident hash chain intact) with counts-only diffs — no PII in the audit trail.

## Acceptance criteria

- [x] Export/delete endpoints for off-chain PII.
- [x] On-chain immutability documented.
- [x] Audit-logged.
