### PR TITLE
docs: add embeddable widget integration docs (#917)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ VITE_CAMPAIGN_CONTRACT_ID=CDDVJVHP6PUYWB42VQJ6YC7GEUQR622JEE5MY65ZIKUETGDT33QZPB
 | **Campaign Contract** | Stores campaign active flag and participant registration                   |
 | **Backend API**       | REST API for campaign metadata, health checks, and integration             |
 | **Frontend**          | React app to list campaigns and connect wallets to interact with contracts |
+| **Embed widgets**     | Sandboxed iframe and script-tag embeds for partners to show campaigns on third-party sites |
 
 ### Use Cases
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -111,6 +111,74 @@ Route-level meta tags are managed with `react-helmet-async` (`PageMeta` componen
 
 Validate share cards with [opengraph.xyz](https://www.opengraph.xyz/) or the [Twitter Card Validator](https://cards-dev.twitter.com/validator).
 
+## Embeddable widgets
+
+Partners can embed Trivela campaign widgets on third-party sites using either an iframe or a script tag.
+
+### iframe embed
+
+```html
+<iframe
+  src="https://trivela.app/embed/v1/card/CAMPAIGN_ID?theme=dark&color=%233b82f6&partner=acme"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+  loading="lazy"
+  style="border:none;width:100%;height:320px"
+  title="Trivela campaign widget"
+></iframe>
+```
+
+### Script tag embed
+
+```html
+<script
+  src="https://trivela.app/embed.js"
+  data-campaign="CAMPAIGN_ID"
+  data-partner="acme"
+  data-theme="dark"
+  data-color="#3b82f6"
+  data-org="MyDAO"
+  data-size="md"
+></script>
+```
+
+### Programmatic usage
+
+After the script loads, you can also mount widgets manually:
+
+```js
+const widget = new TrivelaWidget({
+  campaign: 'CAMPAIGN_ID',
+  partner: 'acme',
+  theme: 'dark',
+  size: 'md',
+  org: 'MyDAO',
+  color: '#3b82f6',
+});
+
+widget.on('trivela:ready', (e) => console.log('loaded', e))
+       .on('trivela:register_click', (e) => console.log('register clicked', e))
+       .on('trivela:claim', (e) => console.log('reward claimed', e))
+       .mount(document.getElementById('my-container'));
+```
+
+### Query parameters
+
+| Param | Description | Default |
+|-------|-------------|---------|
+| `theme` | `dark` or `light` | `dark` |
+| `color` | Custom accent color (hex) | widget default |
+| `partner` | Partner/referrer ID (alphanumeric, max 64 chars) | — |
+| `org` | Partner display name (max 48 chars) | — |
+| `size` | iframe height: `sm` (260px), `md` (320px), `lg` (380px) | `md` |
+
+### Security
+
+- Widgets are served with `Content-Security-Policy: frame-ancestors *`
+- iframe `sandbox` restricts to `allow-scripts allow-same-origin allow-popups allow-forms`
+- postMessage events are validated: only messages from the Trivela origin are forwarded
+- Partner IDs are validated (alphanumeric + `_-`) before being placed in the URL
+- No credentials, API keys, or wallet secrets are ever exposed in the snippet
+
 ## Unit tests
 
 ```bash


### PR DESCRIPTION
Closes #917

## Summary
Added third-party integration documentation for the embeddable campaign widget. The widget infrastructure already existed in the codebase (`frontend/public/embed.js` and `backend/src/routes/embedWidget.js`), but partners had no documented way to use it. This PR adds the missing docs.

## What changed
- Added "Embeddable widgets" section to `frontend/README.md` with:
  - iframe embed snippet
  - script-tag embed snippet using the existing `data-campaign` attributes
  - programmatic `TrivelaWidget` API example
  - query parameter table (`theme`, `color`, `partner`, `org`, `size`)
  - security notes (CSP, sandbox, postMessage validation, partner ID sanitisation)
- Added brief embed mention to root `README.md` in the component table

## Testing / Local Verification
- Ran `npm run build --workspace=frontend` — compiles successfully
- Ran `npm run lint --workspace=frontend` — no new warnings or errors
- Verified existing `frontend/public/embed.js` already handles auto-init, programmatic mounting, and event forwarding

Hey @FinesseStudioLab/maintainer, this closes #917. Let me know if you'd like any adjustments to the documented snippets.
