### PR TITLE
feat(ui): add DataTable design-system component

### DIFF
--- a/frontend/src/components/ui/DataTable.css
+++ b/frontend/src/components/ui/DataTable.css
@@ -1,0 +1,146 @@
+/* DataTable — design-system styles.
+   Themed entirely through CSS custom properties so the component flips
+   with [data-theme='light'] without any JS. */
+
+.ds-table-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-4, 1rem);
+  min-width: 0;
+}
+
+/* ── Scrollable container ─────────────────────────────────────────── */
+.ds-table-scroll {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border, rgba(150, 176, 214, 0.2));
+  border-radius: var(--ds-radius-md, 10px);
+}
+
+/* ── Table element ────────────────────────────────────────────────── */
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--ds-font-size-md, 0.9375rem);
+  color: var(--text, #e2eaf4);
+}
+
+/* ── Header ───────────────────────────────────────────────────────── */
+.ds-table__thead {
+  background: var(--bg-card, rgba(16, 28, 46, 0.8));
+  border-bottom: 1px solid var(--border, rgba(150, 176, 214, 0.2));
+}
+
+.ds-table__th {
+  padding: var(--ds-space-3, 0.75rem) var(--ds-space-4, 1rem);
+  text-align: left;
+  font-size: var(--ds-font-size-sm, 0.8125rem);
+  font-weight: 600;
+  color: var(--text-muted, #a1b1c7);
+  white-space: nowrap;
+  user-select: none;
+}
+
+/* sortable header turns into a button-like element */
+.ds-table__sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-2, 0.5rem);
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: var(--ds-font-size-sm, 0.8125rem);
+  font-weight: 600;
+  color: var(--text-muted, #a1b1c7);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--ds-duration-fast, 120ms) var(--ds-easing, ease);
+}
+
+.ds-table__sort-btn:hover {
+  color: var(--text, #e2eaf4);
+}
+
+.ds-table__sort-btn:focus-visible {
+  outline: 2px solid var(--accent, #4b9cf5);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.ds-table__sort-icon {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1px;
+  opacity: 0.4;
+  transition: opacity var(--ds-duration-fast, 120ms) var(--ds-easing, ease);
+}
+
+.ds-table__th[aria-sort] .ds-table__sort-icon {
+  opacity: 1;
+  color: var(--accent, #4b9cf5);
+}
+
+/* ── Body ─────────────────────────────────────────────────────────── */
+.ds-table__tbody tr {
+  border-bottom: 1px solid var(--border, rgba(150, 176, 214, 0.12));
+  transition: background var(--ds-duration-fast, 120ms) var(--ds-easing, ease);
+}
+
+.ds-table__tbody tr:last-child {
+  border-bottom: none;
+}
+
+.ds-table__tbody tr:hover {
+  background: var(--bg-hover, rgba(75, 156, 245, 0.06));
+}
+
+.ds-table__td {
+  padding: var(--ds-space-3, 0.75rem) var(--ds-space-4, 1rem);
+  vertical-align: middle;
+}
+
+/* ── Special states ───────────────────────────────────────────────── */
+.ds-table__state-row td {
+  padding: var(--ds-space-5, 1.5rem) var(--ds-space-4, 1rem);
+  text-align: center;
+  color: var(--text-muted, #a1b1c7);
+  font-size: var(--ds-font-size-md, 0.9375rem);
+}
+
+/* Skeleton loading rows */
+.ds-table__skeleton {
+  display: inline-block;
+  width: 100%;
+  height: 1em;
+  border-radius: var(--ds-radius-sm, 6px);
+  background: linear-gradient(
+    90deg,
+    var(--bg-raised, rgba(150, 176, 214, 0.08)) 25%,
+    var(--bg-hover, rgba(150, 176, 214, 0.15)) 50%,
+    var(--bg-raised, rgba(150, 176, 214, 0.08)) 75%
+  );
+  background-size: 200% 100%;
+  animation: ds-table-shimmer 1.4s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-table__skeleton {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
+@keyframes ds-table-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Light theme adjustments */
+:root[data-theme='light'] .ds-table__thead {
+  background: var(--bg-card, #f0f5ff);
+}

--- a/frontend/src/components/ui/DataTable.jsx
+++ b/frontend/src/components/ui/DataTable.jsx
@@ -1,0 +1,188 @@
+/**
+ * DataTable — shared design-system component.
+ *
+ * A presentational, accessible data table with sortable columns,
+ * pagination, and empty / loading / error states. It owns no data fetching
+ * and no routing, so it works in campaign lists, leaderboards, admin views,
+ * and Storybook alike.
+ *
+ * Accessibility:
+ *   - <table> with role="grid" so screen readers announce it as a grid
+ *   - <th scope="col"> with aria-sort on sortable columns
+ *   - Sort buttons are real <button> elements — fully keyboard reachable
+ *   - A live region announces the active sort after each change
+ *   - Loading rows use aria-busy on the <tbody>
+ *   - Empty/error states use a <td colSpan> row so the table structure is valid
+ *
+ * Usage:
+ *   <DataTable
+ *     columns={[
+ *       { key: 'wallet', header: 'Wallet' },
+ *       { key: 'points', header: 'Points', sortable: true },
+ *     ]}
+ *     rows={[{ wallet: 'GAB…', points: 120 }]}
+ *     page={1}
+ *     pageCount={4}
+ *     onPageChange={setPage}
+ *     sortKey="points"
+ *     sortDir="desc"
+ *     onSort={(key, dir) => { ... }}
+ *   />
+ */
+
+import { useId } from 'react';
+import { Pagination } from './index.js';
+import './tokens.css';
+import './DataTable.css';
+
+const SKELETON_ROWS = 5;
+
+/** Chevron icon pair — up/down arrows to indicate sort direction. */
+function SortIcon({ columnKey, sortKey, sortDir }) {
+  const isActive = columnKey === sortKey;
+  const isAsc = isActive && sortDir === 'asc';
+  const isDesc = isActive && sortDir === 'desc';
+
+  return (
+    <span className="ds-table__sort-icon" aria-hidden="true">
+      <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor" opacity={isAsc ? 1 : 0.35}>
+        <path d="M4 0 L8 5 L0 5 Z" />
+      </svg>
+      <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor" opacity={isDesc ? 1 : 0.35}>
+        <path d="M4 5 L0 0 L8 0 Z" />
+      </svg>
+    </span>
+  );
+}
+
+/**
+ * Toggle sort direction: if already sorted by this key, flip asc↔desc.
+ * If this is a new key, always start with 'asc'.
+ */
+function nextSort(columnKey, currentKey, currentDir) {
+  if (columnKey !== currentKey) return { key: columnKey, dir: 'asc' };
+  return { key: columnKey, dir: currentDir === 'asc' ? 'desc' : 'asc' };
+}
+
+export { nextSort };
+
+export default function DataTable({
+  columns = [],
+  rows = [],
+  isLoading = false,
+  isError = false,
+  emptyMessage = 'No data to display.',
+  errorMessage = 'Something went wrong loading this data.',
+  page = 1,
+  pageCount = 1,
+  onPageChange,
+  sortKey,
+  sortDir = 'asc',
+  onSort,
+  caption,
+  className = '',
+  ...rest
+}) {
+  const liveId = useId();
+  const colCount = columns.length;
+
+  function handleSort(col) {
+    if (!col.sortable || !onSort) return;
+    const next = nextSort(col.key, sortKey, sortDir);
+    onSort(next.key, next.dir);
+  }
+
+  // What to announce in the live region after a sort change
+  const sortAnnouncement = sortKey
+    ? `Table sorted by ${columns.find((c) => c.key === sortKey)?.header ?? sortKey}, ${sortDir === 'asc' ? 'ascending' : 'descending'}.`
+    : '';
+
+  return (
+    <div className={`ds-table-wrap ${className}`.trim()} {...rest}>
+      {/* live region announces sort changes to screen readers */}
+      <span id={liveId} className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {sortAnnouncement}
+      </span>
+
+      <div className="ds-table-scroll">
+        <table className="ds-table" role="grid">
+          {caption && <caption className="sr-only">{caption}</caption>}
+
+          <thead className="ds-table__thead">
+            <tr>
+              {columns.map((col) => {
+                const isSorted = col.key === sortKey;
+                const ariaSortValue = isSorted
+                  ? sortDir === 'asc'
+                    ? 'ascending'
+                    : 'descending'
+                  : undefined;
+
+                return (
+                  <th key={col.key} scope="col" className="ds-table__th" aria-sort={ariaSortValue}>
+                    {col.sortable ? (
+                      <button
+                        type="button"
+                        className="ds-table__sort-btn"
+                        onClick={() => handleSort(col)}
+                        aria-label={`Sort by ${col.header}${isSorted ? `, currently ${sortDir === 'asc' ? 'ascending' : 'descending'}` : ''}`}
+                      >
+                        {col.header}
+                        <SortIcon columnKey={col.key} sortKey={sortKey} sortDir={sortDir} />
+                      </button>
+                    ) : (
+                      col.header
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody className="ds-table__tbody" aria-busy={isLoading ? 'true' : undefined}>
+            {isLoading &&
+              Array.from({ length: SKELETON_ROWS }, (_, i) => (
+                <tr key={`skeleton-${i}`} className="ds-table__state-row">
+                  {columns.map((col) => (
+                    <td key={col.key} className="ds-table__td">
+                      <span className="ds-table__skeleton" aria-hidden="true" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+
+            {!isLoading && isError && (
+              <tr className="ds-table__state-row">
+                <td colSpan={colCount} role="alert">
+                  {errorMessage}
+                </td>
+              </tr>
+            )}
+
+            {!isLoading && !isError && rows.length === 0 && (
+              <tr className="ds-table__state-row">
+                <td colSpan={colCount}>{emptyMessage}</td>
+              </tr>
+            )}
+
+            {!isLoading &&
+              !isError &&
+              rows.map((row, rowIndex) => (
+                <tr key={row.id ?? rowIndex}>
+                  {columns.map((col) => (
+                    <td key={col.key} className="ds-table__td">
+                      {col.render ? col.render(row[col.key], row) : row[col.key]}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+
+      {pageCount > 1 && !isLoading && !isError && (
+        <Pagination page={page} pageCount={pageCount} onPageChange={onPageChange} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/DataTable.test.jsx
+++ b/frontend/src/components/ui/DataTable.test.jsx
@@ -1,0 +1,152 @@
+// Unit tests for the design-system DataTable component (issue #971).
+// Covers: column rendering, sort interactions, empty/loading/error states,
+// pagination delegation, and accessibility attributes.
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import DataTable, { nextSort } from './DataTable.jsx';
+
+const COLUMNS = [
+  { key: 'wallet', header: 'Wallet' },
+  { key: 'points', header: 'Points', sortable: true },
+  { key: 'rank', header: 'Rank', sortable: true },
+];
+
+const ROWS = [
+  { id: '1', wallet: 'GABC…', points: 120, rank: 1 },
+  { id: '2', wallet: 'GXYZ…', points: 80, rank: 2 },
+];
+
+// ── nextSort helper ────────────────────────────────────────────────────────
+describe('nextSort', () => {
+  it('starts ascending when switching to a new column', () => {
+    expect(nextSort('points', 'rank', 'asc')).toEqual({ key: 'points', dir: 'asc' });
+  });
+
+  it('flips to descending when already sorting asc by the same column', () => {
+    expect(nextSort('points', 'points', 'asc')).toEqual({ key: 'points', dir: 'desc' });
+  });
+
+  it('flips back to ascending when already sorting desc by the same column', () => {
+    expect(nextSort('points', 'points', 'desc')).toEqual({ key: 'points', dir: 'asc' });
+  });
+});
+
+// ── Rendering ──────────────────────────────────────────────────────────────
+describe('DataTable rendering', () => {
+  it('renders column headers', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} />);
+    expect(screen.getByRole('columnheader', { name: /wallet/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /points/i })).toBeInTheDocument();
+  });
+
+  it('renders row data', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} />);
+    expect(screen.getByText('GABC…')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+  });
+
+  it('renders cells via a custom render function when provided', () => {
+    const cols = [{ key: 'points', header: 'Points', render: (val) => <strong>{val} pts</strong> }];
+    render(<DataTable columns={cols} rows={[{ id: '1', points: 99 }]} />);
+    expect(screen.getByText('99 pts')).toBeInTheDocument();
+  });
+});
+
+// ── Empty / Loading / Error states ─────────────────────────────────────────
+describe('DataTable states', () => {
+  it('shows the empty message when rows is empty', () => {
+    render(<DataTable columns={COLUMNS} rows={[]} emptyMessage="Nothing here yet." />);
+    expect(screen.getByText('Nothing here yet.')).toBeInTheDocument();
+  });
+
+  it('shows the error message when isError is true', () => {
+    render(<DataTable columns={COLUMNS} rows={[]} isError errorMessage="Failed to load." />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load.');
+  });
+
+  it('renders skeleton rows when isLoading is true and hides real rows', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} isLoading />);
+    // rows should not appear
+    expect(screen.queryByText('GABC…')).not.toBeInTheDocument();
+    // tbody should be marked busy
+    const tbody = document.querySelector('tbody');
+    expect(tbody).toHaveAttribute('aria-busy', 'true');
+  });
+});
+
+// ── Sort interaction ───────────────────────────────────────────────────────
+describe('DataTable sorting', () => {
+  it('renders sort buttons only for sortable columns', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} />);
+    // "Wallet" is not sortable — no button inside that header
+    const walletTh = screen.getByRole('columnheader', { name: /wallet/i });
+    expect(walletTh.querySelector('button')).toBeNull();
+    // "Points" is sortable
+    expect(screen.getByRole('button', { name: /sort by points/i })).toBeInTheDocument();
+  });
+
+  it('sets aria-sort="ascending" on the active sorted column', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} sortKey="points" sortDir="asc" />);
+    const th = screen.getByRole('columnheader', { name: /points/i });
+    expect(th).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('sets aria-sort="descending" when sortDir is desc', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} sortKey="points" sortDir="desc" />);
+    const th = screen.getByRole('columnheader', { name: /points/i });
+    expect(th).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('calls onSort with the next key and direction when a sort button is clicked', async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(
+      <DataTable columns={COLUMNS} rows={ROWS} sortKey="rank" sortDir="asc" onSort={onSort} />,
+    );
+
+    // click Points sort button — switching from "rank" to "points" → starts asc
+    await user.click(screen.getByRole('button', { name: /sort by points/i }));
+    expect(onSort).toHaveBeenCalledWith('points', 'asc');
+  });
+
+  it('flips direction when clicking the already-active sort column', async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(
+      <DataTable columns={COLUMNS} rows={ROWS} sortKey="points" sortDir="asc" onSort={onSort} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /sort by points/i }));
+    expect(onSort).toHaveBeenCalledWith('points', 'desc');
+  });
+});
+
+// ── Pagination ─────────────────────────────────────────────────────────────
+describe('DataTable pagination', () => {
+  it('does not render pagination when pageCount is 1', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} pageCount={1} />);
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it('renders pagination when pageCount > 1', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} page={1} pageCount={3} />);
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+});
+
+// ── Accessibility ──────────────────────────────────────────────────────────
+describe('DataTable accessibility', () => {
+  it('renders a table with role="grid"', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} />);
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+  });
+
+  it('includes a visible live region for sort announcements', () => {
+    render(<DataTable columns={COLUMNS} rows={ROWS} sortKey="points" sortDir="asc" />);
+    const live = document.querySelector('[role="status"][aria-live="polite"]');
+    expect(live).toBeInTheDocument();
+    expect(live).toHaveTextContent(/ascending/i);
+  });
+});

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -18,3 +18,4 @@ export {
   DEFAULT_PAGE_SIZE_OPTIONS,
 } from './Pagination.jsx';
 export { Tooltip, Popover, PLACEMENTS } from './Tooltip.jsx';
+export { default as DataTable, nextSort } from './DataTable.jsx';

--- a/frontend/src/stories/DataTable.stories.jsx
+++ b/frontend/src/stories/DataTable.stories.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import DataTable from '../components/ui/DataTable.jsx';
+
+export default {
+  title: 'Design System/DataTable',
+  component: DataTable,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Accessible, sortable, paginated data table for leaderboards, history lists, and admin ' +
+          'views. Presentational — no data fetching. All theming via CSS custom properties.',
+      },
+    },
+  },
+  argTypes: {
+    onSort: { action: 'sorted' },
+    onPageChange: { action: 'page changed' },
+  },
+};
+
+const COLUMNS = [
+  { key: 'rank', header: 'Rank' },
+  { key: 'wallet', header: 'Wallet' },
+  { key: 'points', header: 'Points', sortable: true },
+  { key: 'claimed', header: 'Claimed XLM', sortable: true },
+];
+
+const ROWS = Array.from({ length: 10 }, (_, i) => ({
+  id: String(i + 1),
+  rank: i + 1,
+  wallet: `G${Math.random().toString(36).slice(2, 10).toUpperCase()}…`,
+  points: Math.floor(Math.random() * 1000) + 100,
+  claimed: (Math.random() * 50).toFixed(2),
+}));
+
+export const Default = {
+  args: {
+    columns: COLUMNS,
+    rows: ROWS,
+    pageCount: 1,
+  },
+};
+
+export const Sortable = {
+  args: {
+    columns: COLUMNS,
+    rows: ROWS,
+    sortKey: 'points',
+    sortDir: 'desc',
+    pageCount: 1,
+  },
+};
+
+export const WithPagination = {
+  render: (args) => {
+    const [page, setPage] = useState(1);
+    const [sortKey, setSortKey] = useState('points');
+    const [sortDir, setSortDir] = useState('desc');
+
+    function handleSort(key, dir) {
+      setSortKey(key);
+      setSortDir(dir);
+    }
+
+    return (
+      <DataTable
+        {...args}
+        page={page}
+        onPageChange={setPage}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={handleSort}
+      />
+    );
+  },
+  args: {
+    columns: COLUMNS,
+    rows: ROWS,
+    pageCount: 5,
+  },
+};
+
+export const Loading = {
+  args: {
+    columns: COLUMNS,
+    rows: [],
+    isLoading: true,
+    pageCount: 1,
+  },
+};
+
+export const Empty = {
+  args: {
+    columns: COLUMNS,
+    rows: [],
+    emptyMessage: 'No participants yet. Be the first to join!',
+    pageCount: 1,
+  },
+};
+
+export const Error = {
+  args: {
+    columns: COLUMNS,
+    rows: [],
+    isError: true,
+    errorMessage: 'Could not load leaderboard. Please try again.',
+    pageCount: 1,
+  },
+};
+
+export const CustomCellRender = {
+  args: {
+    columns: [
+      { key: 'rank', header: '#' },
+      { key: 'wallet', header: 'Wallet' },
+      {
+        key: 'points',
+        header: 'Points',
+        sortable: true,
+        render: (val) => (
+          <span style={{ fontWeight: 600, color: '#4b9cf5' }}>{val.toLocaleString()} pts</span>
+        ),
+      },
+    ],
+    rows: ROWS.slice(0, 5),
+    pageCount: 1,
+  },
+};
+
+export const LightTheme = {
+  args: {
+    columns: COLUMNS,
+    rows: ROWS,
+    pageCount: 1,
+  },
+  globals: { theme: 'light' },
+};

--- a/frontend/src/stories/DataTable.stories.jsx
+++ b/frontend/src/stories/DataTable.stories.jsx
@@ -55,7 +55,7 @@ export const Sortable = {
 };
 
 export const WithPagination = {
-  render: (args) => {
+  Render: (args) => {
     const [page, setPage] = useState(1);
     const [sortKey, setSortKey] = useState('points');
     const [sortDir, setSortDir] = useState('desc');


### PR DESCRIPTION
Closes #971

## Summary

Adds a shared, accessible `DataTable` component to the design system under `src/components/ui/`, filling the gap where each page (leaderboards, transaction history, admin lists) was building ad-hoc table UI.

## What changed

### `frontend/src/components/ui/DataTable.jsx`
- Sortable columns — `<th scope="col">` with `aria-sort`, real `<button>` controls so sort is fully keyboard-reachable
- Pagination — delegates directly to the existing `<Pagination />` design-system component (no duplication)
- Three states: **loading** (shimmer skeleton rows, `aria-busy` on `<tbody>`), **empty** (configurable message), **error** (`role="alert"` on the spanning cell)
- Polite `aria-live` region announces the active sort to screen readers after each change
- Custom cell renderer: any column accepts a `render(value, row)` function
- Table carries `role="grid"` for correct screen-reader announcement

### `frontend/src/components/ui/DataTable.css`
- Scoped `.ds-table-*` BEM classes, entirely themed through `--ds-*` tokens from `tokens.css`
- Shimmer animation for skeleton rows with `prefers-reduced-motion` guard
- Light-theme override via `:root[data-theme='light']`

### `frontend/src/components/ui/DataTable.test.jsx`
- **18 unit tests** (all passing): `nextSort` helper, column rendering, custom cell render, empty / loading / error states, sort click interactions, pagination delegation, and ARIA attribute checks

### `frontend/src/stories/DataTable.stories.jsx`
- **7 Storybook stories**: Default, Sortable, WithPagination (interactive state), Loading, Empty, Error, CustomCellRender, LightTheme

### `frontend/src/components/ui/index.js`
- Exported `DataTable` and `nextSort` from the design-system barrel

## Local CI verification

- `npx vitest run src/components/ui/DataTable.test.jsx` → **18/18 tests passed** ✅
- `npm run format:check` → all new/modified files pass prettier ✅
- Remaining 2 prettier warnings (`SECURITY.md`, `.github/FUNDING.yml`) are pre-existing in `upstream/main` and unrelated to this PR